### PR TITLE
add ap-voc/ttl draft

### DIFF
--- a/r2.3/ap-voc/ttl/AssessedElement-AP-Voc-RDFS2020.ttl
+++ b/r2.3/ap-voc/ttl/AssessedElement-AP-Voc-RDFS2020.ttl
@@ -1,0 +1,1014 @@
+@prefix ae:      <https://ap.cim4.eu/AssessedElement#> .
+@prefix cim:     <https://cim.ucaiug.io/ns#> .
+@prefix cims:    <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/#> .
+@prefix nc:      <https://cim4.eu/ns/nc#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix profcim: <https://cim.ucaiug.io/ns/prof-cim#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+
+ae:Ontology  rdf:type         owl:Ontology ;
+        dcterms:conformsTo    "file://CIM100_CGMES31v01_501-20v02_NC23v62_MM10v01.eap" , "urn:iso:std:iec:61970-600-2:ed-1" , "urn:iso:std:iec:61970-301:ed-7:amd1" , "file://iec61970cim17v40_iec61968cim13v13a_iec62325cim03v17a.eap" , "urn:iso:std:iec:61970-501:draft:ed-2" , "urn:iso:std:iec:61970-401:draft:ed-1" ;
+        dcterms:creator       "ENTSO-E CIM WG NC project"@en ;
+        dcterms:description   "This vocabulary is describing the aseessed element profile."@en ;
+        dcterms:identifier    "urn:uuid:a2de1738-214d-4552-b894-5b33cbc34218" ;
+        dcterms:language      "en-GB" ;
+        dcterms:license       "https://www.apache.org/licenses/LICENSE-2.0"@en ;
+        dcterms:modified      "2024-04-08"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        dcterms:publisher     "ENTSO-E"@en ;
+        dcterms:rightsHolder  "ENTSO-E"@en ;
+        dcterms:title         "Assessed Element Vocabulary"@en ;
+        owl:priorVersion      <http://entsoe.eu/ns/CIM/AssessedElement-EU/2.2> ;
+        owl:versionIRI        <https://ap.cim4.eu/AssessedElement/2.3> ;
+        owl:versionInfo       "2.3.0"@en ;
+        dcat:keyword          "AE" ;
+        dcat:theme            "vocabulary"@en .
+
+ae:Package_AssessedElementProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains assessed element profile." ;
+        rdfs:label    "AssessedElementProfile"@en .
+
+ae:Package_DocAssessedElementProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains datatypes used only in the RDFS header." ;
+        rdfs:label    "DocAssessedElementProfile"@en .
+
+cim:ActivePower  rdf:type       rdfs:Class ;
+        rdfs:comment            "Product of RMS value of the voltage and the RMS value of the in-phase component of the current." ;
+        rdfs:label              "ActivePower"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:ActivePower.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePower.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "W" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePower.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Boolean  rdf:type           rdfs:Class ;
+        rdfs:comment            "A type with the value space \"true\" and \"false\"." ;
+        rdfs:label              "Boolean"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:ConductingEquipment
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The parts of the AC power system that are designed to carry current or that are conductively connected through terminals." ;
+        rdfs:label              "ConductingEquipment"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile .
+
+cim:Contingency  rdf:type       rdfs:Class ;
+        rdfs:comment            "An event threatening system reliability, consisting of one or more contingency elements." ;
+        rdfs:label              "Contingency"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile .
+
+cim:Date  rdf:type              rdfs:Class ;
+        rdfs:comment            "Date as \"yyyy-mm-dd\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddZ\". A local timezone relative UTC is specified as \"yyyy-mm-dd(+/-)hh:mm\"." ;
+        rdfs:label              "Date"@en ;
+        cims:belongsToCategory  ae:Package_DocAssessedElementProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:DateTime  rdf:type          rdfs:Class ;
+        rdfs:comment            "Date and time as \"yyyy-mm-ddThh:mm:ss.sss\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddThh:mm:ss.sssZ\". A local timezone relative UTC is specified as \"yyyy-mm-ddThh:mm:ss.sss-hh:mm\". The second component (shown here as \"ss.sss\") could have any number of digits in its fractional part to allow any kind of precision beyond seconds." ;
+        rdfs:label              "DateTime"@en ;
+        cims:belongsToCategory  ae:Package_DocAssessedElementProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Float  rdf:type             rdfs:Class ;
+        rdfs:comment            "A floating point number. The range is unspecified and not limited." ;
+        rdfs:label              "Float"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:IdentifiedObject  rdf:type  rdfs:Class ;
+        rdfs:comment            "This is a root class to provide common identification for all classes needing identification and naming attributes." ;
+        rdfs:label              "IdentifiedObject"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile .
+
+cim:IdentifiedObject.description
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The description is a free human readable text describing or naming the object. It may be non unique and may not correlate to a naming hierarchy." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "description"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.name
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The name is any free human readable and possibly non unique text naming the object." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "name"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:OperationalLimit  rdf:type  rdfs:Class ;
+        rdfs:comment            "A value and normal value associated with a specific kind of limit. \nThe sub class value and normalValue attributes vary inversely to the associated OperationalLimitType.acceptableDuration (acceptableDuration for short).  \nIf a particular piece of equipment has multiple operational limits of the same kind (apparent power, current, etc.), the limit with the greatest acceptableDuration shall have the smallest limit value and the limit with the smallest acceptableDuration shall have the largest limit value.  Note: A large current can only be allowed to flow through a piece of equipment for a short duration without causing damage, but a lesser current can be allowed to flow for a longer duration. " ;
+        rdfs:label              "OperationalLimit"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile .
+
+cim:PerCent  rdf:type           rdfs:Class ;
+        rdfs:comment            "Percentage on a defined base.   For example, specify as 100 to indicate at the defined base." ;
+        rdfs:label              "PerCent"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:PerCent.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent.value  rdf:type  rdf:Property ;
+        rdfs:comment       "Normally 0 to 100 on a defined base." ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:String  rdf:type            rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited." ;
+        rdfs:label              "String"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:UnitMultiplier  rdf:type    rdfs:Class ;
+        rdfs:comment            "The unit multipliers defined for the CIM.  When applied to unit symbols, the unit symbol is treated as a derived unit. Regardless of the contents of the unit symbol text, the unit symbol shall be treated as if it were a single-character unit symbol. Unit symbols should not contain multipliers, and it should be left to the multiplier to define the multiple for an entire data type. \n\nFor example, if a unit symbol is \"m2Pers\" and the multiplier is \"k\", then the value is k(m**2/s), and the multiplier applies to the entire final value, not to any individual part of the value. This can be conceptualized by substituting a derived unit symbol for the unit type. If one imagines that the symbol \"Þ\" represents the derived unit \"m2Pers\", then applying the multiplier \"k\" can be conceptualized simply as \"kÞ\".\n\nFor example, the SI unit for mass is \"kg\" and not \"g\".  If the unit symbol is defined as \"kg\", then the multiplier is applied to \"kg\" as a whole and does not replace the \"k\" in front of the \"g\". In this case, the multiplier of \"m\" would be used with the unit symbol of \"kg\" to represent one gram.  As a text string, this violates the instructions in IEC 80000-1. However, because the unit symbol in CIM is treated as a derived unit instead of as an SI unit, it makes more sense to conceptualize the \"kg\" as if it were replaced by one of the proposed replacements for the SI mass symbol. If one imagines that the \"kg\" were replaced by a symbol \"Þ\", then it is easier to conceptualize the multiplier \"m\" as creating the proper unit \"mÞ\", and not the forbidden unit \"mkg\"." ;
+        rdfs:label              "UnitMultiplier"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitMultiplier.M  rdf:type  cim:UnitMultiplier ;
+        rdfs:comment     "Mega 10**6." ;
+        rdfs:label       "M"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitMultiplier.none
+        rdf:type         cim:UnitMultiplier ;
+        rdfs:comment     "No multiplier or equivalently multiply by 1." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol  rdf:type        rdfs:Class ;
+        rdfs:comment            "The derived units defined for usage in the CIM. In some cases, the derived unit is equal to an SI unit. Whenever possible, the standard derived symbol is used instead of the formula for the derived unit. For example, the unit symbol Farad is defined as \"F\" instead of \"CPerV\". In cases where a standard symbol does not exist for a derived unit, the formula for the unit is used as the unit symbol. For example, density does not have a standard symbol and so it is represented as \"kgPerm3\". With the exception of the \"kg\", which is an SI unit, the unit symbols do not contain multipliers and therefore represent the base derived unit to which a multiplier can be applied as a whole. \nEvery unit symbol is treated as an unparseable text as if it were a single-letter symbol. The meaning of each unit symbol is defined by the accompanying descriptive text and not by the text contents of the unit symbol.\nTo allow the widest possible range of serializations without requiring special character handling, several substitutions are made which deviate from the format described in IEC 80000-1. The division symbol \"/\" is replaced by the letters \"Per\". Exponents are written in plain text after the unit as \"m3\" instead of being formatted as \"m\" with a superscript of 3  or introducing a symbol as in \"m^3\". The degree symbol \"°\" is replaced with the letters \"deg\". Any clarification of the meaning for a substitution is included in the description for the unit symbol.\nNon-SI units are included in list of unit symbols to allow sources of data to be correctly labelled with their non-SI units (for example, a GPS sensor that is reporting numbers that represent feet instead of meters). This allows software to use the unit symbol information correctly convert and scale the raw data of those sources into SI-based units. \nThe integer values are used for harmonization with IEC 61850." ;
+        rdfs:label              "UnitSymbol"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitSymbol.W  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Real power in watts (J/s). Electrical power may have real and reactive components. The real portion of electrical power (I&#178;R or VIcos(phi)), is expressed in Watts. See also apparent power and reactive power." ;
+        rdfs:label       "W"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.none  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Dimension less quantity, e.g. count, per unit, etc." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+nc:AssessedElement  rdf:type    rdfs:Class ;
+        rdfs:comment            "Assessed element is a network element for which the electrical state is evaluated in the regional or cross-regional process and which value is expected to fulfil regional rules function of the operational security limits.\nThe measurements and limits are as defined in the steady state hypothesis." ;
+        rdfs:label              "AssessedElement"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AssessedElement.AssessedElementWithContingency
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The contingency and assessed element combination to be simulated for this assessed element." ;
+        rdfs:domain           nc:AssessedElement ;
+        rdfs:label            "AssessedElementWithContingency"@en ;
+        rdfs:range            nc:AssessedElementWithContingency ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AssessedElementWithContingency.AssessedElement ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElement.AssessedElementWithRemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The assessed element and remedial action combination to be simulated for this assessed element." ;
+        rdfs:domain           nc:AssessedElement ;
+        rdfs:label            "AssessedElementWithRemedialAction"@en ;
+        rdfs:range            nc:AssessedElementWithRemedialAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AssessedElementWithRemedialAction.AssessedElement ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElement.AssessedPowerTransferCorridor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The power transfer corridor that is designated as an assessed element." ;
+        rdfs:domain           nc:AssessedElement ;
+        rdfs:label            "AssessedPowerTransferCorridor"@en ;
+        rdfs:range            nc:PowerTransferCorridor ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerTransferCorridor.AssessedElement ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElement.AssessedSystemOperator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "A system operator that assesses the element." ;
+        rdfs:domain           nc:AssessedElement ;
+        rdfs:label            "AssessedSystemOperator"@en ;
+        rdfs:range            nc:SystemOperator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SystemOperator.AssessedElement ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElement.ConductingEquipment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The conducting equipment that is designated as an assessed element, i.e. the equipment that is assessed." ;
+        rdfs:domain           nc:AssessedElement ;
+        rdfs:label            "ConductingEquipment"@en ;
+        rdfs:range            cim:ConductingEquipment ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ConductingEquipment.AssessedElement ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElement.CrossBorderRelevance
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The Bidding zone border for which this assessed element is cross border relevant." ;
+        rdfs:domain           nc:AssessedElement ;
+        rdfs:label            "CrossBorderRelevance"@en ;
+        rdfs:range            nc:CrossBorderRelevance ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:CrossBorderRelevance.AssessedElement ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElement.DCTieCorridor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The DC tie corridor that is assessed." ;
+        rdfs:domain           nc:AssessedElement ;
+        rdfs:label            "DCTieCorridor"@en ;
+        rdfs:range            nc:DCTieCorridor ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DCTieCorridor.AssessedElement ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElement.NativeRegion
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The native region for an assessed element." ;
+        rdfs:domain           nc:AssessedElement ;
+        rdfs:label            "NativeRegion"@en ;
+        rdfs:range            nc:Region ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Region.NativeAssessedElement ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElement.OperationalLimit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The terminal limit that is being assessed against." ;
+        rdfs:domain           nc:AssessedElement ;
+        rdfs:label            "OperationalLimit"@en ;
+        rdfs:range            cim:OperationalLimit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:OperationalLimit.AssessedElement ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElement.OverlappingZone
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The overlapping zone grouping the overlapping assessed elements." ;
+        rdfs:domain           nc:AssessedElement ;
+        rdfs:label            "OverlappingZone"@en ;
+        rdfs:range            nc:OverlappingZone ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:OverlappingZone.OverlappingAssessedElement ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElement.ScannedForRegion
+        rdf:type              rdf:Property ;
+        rdfs:comment          "This is the region in which this assessed element is scanned." ;
+        rdfs:domain           nc:AssessedElement ;
+        rdfs:label            "ScannedForRegion"@en ;
+        rdfs:range            nc:Region ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Region.ScannedAssessedElement ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElement.SecuredForRegion
+        rdf:type              rdf:Property ;
+        rdfs:comment          "This is the region where the element is secured." ;
+        rdfs:domain           nc:AssessedElement ;
+        rdfs:label            "SecuredForRegion"@en ;
+        rdfs:range            nc:Region ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Region.SecuredAssessedElement ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElement.criticalElementContingency
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Indicates the type of the critical element contingency." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "criticalElementContingency"@en ;
+        rdfs:range         nc:CriticalElementContingencyKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.exclusionReason
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Reason for not associating this assessed element with a secured region." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "exclusionReason"@en ;
+        rdfs:range         nc:SecuredExclusionReasonKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.flowReliabilityMargin
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Percentage of the maximum flow (margin) reserved to anticipate forecasting errors.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "flowReliabilityMargin"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.inBaseCase
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Indicates if the assessed element is scanned in the base case. In case of a base case overload, the assessed element is considered as a limiting element for the optimization process.\nTrue means that the assessed element is scanned in the base case. False means it is not scanned in the base case." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "inBaseCase"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.insideCapacityMargin
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Percentage of the maximum flow (margin) from coordinated capacity calculation, i.e. capacity available for cross-zonal trade within the considered coordination area.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "insideCapacityMargin"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.isCombinableWithContingency
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Defines if the AssessedElement is available to be combined with Contingency. If true,  this AssessedElement can be included in various combinations not defined in the data exchange in an explicit way. If false, this assessed element is not to be considered in any combination with remedial actions and contingencies except for the exclusive combination." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "isCombinableWithContingency"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.isCombinableWithRemedialAction
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Defines if the AssessedElement is available to be combined with RemedialAction. If true,  this AssessedElement can be included in various combinations not defined in the data exchange in an explicit way. If false, this assessed element is not to be considered in any combination with remedial actions and contingencies except for the exclusive combination." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "isCombinableWithRemedialAction"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.maxMarginAdjustment
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum adjustment, relative to maximum flow allowed for exceeding the maximum flow of this assessed element.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "maxMarginAdjustment"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.normalAppointedMargin
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The normal percentage (appointed to a region) of the remaining margin obtained in the grid model to reach its current limit under normal operating conditions. The maximum percentage shall by default be 10% of the remaining margin.\nIt is only used when an assessed element is considered conservative for a region.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "normalAppointedMargin"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+nc:AssessedElement.normalCoordinatedValidationAdjustment
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Normal positive value calculated and provided by the Coordinated Capacity Calculator (CCC) for the reduction of Remaining Available Margin (RAM) in order to ensure grid security." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "normalCoordinatedValidationAdjustment"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.normalCoordinatedValidationAdjustmentJustification
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Normal free text description provided by the coordinated capacity calculator (CCC) for justifying the reduction of Remaining Available Margin (RAM) by means of Coordinated Validation Adjustment (CVA). This justification is not intended for any application processing purpose, it should only be used for reporting." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "normalCoordinatedValidationAdjustmentJustification"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.normalCriticalElementContingencyJustification
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Normal free text describing the justification  of critical element contingency categorization (e.g. the use of the kind). This justification is not intended for any application processing purpose, it should only be used for reporting." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "normalCriticalElementContingencyJustification"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.normalEnabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "If true, the assessed element shall be considered under normal operating conditions." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "normalEnabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.normalIndividualValidationAdjustment
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Normal positive value calculated and provided by System Operators from their individual validation process for the reduction of Remaining Available Margin (RAM) in order to ensure grid security." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "normalIndividualValidationAdjustment"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.normalIndividualValidationAdjustmentJustification
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Normal free text description provided by System Operators for justifying the reduction of Remaining Available Margin (RAM) by means of Individual Validation Adjustment (IVA). This justification is not intended for any application processing purpose, it should only be used for reporting." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "normalIndividualValidationAdjustmentJustification"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.normalIndividualValidationAdjustmentShare
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Normal positive value expressed calculated by the Coordinated Capacity Calculator (CCC) based on the provided Individual Validation Adjustment (IVA) by System Operators in order to show the actual reduction of Remaining Available Margin (RAM). Individual Validation Adjustment Share is a positive non-zero value. It is equal or less than the Individual Validation Adjustment value. " ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "normalIndividualValidationAdjustmentShare"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.normalMaxFlow
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum flow on a conducting equipment or a collection of conducting equipment forming a power transfer corridor under normal operating conditions. For assessed elements that become critical due to contingency, this value represents the maximum flow with remedial action taken into consideration." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "normalMaxFlow"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.normalPositiveVirtualMargin
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A positive margin that defines the overload allowed in a solution for the assessed element for a normal situation. The margin represents influences that can be solved by the System Operators using available remedial action which is not cross-border relevant remedial action.\nAll relevant operational limits (e.g. PATL, TATL, etc) are modified by this margin value. The attribute represents the increase. The allowed value range is [0,100]." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "normalPositiveVirtualMargin"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.normalScannedThresholdMargin
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Normal threshold percentage that a scanned element can be overloaded, on a given element, on top of any overload prior to optimisation (default= 5%). e.g. Initial loading of the element is 110%, with a 5% scanned threshold margin, the new maximum is 115% of the limit (e.g. PATL, TATL, etc).\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "normalScannedThresholdMargin"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.normalTargetRemainingAvailableMarginJustification
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Normal free text describing the justification for the target Remaining Available Margin (RAM). This justification is not intended for any application processing purpose, it should only be used for reporting." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "normalTargetRemainingAvailableMarginJustification"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.outsideCapacityMargin
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Percentage of the maximum flow (margin) capacity calculation, i.e. the capacity available for cross-zonal trade outside the considered coordination area. \nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "outsideCapacityMargin"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.targetRemainingAvailableMargin
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Target for the remaining available margin as a percentage of maximum flow.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "targetRemainingAvailableMargin"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementWithContingency
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Combination of an assessed element and a contingency." ;
+        rdfs:label              "AssessedElementWithContingency"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AssessedElementWithContingency.AssessedElement
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The assessed element defined for this contingency and assessed element combination." ;
+        rdfs:domain           nc:AssessedElementWithContingency ;
+        rdfs:label            "AssessedElement"@en ;
+        rdfs:range            nc:AssessedElement ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AssessedElement.AssessedElementWithContingency ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElementWithContingency.Contingency
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The contingency defined for this contingency and assessed element combination." ;
+        rdfs:domain           nc:AssessedElementWithContingency ;
+        rdfs:label            "Contingency"@en ;
+        rdfs:range            cim:Contingency ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Contingency.AssessedElementWithContingency ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElementWithContingency.combinationConstraintKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Defines the combination constraint of the AssessedElement and Contingency. If included, this assessed element is only assessed for this contingency. Else if excluded, this assessed element should not be assessed for this contingency. Considered shall not be used for this combination." ;
+        rdfs:domain        nc:AssessedElementWithContingency ;
+        rdfs:label         "combinationConstraintKind"@en ;
+        rdfs:range         nc:ElementCombinationConstraintKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementWithContingency.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:AssessedElementWithContingency ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementWithContingency.normalEnabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "If true, the assessed element with contingency is enabled, otherwise it is disabled under normal operating conditions." ;
+        rdfs:domain        nc:AssessedElementWithContingency ;
+        rdfs:label         "normalEnabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementWithRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Combination of an assessed element and a remedial action" ;
+        rdfs:label              "AssessedElementWithRemedialAction"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AssessedElementWithRemedialAction.AssessedElement
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The assessed element defined for this assessed element and remedial action combination." ;
+        rdfs:domain           nc:AssessedElementWithRemedialAction ;
+        rdfs:label            "AssessedElement"@en ;
+        rdfs:range            nc:AssessedElement ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AssessedElement.AssessedElementWithRemedialAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElementWithRemedialAction.RemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The remedial action defined for this assessed element and remedial action combination." ;
+        rdfs:domain           nc:AssessedElementWithRemedialAction ;
+        rdfs:label            "RemedialAction"@en ;
+        rdfs:range            nc:RemedialAction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialAction.AssessedElementWithRemedialAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElementWithRemedialAction.combinationConstraintKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Defines the combination constraint of the AssessedElement and Remedial Action. If included, this remedial action is only assessed for this assessed element. Else if excluded, this remedial action should not be used for this assessed element. Else if considered, this remedial action can be considered for this assessed element." ;
+        rdfs:domain        nc:AssessedElementWithRemedialAction ;
+        rdfs:label         "combinationConstraintKind"@en ;
+        rdfs:range         nc:ElementCombinationConstraintKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementWithRemedialAction.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:AssessedElementWithRemedialAction ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementWithRemedialAction.normalEnabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "If true, the assessed element with remedial action is enabled, otherwise it is disabled under normal operating conditions." ;
+        rdfs:domain        nc:AssessedElementWithRemedialAction ;
+        rdfs:label         "normalEnabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BiddingZoneBorder  rdf:type  rdfs:Class ;
+        rdfs:comment            "Defines the aggregated connection capacity between two Bidding Zones." ;
+        rdfs:label              "BiddingZoneBorder"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile ;
+        cims:stereotype         "NC" .
+
+nc:BiddingZoneBorder.CrossBorderRelevance
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Cross border relevant combination for this bidding zone border." ;
+        rdfs:domain           nc:BiddingZoneBorder ;
+        rdfs:label            "CrossBorderRelevance"@en ;
+        rdfs:range            nc:CrossBorderRelevance ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:CrossBorderRelevance.BiddingZoneBorder ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ConductingEquipment.AssessedElement
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The assessed element indicating that the conducting equipment is assessed, i.e. monitored." ;
+        rdfs:domain           cim:ConductingEquipment ;
+        rdfs:label            "AssessedElement"@en ;
+        rdfs:range            nc:AssessedElement ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AssessedElement.ConductingEquipment ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Contingency.AssessedElementWithContingency
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The contingency and assessed element combination to be simulated for this contingency." ;
+        rdfs:domain           cim:Contingency ;
+        rdfs:label            "AssessedElementWithContingency"@en ;
+        rdfs:range            nc:AssessedElementWithContingency ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AssessedElementWithContingency.Contingency ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:CriticalElementContingencyKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The kind of critical element contingency." ;
+        rdfs:label              "CriticalElementContingencyKind"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:CriticalElementContingencyKind.critical
+        rdf:type         nc:CriticalElementContingencyKind ;
+        rdfs:comment     "Network element is considered to be critical according to the methodology." ;
+        rdfs:label       "critical"@en ;
+        cims:stereotype  "enum" .
+
+nc:CriticalElementContingencyKind.criticalAndMonitored
+        rdf:type         nc:CriticalElementContingencyKind ;
+        rdfs:comment     "Network element is considered to be Critical Network Element monitored under Contingency (CNEC)." ;
+        rdfs:label       "criticalAndMonitored"@en ;
+        cims:stereotype  "enum" .
+
+nc:CriticalElementContingencyKind.monitored
+        rdf:type         nc:CriticalElementContingencyKind ;
+        rdfs:comment     "Network element is considered to be monitored under contingency." ;
+        rdfs:label       "monitored"@en ;
+        cims:stereotype  "enum" .
+
+nc:CriticalElementContingencyKind.validation
+        rdf:type         nc:CriticalElementContingencyKind ;
+        rdfs:comment     "Network element should be assessed according to the methodology." ;
+        rdfs:label       "validation"@en ;
+        cims:stereotype  "enum" .
+
+nc:CrossBorderRelevance
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Combination of an assessed element and a bidding zone border." ;
+        rdfs:label              "CrossBorderRelevance"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:CrossBorderRelevance.AssessedElement
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Assessed element which is cross border relevant." ;
+        rdfs:domain           nc:CrossBorderRelevance ;
+        rdfs:label            "AssessedElement"@en ;
+        rdfs:range            nc:AssessedElement ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AssessedElement.CrossBorderRelevance ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:CrossBorderRelevance.BiddingZoneBorder
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Bidding zone border relevant for this combination." ;
+        rdfs:domain           nc:CrossBorderRelevance ;
+        rdfs:label            "BiddingZoneBorder"@en ;
+        rdfs:range            nc:BiddingZoneBorder ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:BiddingZoneBorder.CrossBorderRelevance ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:CrossBorderRelevance.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:CrossBorderRelevance ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCTieCorridor  rdf:type      rdfs:Class ;
+        rdfs:comment            "A collection of one or more direct current poles that connect two different control areas." ;
+        rdfs:label              "DCTieCorridor"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile ;
+        cims:stereotype         "NC" .
+
+nc:DCTieCorridor.AssessedElement
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The assessed element indicating that the DC tie corridor is assessed, i.e. monitored." ;
+        rdfs:domain           nc:DCTieCorridor ;
+        rdfs:label            "AssessedElement"@en ;
+        rdfs:range            nc:AssessedElement ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AssessedElement.DCTieCorridor ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ElementCombinationConstraintKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of constraint for an element combination." ;
+        rdfs:label              "ElementCombinationConstraintKind"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:ElementCombinationConstraintKind.considered
+        rdf:type         nc:ElementCombinationConstraintKind ;
+        rdfs:comment     "Element combination can be considered." ;
+        rdfs:label       "considered"@en ;
+        cims:stereotype  "enum" .
+
+nc:ElementCombinationConstraintKind.excluded
+        rdf:type         nc:ElementCombinationConstraintKind ;
+        rdfs:comment     "Element combination is excluded." ;
+        rdfs:label       "excluded"@en ;
+        cims:stereotype  "enum" .
+
+nc:ElementCombinationConstraintKind.included
+        rdf:type         nc:ElementCombinationConstraintKind ;
+        rdfs:comment     "Element combination is included." ;
+        rdfs:label       "included"@en ;
+        cims:stereotype  "enum" .
+
+nc:OperationalLimit.AssessedElement
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The assessed element indicating which operational limit is assessed." ;
+        rdfs:domain           cim:OperationalLimit ;
+        rdfs:label            "AssessedElement"@en ;
+        rdfs:range            nc:AssessedElement ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AssessedElement.OperationalLimit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:OverlappingZone  rdf:type    rdfs:Class ;
+        rdfs:comment            "A collection of all the overlapping cross border assessed elements which have the same sets of impacted and impacting regions." ;
+        rdfs:label              "OverlappingZone"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile ;
+        cims:stereotype         "NC" .
+
+nc:OverlappingZone.OverlappingAssessedElement
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The overlapping assessed element on which the physical flows are significantly impacted by\nelectricity exchanges in two or more regions or by remedial actions from two or more regions." ;
+        rdfs:domain           nc:OverlappingZone ;
+        rdfs:label            "OverlappingAssessedElement"@en ;
+        rdfs:range            nc:AssessedElement ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AssessedElement.OverlappingZone ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerTransferCorridor
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A power transfer corridor is defined as a set of circuits (transmission lines or transformers) separating two portions of the power system, or a subset of circuits exposed to a substantial portion of the transmission exchange between two parts of the system." ;
+        rdfs:label              "PowerTransferCorridor"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile ;
+        cims:stereotype         "NC" .
+
+nc:PowerTransferCorridor.AssessedElement
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The assessed element indicating that the power transfer corridor is assessed, i.e. monitored." ;
+        rdfs:domain           nc:PowerTransferCorridor ;
+        rdfs:label            "AssessedElement"@en ;
+        rdfs:range            nc:AssessedElement ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AssessedElement.AssessedPowerTransferCorridor ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Region  rdf:type             rdfs:Class ;
+        rdfs:comment            "A region where the system operator belongs to." ;
+        rdfs:label              "Region"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile ;
+        cims:stereotype         "NC" .
+
+nc:Region.NativeAssessedElement
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The native assessed element for a native region." ;
+        rdfs:domain           nc:Region ;
+        rdfs:label            "NativeAssessedElement"@en ;
+        rdfs:range            nc:AssessedElement ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AssessedElement.NativeRegion ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Region.ScannedAssessedElement
+        rdf:type              rdf:Property ;
+        rdfs:comment          "These are the scanned assessed elements for a region." ;
+        rdfs:domain           nc:Region ;
+        rdfs:label            "ScannedAssessedElement"@en ;
+        rdfs:range            nc:AssessedElement ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AssessedElement.ScannedForRegion ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Region.SecuredAssessedElement
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The assessed element secured for this region." ;
+        rdfs:domain           nc:Region ;
+        rdfs:label            "SecuredAssessedElement"@en ;
+        rdfs:range            nc:AssessedElement ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AssessedElement.SecuredForRegion ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialAction  rdf:type     rdfs:Class ;
+        rdfs:comment            "Remedial action describes one or more actions that can be performed on a given power system model situation to eliminate one or more identified breaches of constraints. The remedial action can be costly, and have a cost characteristic, or non costly. " ;
+        rdfs:label              "RemedialAction"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile ;
+        cims:stereotype         "NC" .
+
+nc:RemedialAction.AssessedElementWithRemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The assessed element and remedial action combination to be simulated for this remedial action." ;
+        rdfs:domain           nc:RemedialAction ;
+        rdfs:label            "AssessedElementWithRemedialAction"@en ;
+        rdfs:range            nc:AssessedElementWithRemedialAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AssessedElementWithRemedialAction.RemedialAction ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SecuredExclusionReasonKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The kind of secured exclusion reason." ;
+        rdfs:label              "SecuredExclusionReasonKind"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:SecuredExclusionReasonKind.capacityCalculationRegion
+        rdf:type         nc:SecuredExclusionReasonKind ;
+        rdfs:comment     "The network element that is going to be assessed is excluded for being secured by the capacity calculation region." ;
+        rdfs:label       "capacityCalculationRegion"@en ;
+        cims:stereotype  "enum" .
+
+nc:SecuredExclusionReasonKind.nonNativeCapacityCalculationRegion
+        rdf:type         nc:SecuredExclusionReasonKind ;
+        rdfs:comment     "The network element that is going to be assessed is excluded for being secured for the native capacity calculation region since it would be secured for a non native capacity calculation region." ;
+        rdfs:label       "nonNativeCapacityCalculationRegion"@en ;
+        cims:stereotype  "enum" .
+
+nc:SecuredExclusionReasonKind.systemOperator
+        rdf:type         nc:SecuredExclusionReasonKind ;
+        rdfs:comment     "The network element that is going to be assessed is excluded for being secured by the system operator." ;
+        rdfs:label       "systemOperator"@en ;
+        cims:stereotype  "enum" .
+
+nc:SystemOperator  rdf:type     rdfs:Class ;
+        rdfs:comment            "System operator." ;
+        rdfs:label              "SystemOperator"@en ;
+        cims:belongsToCategory  ae:Package_AssessedElementProfile ;
+        cims:stereotype         "NC" .
+
+nc:SystemOperator.AssessedElement
+        rdf:type              rdf:Property ;
+        rdfs:comment          "All relevant network elements on which operational security violations need to be managed in a coordinated way." ;
+        rdfs:domain           nc:SystemOperator ;
+        rdfs:label            "AssessedElement"@en ;
+        rdfs:range            nc:AssessedElement ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AssessedElement.AssessedSystemOperator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+profcim:IRI  rdf:type           rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as rdf:resource in RDFXML.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "IRI"@en ;
+        cims:belongsToCategory  ae:Package_DocAssessedElementProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringFixedLanguage
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited.\nThe primitive is serialized as literal without language support." ;
+        rdfs:label              "StringFixedLanguage"@en ;
+        cims:belongsToCategory  ae:Package_DocAssessedElementProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringIRI  rdf:type     rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as literal without language support.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "StringIRI"@en ;
+        cims:belongsToCategory  ae:Package_DocAssessedElementProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:URL  rdf:type           rdfs:Class ;
+        rdfs:comment            "A Uniform Resource Locator (URL), colloquially termed a web address, is a reference to a web resource that specifies its location on a computer network and a mechanism for retrieving it. A URL is a specific type of Uniform Resource Identifier (URI), although many people use the two terms interchangeably.URLs occur most commonly to reference web pages (http), but are also used for file transfer (ftp), email (mailto), database access (JDBC), and many other applications." ;
+        rdfs:label              "URL"@en ;
+        cims:belongsToCategory  ae:Package_DocAssessedElementProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+

--- a/r2.3/ap-voc/ttl/AvailabilitySchedule-AP-Voc-RDFS2020.ttl
+++ b/r2.3/ap-voc/ttl/AvailabilitySchedule-AP-Voc-RDFS2020.ttl
@@ -1,0 +1,937 @@
+@prefix as:      <https://ap.cim4.eu/AvailabilitySchedule#> .
+@prefix cim:     <https://cim.ucaiug.io/ns#> .
+@prefix cims:    <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/#> .
+@prefix nc:      <https://cim4.eu/ns/nc#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix profcim: <https://cim.ucaiug.io/ns/prof-cim#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+
+as:Ontology  rdf:type         owl:Ontology ;
+        dcterms:conformsTo    "urn:iso:std:iec:61970-501:draft:ed-2" , "file://CIM100_CGMES31v01_501-20v02_NC23v62_MM10v01.eap" , "urn:iso:std:iec:61970-600-2:ed-1" , "urn:iso:std:iec:61970-301:ed-7:amd1" , "file://iec61970cim17v40_iec61968cim13v13a_iec62325cim03v17a.eap" , "urn:iso:std:iec:61970-401:draft:ed-1" ;
+        dcterms:creator       "ENTSO-E CIM WG NC project"@en ;
+        dcterms:description   "This vocabulary is describing the availability schedule profile."@en ;
+        dcterms:identifier    "urn:uuid:8d128e35-86c7-4d67-b2dd-93229bf1005a" ;
+        dcterms:language      "en-GB" ;
+        dcterms:license       "https://www.apache.org/licenses/LICENSE-2.0"@en ;
+        dcterms:modified      "2024-03-20"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        dcterms:publisher     "ENTSO-E"@en ;
+        dcterms:rightsHolder  "ENTSO-E"@en ;
+        dcterms:title         "Availability schedule vocabulary"@en ;
+        owl:priorVersion      <http://entsoe.eu/ns/CIM/AvailabilitySchedule-EU/2.2> ;
+        owl:versionIRI        <https://ap.cim4.eu/AvailabilitySchedule/2.3> ;
+        owl:versionInfo       "2.3.0"@en ;
+        dcat:keyword          "AS" ;
+        dcat:theme            "vocabulary"@en .
+
+as:Package_AvailabilityScheduleProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains the availability schedule profile." ;
+        rdfs:label    "AvailabilityScheduleProfile"@en .
+as:Package_DocAvailabilityScheduleProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains datatypes used only in the RDFS header." ;
+        rdfs:label    "DocAvailabilityScheduleProfile"@en .
+
+cim:Boolean  rdf:type           rdfs:Class ;
+        rdfs:comment            "A type with the value space \"true\" and \"false\"." ;
+        rdfs:label              "Boolean"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Date  rdf:type              rdfs:Class ;
+        rdfs:comment            "Date as \"yyyy-mm-dd\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddZ\". A local timezone relative UTC is specified as \"yyyy-mm-dd(+/-)hh:mm\"." ;
+        rdfs:label              "Date"@en ;
+        cims:belongsToCategory  as:Package_DocAvailabilityScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:DateTime  rdf:type          rdfs:Class ;
+        rdfs:comment            "Date and time as \"yyyy-mm-ddThh:mm:ss.sss\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddThh:mm:ss.sssZ\". A local timezone relative UTC is specified as \"yyyy-mm-ddThh:mm:ss.sss-hh:mm\". The second component (shown here as \"ss.sss\") could have any number of digits in its fractional part to allow any kind of precision beyond seconds." ;
+        rdfs:label              "DateTime"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Duration  rdf:type          rdfs:Class ;
+        rdfs:comment            "Duration as \"PnYnMnDTnHnMnS\" which conforms to ISO 8601, where nY expresses a number of years, nM a number of months, nD a number of days. The letter T separates the date expression from the time expression and, after it, nH identifies a number of hours, nM a number of minutes and nS a number of seconds. The number of seconds could be expressed as a decimal number, but all other numbers are integers." ;
+        rdfs:label              "Duration"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Equipment  rdf:type         rdfs:Class ;
+        rdfs:comment            "The parts of a power system that are physical devices, electronic or mechanical." ;
+        rdfs:label              "Equipment"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile .
+
+cim:EquipmentContainer
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A modelling construct to provide a root class for containing equipment. " ;
+        rdfs:label              "EquipmentContainer"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile .
+
+cim:Float  rdf:type             rdfs:Class ;
+        rdfs:comment            "A floating point number. The range is unspecified and not limited." ;
+        rdfs:label              "Float"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:IdentifiedObject  rdf:type  rdfs:Class ;
+        rdfs:comment            "This is a root class to provide common identification for all classes needing identification and naming attributes." ;
+        rdfs:label              "IdentifiedObject"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile .
+
+cim:IdentifiedObject.description
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The description is a free human readable text describing or naming the object. It may be non unique and may not correlate to a naming hierarchy." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "description"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.name
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The name is any free human readable and possibly non unique text naming the object." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "name"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Integer  rdf:type           rdfs:Class ;
+        rdfs:comment            "An integer number. The range is unspecified and not limited." ;
+        rdfs:label              "Integer"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:OperationalLimit  rdf:type  rdfs:Class ;
+        rdfs:comment            "A value and normal value associated with a specific kind of limit. \nThe sub class value and normalValue attributes vary inversely to the associated OperationalLimitType.acceptableDuration (acceptableDuration for short).  \nIf a particular piece of equipment has multiple operational limits of the same kind (apparent power, current, etc.), the limit with the greatest acceptableDuration shall have the smallest limit value and the limit with the smallest acceptableDuration shall have the largest limit value.  Note: A large current can only be allowed to flow through a piece of equipment for a short duration without causing damage, but a lesser current can be allowed to flow for a longer duration. " ;
+        rdfs:label              "OperationalLimit"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile .
+
+cim:Seconds  rdf:type           rdfs:Class ;
+        rdfs:comment            "Time, in seconds." ;
+        rdfs:label              "Seconds"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Seconds.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:Seconds ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Seconds.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Seconds ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "s" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Seconds.value  rdf:type  rdf:Property ;
+        rdfs:comment       "Time, in seconds" ;
+        rdfs:domain        cim:Seconds ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:String  rdf:type            rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited." ;
+        rdfs:label              "String"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:UnitMultiplier  rdf:type    rdfs:Class ;
+        rdfs:comment            "The unit multipliers defined for the CIM.  When applied to unit symbols, the unit symbol is treated as a derived unit. Regardless of the contents of the unit symbol text, the unit symbol shall be treated as if it were a single-character unit symbol. Unit symbols should not contain multipliers, and it should be left to the multiplier to define the multiple for an entire data type. \n\nFor example, if a unit symbol is \"m2Pers\" and the multiplier is \"k\", then the value is k(m**2/s), and the multiplier applies to the entire final value, not to any individual part of the value. This can be conceptualized by substituting a derived unit symbol for the unit type. If one imagines that the symbol \"Þ\" represents the derived unit \"m2Pers\", then applying the multiplier \"k\" can be conceptualized simply as \"kÞ\".\n\nFor example, the SI unit for mass is \"kg\" and not \"g\".  If the unit symbol is defined as \"kg\", then the multiplier is applied to \"kg\" as a whole and does not replace the \"k\" in front of the \"g\". In this case, the multiplier of \"m\" would be used with the unit symbol of \"kg\" to represent one gram.  As a text string, this violates the instructions in IEC 80000-1. However, because the unit symbol in CIM is treated as a derived unit instead of as an SI unit, it makes more sense to conceptualize the \"kg\" as if it were replaced by one of the proposed replacements for the SI mass symbol. If one imagines that the \"kg\" were replaced by a symbol \"Þ\", then it is easier to conceptualize the multiplier \"m\" as creating the proper unit \"mÞ\", and not the forbidden unit \"mkg\"." ;
+        rdfs:label              "UnitMultiplier"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitMultiplier.none
+        rdf:type         cim:UnitMultiplier ;
+        rdfs:comment     "No multiplier or equivalently multiply by 1." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol  rdf:type        rdfs:Class ;
+        rdfs:comment            "The derived units defined for usage in the CIM. In some cases, the derived unit is equal to an SI unit. Whenever possible, the standard derived symbol is used instead of the formula for the derived unit. For example, the unit symbol Farad is defined as \"F\" instead of \"CPerV\". In cases where a standard symbol does not exist for a derived unit, the formula for the unit is used as the unit symbol. For example, density does not have a standard symbol and so it is represented as \"kgPerm3\". With the exception of the \"kg\", which is an SI unit, the unit symbols do not contain multipliers and therefore represent the base derived unit to which a multiplier can be applied as a whole. \nEvery unit symbol is treated as an unparseable text as if it were a single-letter symbol. The meaning of each unit symbol is defined by the accompanying descriptive text and not by the text contents of the unit symbol.\nTo allow the widest possible range of serializations without requiring special character handling, several substitutions are made which deviate from the format described in IEC 80000-1. The division symbol \"/\" is replaced by the letters \"Per\". Exponents are written in plain text after the unit as \"m3\" instead of being formatted as \"m\" with a superscript of 3  or introducing a symbol as in \"m^3\". The degree symbol \"°\" is replaced with the letters \"deg\". Any clarification of the meaning for a substitution is included in the description for the unit symbol.\nNon-SI units are included in list of unit symbols to allow sources of data to be correctly labelled with their non-SI units (for example, a GPS sensor that is reporting numbers that represent feet instead of meters). This allows software to use the unit symbol information correctly convert and scale the raw data of those sources into SI-based units. \nThe integer values are used for harmonization with IEC 61850." ;
+        rdfs:label              "UnitSymbol"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitSymbol.s  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Time in seconds." ;
+        rdfs:label       "s"@en ;
+        cims:stereotype  "enum" .
+
+nc:AssessedElement  rdf:type    rdfs:Class ;
+        rdfs:comment            "Assessed element is a network element for which the electrical state is evaluated in the regional or cross-regional process and which value is expected to fulfil regional rules function of the operational security limits.\nThe measurements and limits are as defined in the steady state hypothesis." ;
+        rdfs:label              "AssessedElement"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:AssessedElement.AvailabilityEnabled
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Availability enabled describes the enabling or disabling of this assessed element." ;
+        rdfs:domain           nc:AssessedElement ;
+        rdfs:label            "AvailabilityEnabled"@en ;
+        rdfs:range            nc:AvailabilityEnabled ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AvailabilityEnabled.AssessedElement ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilityContainer
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Availability container serves for associating an equipment container with an availability schedule. For instance, putting in or out of service all the equipment inside a Line or a Bay in combination with other availability functions with the same availability schedule." ;
+        rdfs:label              "AvailabilityContainer"@en ;
+        rdfs:subClassOf         nc:AvailabilityPowerSystemFunction ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AvailabilityContainer.EquipmentContainer
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Equipment container that is affected by the availability given by this availability container." ;
+        rdfs:domain           nc:AvailabilityContainer ;
+        rdfs:label            "EquipmentContainer"@en ;
+        rdfs:range            cim:EquipmentContainer ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EquipmentContainer.AvailabilityContainer ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilityEnabled
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Availability enabled is enabling or disabling grid state alteration (e.g. tap position action) or assessed element that is related to the availability schedule. For instance, the cancellation of availability schedule can lead to changes in the  assessed element. This is done by enabling one assessment and disabling another." ;
+        rdfs:label              "AvailabilityEnabled"@en ;
+        rdfs:subClassOf         nc:AvailabilityPowerSystemFunction ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AvailabilityEnabled.AssessedElement
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Assessed element that is affected by the availability given by this availability enabling." ;
+        rdfs:domain           nc:AvailabilityEnabled ;
+        rdfs:label            "AssessedElement"@en ;
+        rdfs:range            nc:AssessedElement ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AssessedElement.AvailabilityEnabled ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilityEnabled.GridStateAlteration
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Grid state alteration that is affected by the availability given by this availability enabling." ;
+        rdfs:domain           nc:AvailabilityEnabled ;
+        rdfs:label            "GridStateAlteration"@en ;
+        rdfs:range            nc:GridStateAlteration ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GridStateAlteration.AvailabilityEnabled ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilityEnabled.enabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Instruction to enable or disable alteration and assessment." ;
+        rdfs:domain        nc:AvailabilityEnabled ;
+        rdfs:label         "enabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AvailabilityEquipment
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Availability equipment serves for associating an equipment with an availability schedule. For instance, putting in or out of service an ACLineSegment in combination with other availability functions with the same availability schedule." ;
+        rdfs:label              "AvailabilityEquipment"@en ;
+        rdfs:subClassOf         nc:AvailabilityPowerSystemFunction ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AvailabilityEquipment.Equipment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Equipment that is affected by the availability given by this availability equipment." ;
+        rdfs:domain           nc:AvailabilityEquipment ;
+        rdfs:label            "Equipment"@en ;
+        rdfs:range            cim:Equipment ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Equipment.AvailabilityEquipment ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilityExceptionalLimit
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Availability exceptional limit serves for associating an operational limit restriction with an availability schedule. For instance, enabling or disabling the current limit on ACLineSegment terminal in combination with other availability functions with the same availability schedule or de-rating due to fault." ;
+        rdfs:label              "AvailabilityExceptionalLimit"@en ;
+        rdfs:subClassOf         nc:AvailabilityPowerSystemFunction ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AvailabilityExceptionalLimit.OperationalLimit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Operational limit that is constrained by this availability exceptional limit." ;
+        rdfs:domain           nc:AvailabilityExceptionalLimit ;
+        rdfs:label            "OperationalLimit"@en ;
+        rdfs:range            cim:OperationalLimit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:OperationalLimit.AvailabilityExceptionalLimit ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilityExceptionalLimit.value
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Value for the referred operational limit." ;
+        rdfs:domain        nc:AvailabilityExceptionalLimit ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AvailabilityFunctionKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of availability that is affecting the function." ;
+        rdfs:label              "AvailabilityFunctionKind"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:AvailabilityFunctionKind.inService
+        rdf:type         nc:AvailabilityFunctionKind ;
+        rdfs:comment     "Function is in service." ;
+        rdfs:label       "inService"@en ;
+        cims:stereotype  "enum" .
+
+nc:AvailabilityFunctionKind.outOfService
+        rdf:type         nc:AvailabilityFunctionKind ;
+        rdfs:comment     "Function is out-of-service." ;
+        rdfs:label       "outOfService"@en ;
+        cims:stereotype  "enum" .
+
+nc:AvailabilityFunctionKind.underTesting
+        rdf:type         nc:AvailabilityFunctionKind ;
+        rdfs:comment     "Function is under testing and need to expect unscheduled availability." ;
+        rdfs:label       "underTesting"@en ;
+        cims:stereotype  "enum" .
+
+nc:AvailabilityGroup  rdf:type  rdfs:Class ;
+        rdfs:comment            "Container to link relevant equipment that is affected by (un)availability schedule across availability coordinator (e.g. TSO-TSO, TSO-DSO or DSO-DSO)." ;
+        rdfs:label              "AvailabilityGroup"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AvailabilityGroup.AvailabilityPowerSystemFunction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "All availability power system functions linked through mutual dependency with other availability power system functions controlled by other system operators." ;
+        rdfs:domain           nc:AvailabilityGroup ;
+        rdfs:label            "AvailabilityPowerSystemFunction"@en ;
+        rdfs:range            nc:AvailabilityPowerSystemFunction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AvailabilityPowerSystemFunction.AvailabilityGroup ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilityPowerSystemFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Availability power system function describes the power system function that has a non-normal availability in the associated availability schedule. The availability of the function is needed as part of a power flow solution. This function is the cause and not the effect of the availability, if the effect can be calculated through power flow. For instance if only the step-up transformer for a generator is not available, the power flow will calculate that the generator is de-energized (outage). If both are tagged as not available it will not be possible to investigate remedial action for connecting the generator. It is expected that the power flow function is able to perform simple topology changes affected by a function taken out of service, e.g. open switches on both end of a ACLineSegment when the ACLineSegment is taken out of service. More complex changes, like change regulation set point, must be described in the linked GridStateAlterationCollection." ;
+        rdfs:label              "AvailabilityPowerSystemFunction"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:AvailabilityPowerSystemFunction.AvailabilityGroup
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Grouping for all availability power system functions (controlled by all relevant system operators) that have the same availability schedule." ;
+        rdfs:domain           nc:AvailabilityPowerSystemFunction ;
+        rdfs:label            "AvailabilityGroup"@en ;
+        rdfs:range            nc:AvailabilityGroup ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AvailabilityGroup.AvailabilityPowerSystemFunction ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilityPowerSystemFunction.AvailabilitySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Availability schedule for this availability power system function." ;
+        rdfs:domain           nc:AvailabilityPowerSystemFunction ;
+        rdfs:label            "AvailabilitySchedule"@en ;
+        rdfs:range            nc:AvailabilitySchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AvailabilitySchedule.AvailabilityPowerSystemFunction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilityPowerSystemFunction.kind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of availability that affect the power system function." ;
+        rdfs:domain        nc:AvailabilityPowerSystemFunction ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         nc:AvailabilityFunctionKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AvailabilityRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Availability remedial action is a remedial action that cancels or reschedules an availability schedule." ;
+        rdfs:label              "AvailabilityRemedialAction"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:AvailabilityRemedialAction.AvailabilitySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Availability schedule that is part of the remedial action." ;
+        rdfs:domain           nc:AvailabilityRemedialAction ;
+        rdfs:label            "AvailabilitySchedule"@en ;
+        rdfs:range            nc:AvailabilitySchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AvailabilitySchedule.RemedialAction ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilityRemedialActionScheme
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Availability remedial action scheme serves for associating a remedial action scheme with an availability schedule. For instance, taking in or out of service a SIPS / SPS due to communication issue, in combination with other availability functions with the same availability schedule." ;
+        rdfs:label              "AvailabilityRemedialActionScheme"@en ;
+        rdfs:subClassOf         nc:AvailabilityPowerSystemFunction ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AvailabilityRemedialActionScheme.RemedialActionScheme
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action scheme that is affected by the availability given by this availability remedial action scheme." ;
+        rdfs:domain           nc:AvailabilityRemedialActionScheme ;
+        rdfs:label            "RemedialActionScheme"@en ;
+        rdfs:range            nc:RemedialActionScheme ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialActionScheme.AvailabilityRemedialActionScheme ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilitySchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A given (un)availability schedule with a given status and cause that include multiple equipment that need to follow the same scheduling periods." ;
+        rdfs:label              "AvailabilitySchedule"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AvailabilitySchedule.ActualSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Actual schedule that relates to this availability schedule; used for ex-post reporting and analysis (e.g., to compare planned vs. actual)." ;
+        rdfs:domain           nc:AvailabilitySchedule ;
+        rdfs:label            "ActualSchedule"@en ;
+        rdfs:range            nc:EventSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EventSchedule.ActualAvailabilitySchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilitySchedule.AlternativeSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Alternative schedule. The priority in regards to multiple alternatives is given by the priority attribute. This schedule is only relevant if all the alternatives with higher priority are cancelled." ;
+        rdfs:domain           nc:AvailabilitySchedule ;
+        rdfs:label            "AlternativeSchedule"@en ;
+        rdfs:range            nc:AvailabilitySchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AvailabilitySchedule.PrioritySchedule ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilitySchedule.AvailabilityPowerSystemFunction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "All the couplings that associate one concrete function (e.g., equipment or container, SIPS/SPSs, grid state alteration, exceptional operational limits) with the same availability schedule." ;
+        rdfs:domain           nc:AvailabilitySchedule ;
+        rdfs:label            "AvailabilityPowerSystemFunction"@en ;
+        rdfs:range            nc:AvailabilityPowerSystemFunction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AvailabilityPowerSystemFunction.AvailabilitySchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilitySchedule.AvailabilitySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Availability schedule that has a dependent availability schedule." ;
+        rdfs:domain           nc:AvailabilitySchedule ;
+        rdfs:label            "AvailabilitySchedule"@en ;
+        rdfs:range            nc:AvailabilitySchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AvailabilitySchedule.DependentOnSchedule ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilitySchedule.DependentOnSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "(Un)availability schedule requested by one operator may require another operator to request their (un)availability schedule. This association is linking the schedules so that the dependency is clear.  " ;
+        rdfs:domain           nc:AvailabilitySchedule ;
+        rdfs:label            "DependentOnSchedule"@en ;
+        rdfs:range            nc:AvailabilitySchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AvailabilitySchedule.AvailabilitySchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilitySchedule.GridStateAlterationCollection
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The grid state alteration collection that has this availability schedule." ;
+        rdfs:domain           nc:AvailabilitySchedule ;
+        rdfs:label            "GridStateAlterationCollection"@en ;
+        rdfs:range            nc:GridStateAlterationCollection ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GridStateAlterationCollection.AvailabilitySchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilitySchedule.PlannedSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Planned schedule that relates to this availability schedule used for planning availability (e.g., to compare planned vs. actual)." ;
+        rdfs:domain           nc:AvailabilitySchedule ;
+        rdfs:label            "PlannedSchedule"@en ;
+        rdfs:range            nc:EventSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EventSchedule.PlannedAvailabilitySchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilitySchedule.PrioritySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Priority schedule. This is the schedule that has the highest priority and the only valid if not cancelled." ;
+        rdfs:domain           nc:AvailabilitySchedule ;
+        rdfs:label            "PrioritySchedule"@en ;
+        rdfs:range            nc:AvailabilitySchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AvailabilitySchedule.AlternativeSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilitySchedule.RemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action that is cancelling this availability schedule." ;
+        rdfs:domain           nc:AvailabilitySchedule ;
+        rdfs:label            "RemedialAction"@en ;
+        rdfs:range            nc:AvailabilityRemedialAction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AvailabilityRemedialAction.AvailabilitySchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilitySchedule.cancelledDateTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The date and time the (un)availability schedule were cancelled . " ;
+        rdfs:domain        nc:AvailabilitySchedule ;
+        rdfs:label         "cancelledDateTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AvailabilitySchedule.causeDescription
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A cause description for a cause kind. In case of CauseKind equals other, description or a reference of the cause of the (un)availability schedule." ;
+        rdfs:domain        nc:AvailabilitySchedule ;
+        rdfs:label         "causeDescription"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AvailabilitySchedule.causeKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of cause for the availability schedule." ;
+        rdfs:domain        nc:AvailabilitySchedule ;
+        rdfs:label         "causeKind"@en ;
+        rdfs:range         nc:AvailabilityScheduleCauseKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AvailabilitySchedule.daytimeRestitutionDuration
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time required to take the out-of-service equipment back into service during daytime. This includes the start-up time for generating units." ;
+        rdfs:domain        nc:AvailabilitySchedule ;
+        rdfs:label         "daytimeRestitutionDuration"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AvailabilitySchedule.eveningRestitutionDuration
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time required to take the out-of-service equipment back into service after office hours. This includes the start-up time for generating units." ;
+        rdfs:domain        nc:AvailabilitySchedule ;
+        rdfs:label         "eveningRestitutionDuration"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AvailabilitySchedule.maxRestitutionDuration
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The maximum time required to take the out-of-service equipment back into service. This includes the start-up time for generating units." ;
+        rdfs:domain        nc:AvailabilitySchedule ;
+        rdfs:label         "maxRestitutionDuration"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AvailabilitySchedule.priority
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Value 0 means ignore priority. 1 means the highest priority, 2 is the second highest priority." ;
+        rdfs:domain        nc:AvailabilitySchedule ;
+        rdfs:label         "priority"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AvailabilitySchedule.weekendRestitutionDuration
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time required to take the out-of-service equipment back into service in the weekend or during bank holidays. This includes the start-up time for generating units." ;
+        rdfs:domain        nc:AvailabilitySchedule ;
+        rdfs:label         "weekendRestitutionDuration"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AvailabilityScheduleCauseKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The kinds of cause of the (un)availability schedule." ;
+        rdfs:label              "AvailabilityScheduleCauseKind"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:AvailabilityScheduleCauseKind.commissioning
+        rdf:type         nc:AvailabilityScheduleCauseKind ;
+        rdfs:comment     "The cause is due to a commissioning." ;
+        rdfs:label       "commissioning"@en ;
+        cims:stereotype  "enum" .
+
+nc:AvailabilityScheduleCauseKind.decommissioning
+        rdf:type         nc:AvailabilityScheduleCauseKind ;
+        rdfs:comment     "The cause is due to a decommissioning." ;
+        rdfs:label       "decommissioning"@en ;
+        cims:stereotype  "enum" .
+
+nc:AvailabilityScheduleCauseKind.environmentalCondition
+        rdf:type         nc:AvailabilityScheduleCauseKind ;
+        rdfs:comment     "The cause is due to an environmental condition. This can lead to exceptional margin and limits." ;
+        rdfs:label       "environmentalCondition"@en ;
+        cims:stereotype  "enum" .
+
+nc:AvailabilityScheduleCauseKind.functionalControl
+        rdf:type         nc:AvailabilityScheduleCauseKind ;
+        rdfs:comment     "The cause is due to a functional control (in &amp; out)." ;
+        rdfs:label       "functionalControl"@en ;
+        cims:stereotype  "enum" .
+
+nc:AvailabilityScheduleCauseKind.maintenance
+        rdf:type         nc:AvailabilityScheduleCauseKind ;
+        rdfs:comment     "The cause is due to a maintenance." ;
+        rdfs:label       "maintenance"@en ;
+        cims:stereotype  "enum" .
+
+nc:AvailabilityScheduleCauseKind.other
+        rdf:type         nc:AvailabilityScheduleCauseKind ;
+        rdfs:comment     "The cause is of other kind." ;
+        rdfs:label       "other"@en ;
+        cims:stereotype  "enum" .
+
+nc:AvailabilityScheduleCauseKind.refurbishment
+        rdf:type         nc:AvailabilityScheduleCauseKind ;
+        rdfs:comment     "The cause is due to a refurbishment, either upgrade or downgrade." ;
+        rdfs:label       "refurbishment"@en ;
+        cims:stereotype  "enum" .
+
+nc:AvailabilityScheduleCauseKind.worksInProximity
+        rdf:type         nc:AvailabilityScheduleCauseKind ;
+        rdfs:comment     "The cause is due to a works in proximity." ;
+        rdfs:label       "worksInProximity"@en ;
+        cims:stereotype  "enum" .
+
+nc:BaseIrregularTimeSeries
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Time series that has irregular points in time." ;
+        rdfs:label              "BaseIrregularTimeSeries"@en ;
+        rdfs:subClassOf         nc:BaseTimeSeries ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:BaseTimeSeries  rdf:type     rdfs:Class ;
+        rdfs:comment            "Time series of values at points in time." ;
+        rdfs:label              "BaseTimeSeries"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:BaseTimeSeries.interpolationKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of interpolation done between time point." ;
+        rdfs:domain        nc:BaseTimeSeries ;
+        rdfs:label         "interpolationKind"@en ;
+        rdfs:range         nc:TimeSeriesInterpolationKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseTimeSeries.kind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of base time series." ;
+        rdfs:domain        nc:BaseTimeSeries ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         nc:BaseTimeSeriesKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseTimeSeriesKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of time series. " ;
+        rdfs:label              "BaseTimeSeriesKind"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:BaseTimeSeriesKind.actual
+        rdf:type         nc:BaseTimeSeriesKind ;
+        rdfs:comment     "Time series is actual data. The values represent measured or calculated values that represent the actual behaviour. " ;
+        rdfs:label       "actual"@en ;
+        cims:stereotype  "enum" .
+
+nc:BaseTimeSeriesKind.schedule
+        rdf:type         nc:BaseTimeSeriesKind ;
+        rdfs:comment     "Time series is schedule data. The values represent the result of a committed and plan forecast data that has been through a quality control and could incur penalty when not followed." ;
+        rdfs:label       "schedule"@en ;
+        cims:stereotype  "enum" .
+
+nc:Equipment.AvailabilityEquipment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Availability equipment describe the availabilty that affect this equipment." ;
+        rdfs:domain           cim:Equipment ;
+        rdfs:label            "AvailabilityEquipment"@en ;
+        rdfs:range            nc:AvailabilityEquipment ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AvailabilityEquipment.Equipment ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EquipmentContainer.AvailabilityContainer
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Availability container describe the availabiltiy that affect this equipment container." ;
+        rdfs:domain           cim:EquipmentContainer ;
+        rdfs:label            "AvailabilityContainer"@en ;
+        rdfs:range            nc:AvailabilityContainer ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AvailabilityContainer.EquipmentContainer ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EventSchedule  rdf:type      rdfs:Class ;
+        rdfs:comment            "Time series represent irregular event described by event points in time." ;
+        rdfs:label              "EventSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EventSchedule.ActualAvailabilitySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Actual availability schedule that has this irregular interval schedule." ;
+        rdfs:domain           nc:EventSchedule ;
+        rdfs:label            "ActualAvailabilitySchedule"@en ;
+        rdfs:range            nc:AvailabilitySchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AvailabilitySchedule.ActualSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:EventSchedule.EventTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Value for the point in time." ;
+        rdfs:domain           nc:EventSchedule ;
+        rdfs:label            "EventTimePoint"@en ;
+        rdfs:range            nc:EventTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EventTimePoint.EventSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:EventSchedule.PlannedAvailabilitySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Planned availability schedule that has this irregular interval schedule." ;
+        rdfs:domain           nc:EventSchedule ;
+        rdfs:label            "PlannedAvailabilitySchedule"@en ;
+        rdfs:range            nc:AvailabilitySchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AvailabilitySchedule.PlannedSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:EventTimePoint  rdf:type     rdfs:Class ;
+        rdfs:comment            "Event valid for a given point in time." ;
+        rdfs:label              "EventTimePoint"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EventTimePoint.EventSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Time series the time point values belongs to." ;
+        rdfs:domain           nc:EventTimePoint ;
+        rdfs:label            "EventSchedule"@en ;
+        rdfs:range            nc:EventSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EventSchedule.EventTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:EventTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:EventTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EventTimePoint.isActive
+        rdf:type           rdf:Property ;
+        rdfs:comment       "True, if the event is occurring (Active) at this time point. Otherwise false." ;
+        rdfs:domain        nc:EventTimePoint ;
+        rdfs:label         "isActive"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GridStateAlteration
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Grid state alteration is a change of values describing state (operating point) of one element in the grid model compared to the base case." ;
+        rdfs:label              "GridStateAlteration"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:GridStateAlteration.AvailabilityEnabled
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Availability enabled describes the enabling or disabling of this grid state alteration." ;
+        rdfs:domain           nc:GridStateAlteration ;
+        rdfs:label            "AvailabilityEnabled"@en ;
+        rdfs:range            nc:AvailabilityEnabled ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AvailabilityEnabled.GridStateAlteration ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:GridStateAlterationCollection
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A collection of grid state alterations." ;
+        rdfs:label              "GridStateAlterationCollection"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:GridStateAlterationCollection.AvailabilitySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Availability schedule that require the a collection of grid state alteration to provide a valid power flow solution. For instance, a set of switching plans." ;
+        rdfs:domain           nc:GridStateAlterationCollection ;
+        rdfs:label            "AvailabilitySchedule"@en ;
+        rdfs:range            nc:AvailabilitySchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AvailabilitySchedule.GridStateAlterationCollection ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:OperationalLimit.AvailabilityExceptionalLimit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Availability exceptional limit that constrain this operational limit." ;
+        rdfs:domain           cim:OperationalLimit ;
+        rdfs:label            "AvailabilityExceptionalLimit"@en ;
+        rdfs:range            nc:AvailabilityExceptionalLimit ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AvailabilityExceptionalLimit.OperationalLimit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionScheme
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Remedial Action Scheme (RAS), Special Protection Schemes (SPS), System Protection Schemes (SPS) or System Integrity Protection Schemes (SIPS).\nA Remedial Action Scheme consists of one or more stages that can trigger and execute a protection action." ;
+        rdfs:label              "RemedialActionScheme"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:RemedialActionScheme.AvailabilityRemedialActionScheme
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Availability remedial action scheme describe the availabiltiy that affect this remedial action scheme." ;
+        rdfs:domain           nc:RemedialActionScheme ;
+        rdfs:label            "AvailabilityRemedialActionScheme"@en ;
+        rdfs:range            nc:AvailabilityRemedialActionScheme ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AvailabilityRemedialActionScheme.RemedialActionScheme ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:TimeSeriesInterpolationKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kinds of interpolation of values between two time point. " ;
+        rdfs:label              "TimeSeriesInterpolationKind"@en ;
+        cims:belongsToCategory  as:Package_AvailabilityScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:TimeSeriesInterpolationKind.previous
+        rdf:type         nc:TimeSeriesInterpolationKind ;
+        rdfs:comment     "The value between two time points is set to previous value." ;
+        rdfs:label       "previous"@en ;
+        cims:stereotype  "enum" .
+
+profcim:IRI  rdf:type           rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as rdf:resource in RDFXML.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "IRI"@en ;
+        cims:belongsToCategory  as:Package_DocAvailabilityScheduleProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringFixedLanguage
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited.\nThe primitive is serialized as literal without language support." ;
+        rdfs:label              "StringFixedLanguage"@en ;
+        cims:belongsToCategory  as:Package_DocAvailabilityScheduleProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringIRI  rdf:type     rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as literal without language support.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "StringIRI"@en ;
+        cims:belongsToCategory  as:Package_DocAvailabilityScheduleProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:URL  rdf:type           rdfs:Class ;
+        rdfs:comment            "A Uniform Resource Locator (URL), colloquially termed a web address, is a reference to a web resource that specifies its location on a computer network and a mechanism for retrieving it. A URL is a specific type of Uniform Resource Identifier (URI), although many people use the two terms interchangeably.URLs occur most commonly to reference web pages (http), but are also used for file transfer (ftp), email (mailto), database access (JDBC), and many other applications." ;
+        rdfs:label              "URL"@en ;
+        cims:belongsToCategory  as:Package_DocAvailabilityScheduleProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+

--- a/r2.3/ap-voc/ttl/Contingency-AP-Voc-RDFS2020.ttl
+++ b/r2.3/ap-voc/ttl/Contingency-AP-Voc-RDFS2020.ttl
@@ -1,0 +1,423 @@
+@prefix cim:     <https://cim.ucaiug.io/ns#> .
+@prefix cims:    <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#> .
+@prefix co:      <https://ap.cim4.eu/Contingency#> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/#> .
+@prefix nc:      <https://cim4.eu/ns/nc#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix profcim: <https://cim.ucaiug.io/ns/prof-cim#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+
+cim:Boolean  rdf:type           rdfs:Class ;
+        rdfs:comment            "A type with the value space \"true\" and \"false\"." ;
+        rdfs:label              "Boolean"@en ;
+        cims:belongsToCategory  co:Package_ContingencyProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Contingency  rdf:type       rdfs:Class ;
+        rdfs:comment            "An event threatening system reliability, consisting of one or more contingency elements." ;
+        rdfs:label              "Contingency"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  co:Package_ContingencyProfile .
+
+cim:Contingency.ContingencyElement
+        rdf:type              rdf:Property ;
+        rdfs:comment          "A contingency can have any number of contingency elements." ;
+        rdfs:domain           cim:Contingency ;
+        rdfs:label            "ContingencyElement"@en ;
+        rdfs:range            cim:ContingencyElement ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:ContingencyElement.Contingency ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+cim:Contingency.SimulationEvents
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Simulation event for a contingency." ;
+        rdfs:domain           cim:Contingency ;
+        rdfs:label            "SimulationEvents"@en ;
+        rdfs:range            cim:SimulationEvents ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:SimulationEvents.Contingency ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+cim:ContingencyElement
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "An element of a system event to be studied by contingency analysis, representing a change in status of a single piece of equipment. " ;
+        rdfs:label              "ContingencyElement"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  co:Package_ContingencyProfile .
+
+cim:ContingencyElement.Contingency
+        rdf:type              rdf:Property ;
+        rdfs:comment          "A contingency element belongs to one contingency." ;
+        rdfs:domain           cim:ContingencyElement ;
+        rdfs:label            "Contingency"@en ;
+        rdfs:range            cim:Contingency ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:Contingency.ContingencyElement ;
+        cims:multiplicity     cims:M:1 .
+
+cim:ContingencyEquipment
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Equipment whose in service status is to change, such as a power transformer or AC line segment." ;
+        rdfs:label              "ContingencyEquipment"@en ;
+        rdfs:subClassOf         cim:ContingencyElement ;
+        cims:belongsToCategory  co:Package_ContingencyProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:ContingencyEquipment.Equipment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The single piece of equipment to which to apply the contingency." ;
+        rdfs:domain           cim:ContingencyEquipment ;
+        rdfs:label            "Equipment"@en ;
+        rdfs:range            cim:Equipment ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:Equipment.ContingencyEquipment ;
+        cims:multiplicity     cims:M:1 .
+
+cim:ContingencyEquipment.contingentStatus
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The status for the associated equipment when in the contingency state.   This status is independent of the case to which the contingency is originally applied, but defines the equipment status when the contingency is applied." ;
+        rdfs:domain        cim:ContingencyEquipment ;
+        rdfs:label         "contingentStatus"@en ;
+        rdfs:range         cim:ContingencyEquipmentStatusKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ContingencyEquipmentStatusKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Indicates the state which the contingency equipment is to be in when the contingency is applied." ;
+        rdfs:label              "ContingencyEquipmentStatusKind"@en ;
+        cims:belongsToCategory  co:Package_ContingencyProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:ContingencyEquipmentStatusKind.inService
+        rdf:type         cim:ContingencyEquipmentStatusKind ;
+        rdfs:comment     "The equipment is to be put into service." ;
+        rdfs:label       "inService"@en ;
+        cims:stereotype  "enum" .
+
+cim:ContingencyEquipmentStatusKind.outOfService
+        rdf:type         cim:ContingencyEquipmentStatusKind ;
+        rdfs:comment     "The equipment is to be taken out of service." ;
+        rdfs:label       "outOfService"@en ;
+        cims:stereotype  "enum" .
+
+cim:Date  rdf:type              rdfs:Class ;
+        rdfs:comment            "Date as \"yyyy-mm-dd\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddZ\". A local timezone relative UTC is specified as \"yyyy-mm-dd(+/-)hh:mm\"." ;
+        rdfs:label              "Date"@en ;
+        cims:belongsToCategory  co:Package_DocContingencyProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:DateTime  rdf:type          rdfs:Class ;
+        rdfs:comment            "Date and time as \"yyyy-mm-ddThh:mm:ss.sss\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddThh:mm:ss.sssZ\". A local timezone relative UTC is specified as \"yyyy-mm-ddThh:mm:ss.sss-hh:mm\". The second component (shown here as \"ss.sss\") could have any number of digits in its fractional part to allow any kind of precision beyond seconds." ;
+        rdfs:label              "DateTime"@en ;
+        cims:belongsToCategory  co:Package_DocContingencyProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Equipment  rdf:type         rdfs:Class ;
+        rdfs:comment            "The parts of a power system that are physical devices, electronic or mechanical." ;
+        rdfs:label              "Equipment"@en ;
+        cims:belongsToCategory  co:Package_ContingencyProfile .
+
+cim:Equipment.ContingencyEquipment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The contingency equipments in which this equipment participates." ;
+        rdfs:domain           cim:Equipment ;
+        rdfs:label            "ContingencyEquipment"@en ;
+        rdfs:range            cim:ContingencyEquipment ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:ContingencyEquipment.Equipment ;
+        cims:multiplicity     cims:M:0..n .
+
+cim:Float  rdf:type             rdfs:Class ;
+        rdfs:comment            "A floating point number. The range is unspecified and not limited." ;
+        rdfs:label              "Float"@en ;
+        cims:belongsToCategory  co:Package_ContingencyProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:IdentifiedObject  rdf:type  rdfs:Class ;
+        rdfs:comment            "This is a root class to provide common identification for all classes needing identification and naming attributes." ;
+        rdfs:label              "IdentifiedObject"@en ;
+        cims:belongsToCategory  co:Package_ContingencyProfile .
+
+cim:IdentifiedObject.description
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The description is a free human readable text describing or naming the object. It may be non unique and may not correlate to a naming hierarchy." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "description"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.name
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The name is any free human readable and possibly non unique text naming the object." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "name"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent  rdf:type           rdfs:Class ;
+        rdfs:comment            "Percentage on a defined base.   For example, specify as 100 to indicate at the defined base." ;
+        rdfs:label              "PerCent"@en ;
+        cims:belongsToCategory  co:Package_ContingencyProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:PerCent.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent.value  rdf:type  rdf:Property ;
+        rdfs:comment       "Normally 0 to 100 on a defined base." ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:SimulationEvents  rdf:type  rdfs:Class ;
+        rdfs:comment            "A configuration or a set of events executed during a simulation." ;
+        rdfs:label              "SimulationEvents"@en ;
+        cims:belongsToCategory  co:Package_ContingencyProfile .
+
+cim:SimulationEvents.Contingency
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Contingency which has simulation events." ;
+        rdfs:domain           cim:SimulationEvents ;
+        rdfs:label            "Contingency"@en ;
+        rdfs:range            cim:Contingency ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:Contingency.SimulationEvents ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+cim:String  rdf:type            rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited." ;
+        rdfs:label              "String"@en ;
+        cims:belongsToCategory  co:Package_ContingencyProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:UnitMultiplier  rdf:type    rdfs:Class ;
+        rdfs:comment            "The unit multipliers defined for the CIM.  When applied to unit symbols, the unit symbol is treated as a derived unit. Regardless of the contents of the unit symbol text, the unit symbol shall be treated as if it were a single-character unit symbol. Unit symbols should not contain multipliers, and it should be left to the multiplier to define the multiple for an entire data type. \n\nFor example, if a unit symbol is \"m2Pers\" and the multiplier is \"k\", then the value is k(m**2/s), and the multiplier applies to the entire final value, not to any individual part of the value. This can be conceptualized by substituting a derived unit symbol for the unit type. If one imagines that the symbol \"Þ\" represents the derived unit \"m2Pers\", then applying the multiplier \"k\" can be conceptualized simply as \"kÞ\".\n\nFor example, the SI unit for mass is \"kg\" and not \"g\".  If the unit symbol is defined as \"kg\", then the multiplier is applied to \"kg\" as a whole and does not replace the \"k\" in front of the \"g\". In this case, the multiplier of \"m\" would be used with the unit symbol of \"kg\" to represent one gram.  As a text string, this violates the instructions in IEC 80000-1. However, because the unit symbol in CIM is treated as a derived unit instead of as an SI unit, it makes more sense to conceptualize the \"kg\" as if it were replaced by one of the proposed replacements for the SI mass symbol. If one imagines that the \"kg\" were replaced by a symbol \"Þ\", then it is easier to conceptualize the multiplier \"m\" as creating the proper unit \"mÞ\", and not the forbidden unit \"mkg\"." ;
+        rdfs:label              "UnitMultiplier"@en ;
+        cims:belongsToCategory  co:Package_ContingencyProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitMultiplier.none
+        rdf:type         cim:UnitMultiplier ;
+        rdfs:comment     "No multiplier or equivalently multiply by 1." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol  rdf:type        rdfs:Class ;
+        rdfs:comment            "The derived units defined for usage in the CIM. In some cases, the derived unit is equal to an SI unit. Whenever possible, the standard derived symbol is used instead of the formula for the derived unit. For example, the unit symbol Farad is defined as \"F\" instead of \"CPerV\". In cases where a standard symbol does not exist for a derived unit, the formula for the unit is used as the unit symbol. For example, density does not have a standard symbol and so it is represented as \"kgPerm3\". With the exception of the \"kg\", which is an SI unit, the unit symbols do not contain multipliers and therefore represent the base derived unit to which a multiplier can be applied as a whole. \nEvery unit symbol is treated as an unparseable text as if it were a single-letter symbol. The meaning of each unit symbol is defined by the accompanying descriptive text and not by the text contents of the unit symbol.\nTo allow the widest possible range of serializations without requiring special character handling, several substitutions are made which deviate from the format described in IEC 80000-1. The division symbol \"/\" is replaced by the letters \"Per\". Exponents are written in plain text after the unit as \"m3\" instead of being formatted as \"m\" with a superscript of 3  or introducing a symbol as in \"m^3\". The degree symbol \"°\" is replaced with the letters \"deg\". Any clarification of the meaning for a substitution is included in the description for the unit symbol.\nNon-SI units are included in list of unit symbols to allow sources of data to be correctly labelled with their non-SI units (for example, a GPS sensor that is reporting numbers that represent feet instead of meters). This allows software to use the unit symbol information correctly convert and scale the raw data of those sources into SI-based units. \nThe integer values are used for harmonization with IEC 61850." ;
+        rdfs:label              "UnitSymbol"@en ;
+        cims:belongsToCategory  co:Package_ContingencyProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitSymbol.none  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Dimension less quantity, e.g. count, per unit, etc." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+co:Ontology  rdf:type         owl:Ontology ;
+        dcterms:conformsTo    "file://CIM100_CGMES31v01_501-20v02_NC23v62_MM10v01.eap" , "urn:iso:std:iec:61970-401:draft:ed-1" , "urn:iso:std:iec:61970-301:ed-7:amd1" , "urn:iso:std:iec:61970-501:draft:ed-2" , "urn:iso:std:iec:61970-600-2:ed-1" , "file://iec61970cim17v40_iec61968cim13v13a_iec62325cim03v17a.eap" ;
+        dcterms:creator       "ENTSO-E CIM WG NC project"@en ;
+        dcterms:description   "This vocabulary is describing the contingency profile."@en ;
+        dcterms:identifier    "urn:uuid:8947de1c-6e53-4f1f-82c3-99ef118db9eb" ;
+        dcterms:language      "en-GB" ;
+        dcterms:license       "https://www.apache.org/licenses/LICENSE-2.0"@en ;
+        dcterms:modified      "2024-03-20"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        dcterms:publisher     "ENTSO-E"@en ;
+        dcterms:rightsHolder  "ENTSO-E"@en ;
+        dcterms:title         "Contingency Vocabulary"@en ;
+        owl:priorVersion      <http://entsoe.eu/ns/CIM/Contingency-EU/2.2> ;
+        owl:versionIRI        <https://ap.cim4.eu/Contingency/2.3> ;
+        owl:versionInfo       "2.3.0"@en ;
+        dcat:keyword          "CO" ;
+        dcat:theme            "vocabulary"@en .
+
+co:Package_ContingencyProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains contingency profile." ;
+        rdfs:label    "ContingencyProfile"@en .
+
+co:Package_DocContingencyProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains datatypes used only in the RDFS header." ;
+        rdfs:label    "DocContingencyProfile"@en .
+
+nc:Contingency.EquipmentOperator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "System operator that is operating the equipment that is being run a contingency on." ;
+        rdfs:domain           cim:Contingency ;
+        rdfs:label            "EquipmentOperator"@en ;
+        rdfs:range            nc:SystemOperator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SystemOperator.Contingency ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:Contingency.normalMustStudy
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Specifies the requirement of study the contingency under normal operating conditions. True means the contingency must be study in a normal scenario. False means that the contingency does not need to be included in the scenario. This is the default value if mustStudy is missing." ;
+        rdfs:domain        cim:Contingency ;
+        rdfs:label         "normalMustStudy"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Contingency.normalProbability
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Normal probability of the occurrence of the contingency based on normal operational condition. The value is used as the default if the probability is missing.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        cim:Contingency ;
+        rdfs:label         "normalProbability"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ContingencyConditionKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kinds of occurrence criteria of application." ;
+        rdfs:label              "ContingencyConditionKind"@en ;
+        cims:belongsToCategory  co:Package_ContingencyProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:ContingencyConditionKind.design
+        rdf:type         nc:ContingencyConditionKind ;
+        rdfs:comment     "Permanent occurrence factor which is design condition." ;
+        rdfs:label       "design"@en ;
+        cims:stereotype  "enum" .
+
+nc:ContingencyConditionKind.environmental
+        rdf:type         nc:ContingencyConditionKind ;
+        rdfs:comment     "Temporary occurrence factor which is weather or environmental condition (e.g. storm)." ;
+        rdfs:label       "environmental"@en ;
+        cims:stereotype  "enum" .
+
+nc:ContingencyConditionKind.geographicalLocation
+        rdf:type         nc:ContingencyConditionKind ;
+        rdfs:comment     "Permanent occurrence factor which is specific geographical location." ;
+        rdfs:label       "geographicalLocation"@en ;
+        cims:stereotype  "enum" .
+
+nc:ContingencyConditionKind.malfunction
+        rdf:type         nc:ContingencyConditionKind ;
+        rdfs:comment     "Temporary occurrence factor which is life time or generic malfunction affecting the risk of failure condition." ;
+        rdfs:label       "malfunction"@en ;
+        cims:stereotype  "enum" .
+
+nc:ContingencyConditionKind.operational
+        rdf:type         nc:ContingencyConditionKind ;
+        rdfs:comment     "Temporary occurrence factor which is operational condition." ;
+        rdfs:label       "operational"@en ;
+        cims:stereotype  "enum" .
+
+nc:ExceptionalContingency
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Exceptional contingency means the simultaneous occurrence of multiple contingencies with a common cause." ;
+        rdfs:label              "ExceptionalContingency"@en ;
+        rdfs:subClassOf         cim:Contingency ;
+        cims:belongsToCategory  co:Package_ContingencyProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ExceptionalContingency.kind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Defines the kind of relevance and criteria of application of the exceptional contingency." ;
+        rdfs:domain        nc:ExceptionalContingency ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         nc:ContingencyConditionKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:OrdinaryContingency
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Ordinary contingency means the occurrence of a contingency of a single branch or injection." ;
+        rdfs:label              "OrdinaryContingency"@en ;
+        rdfs:subClassOf         cim:Contingency ;
+        cims:belongsToCategory  co:Package_ContingencyProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:OutOfRangeContingency
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Out of range means the simultaneous occurrence of multiple contingencies without a common cause, or a loss of power generating modules with a total loss of generation capacity exceeding the reference incident." ;
+        rdfs:label              "OutOfRangeContingency"@en ;
+        rdfs:subClassOf         cim:Contingency ;
+        cims:belongsToCategory  co:Package_ContingencyProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SystemOperator  rdf:type     rdfs:Class ;
+        rdfs:comment            "System operator." ;
+        rdfs:label              "SystemOperator"@en ;
+        cims:belongsToCategory  co:Package_ContingencyProfile ;
+        cims:stereotype         "NC" .
+
+nc:SystemOperator.Contingency
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Contingency for the equipment that is operated by the system operator." ;
+        rdfs:domain           nc:SystemOperator ;
+        rdfs:label            "Contingency"@en ;
+        rdfs:range            cim:Contingency ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:Contingency.EquipmentOperator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+profcim:IRI  rdf:type           rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as rdf:resource in RDFXML.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "IRI"@en ;
+        cims:belongsToCategory  co:Package_DocContingencyProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+profcim:StringFixedLanguage
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited.\nThe primitive is serialized as literal without language support." ;
+        rdfs:label              "StringFixedLanguage"@en ;
+        cims:belongsToCategory  co:Package_DocContingencyProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringIRI  rdf:type     rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as literal without language support.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "StringIRI"@en ;
+        cims:belongsToCategory  co:Package_DocContingencyProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:URL  rdf:type           rdfs:Class ;
+        rdfs:comment            "A Uniform Resource Locator (URL), colloquially termed a web address, is a reference to a web resource that specifies its location on a computer network and a mechanism for retrieving it. A URL is a specific type of Uniform Resource Identifier (URI), although many people use the two terms interchangeably.URLs occur most commonly to reference web pages (http), but are also used for file transfer (ftp), email (mailto), database access (JDBC), and many other applications." ;
+        rdfs:label              "URL"@en ;
+        cims:belongsToCategory  co:Package_DocContingencyProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+

--- a/r2.3/ap-voc/ttl/EquipmentReliability-AP-Voc-RDFS2020.ttl
+++ b/r2.3/ap-voc/ttl/EquipmentReliability-AP-Voc-RDFS2020.ttl
@@ -1,0 +1,8183 @@
+@prefix cim:     <https://cim.ucaiug.io/ns#> .
+@prefix cims:    <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/#> .
+@prefix er:      <https://ap.cim4.eu/EquipmentReliability#> .
+@prefix eu:      <https://cim.ucaiug.io/ns/eu#> .
+@prefix nc:      <https://cim4.eu/ns/nc#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix profcim: <https://cim.ucaiug.io/ns/prof-cim#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+
+er:Ontology  rdf:type         owl:Ontology ;
+        dcterms:conformsTo    "urn:iso:std:iec:61970-301:ed-7:amd1" , "urn:iso:std:iec:61970-600-2:ed-1" , "urn:iso:std:iec:61970-401:draft:ed-1" , "urn:iso:std:iec:61970-501:draft:ed-2" , "file://CIM100_CGMES31v01_501-20v02_NC23v62_MM10v01.eap" , "file://iec61970cim17v40_iec61968cim13v13a_iec62325cim03v17a.eap" ;
+        dcterms:creator       "ENTSO-E CIM WG NC project"@en ;
+        dcterms:description   "This vocabulary is describing the equipment reliability profile."@en ;
+        dcterms:identifier    "urn:uuid:5f727c5c-b49f-47be-b750-a00fefb7e806" ;
+        dcterms:language      "en-GB" ;
+        dcterms:license       "https://www.apache.org/licenses/LICENSE-2.0"@en ;
+        dcterms:modified      "2024-04-08"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        dcterms:publisher     "ENTSO-E"@en ;
+        dcterms:rightsHolder  "ENTSO-E"@en ;
+        dcterms:title         "Equipment Reliability Vocabulary"@en ;
+        owl:priorVersion      <http://entsoe.eu/ns/CIM/EquipmentReliability-EU/2.2> ;
+        owl:versionIRI        <https://ap.cim4.eu/EquipmentReliability/2.3> ;
+        owl:versionInfo       "2.3.0"@en ;
+        dcat:keyword          "ER" ;
+        dcat:theme            "vocabulary"@en .
+
+er:Package_DocEquipmentReliabilityProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains datatypes used only in the RDFS header." ;
+        rdfs:label    "DocEquipmentReliabilityProfile"@en .
+
+er:Package_EquipmentReliabilityProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains equipment reliability profile." ;
+        rdfs:label    "EquipmentReliabilityProfile"@en .
+
+cim:ACDCConverter  rdf:type     rdfs:Class ;
+        rdfs:comment            "A unit with valves for three phases, together with unit control equipment, essential protective and switching devices, DC storage capacitors, phase reactors and auxiliaries, if any, used for conversion." ;
+        rdfs:label              "ACDCConverter"@en ;
+        rdfs:subClassOf         cim:ConductingEquipment ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile .
+
+cim:ACDCTerminal  rdf:type      rdfs:Class ;
+        rdfs:comment            "An electrical connection point (AC or DC) to a piece of conducting equipment. Terminals are connected at physical connection points called connectivity nodes." ;
+        rdfs:label              "ACDCTerminal"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile .
+
+cim:ACDCTerminal.OperationalLimitSet
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The operational limit sets at the terminal." ;
+        rdfs:domain           cim:ACDCTerminal ;
+        rdfs:label            "OperationalLimitSet"@en ;
+        rdfs:range            cim:OperationalLimitSet ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:OperationalLimitSet.Terminal ;
+        cims:multiplicity     cims:M:0..n .
+
+cim:ActivePower  rdf:type       rdfs:Class ;
+        rdfs:comment            "Product of RMS value of the voltage and the RMS value of the in-phase component of the current." ;
+        rdfs:label              "ActivePower"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:ActivePower.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePower.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "W" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePower.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePowerChangeRate
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Rate of change of active power per time." ;
+        rdfs:label              "ActivePowerChangeRate"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:ActivePowerChangeRate.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePowerChangeRate ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePowerChangeRate.unit
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePowerChangeRate ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "WPers" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePowerChangeRate.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePowerChangeRate ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:AngleDegrees  rdf:type      rdfs:Class ;
+        rdfs:comment            "Measurement of angle in degrees." ;
+        rdfs:label              "AngleDegrees"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:AngleDegrees.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:AngleDegrees ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:AngleDegrees.unit
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:AngleDegrees ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "deg" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:AngleDegrees.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:AngleDegrees ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Boolean  rdf:type           rdfs:Class ;
+        rdfs:comment            "A type with the value space \"true\" and \"false\"." ;
+        rdfs:label              "Boolean"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:ConductingEquipment
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The parts of the AC power system that are designed to carry current or that are conductively connected through terminals." ;
+        rdfs:label              "ConductingEquipment"@en ;
+        rdfs:subClassOf         cim:Equipment ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile .
+
+cim:Conductor  rdf:type         rdfs:Class ;
+        rdfs:comment            "Combination of conducting material with consistent electrical characteristics, building a single electrical system, used to carry current between points in the power system.  " ;
+        rdfs:label              "Conductor"@en ;
+        rdfs:subClassOf         cim:ConductingEquipment ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile .
+
+cim:ConnectivityNode  rdf:type  rdfs:Class ;
+        rdfs:comment            "Connectivity nodes are points where terminals of AC conducting equipment are connected together with zero impedance." ;
+        rdfs:label              "ConnectivityNode"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:ConnectivityNodeContainer
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A base class for all objects that may contain connectivity nodes or topological nodes." ;
+        rdfs:label              "ConnectivityNodeContainer"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile .
+
+cim:ControlArea  rdf:type       rdfs:Class ;
+        rdfs:comment            "A control area is a grouping of generating units and/or loads and a cutset of tie lines (as terminals) which may be used for a variety of purposes including automatic generation control, power flow solution area interchange control specification, and input to load forecasting. All generation and load within the area defined by the terminals on the border are considered in the area interchange control. Note that any number of overlapping control area specifications can be superimposed on the physical model. The following general principles apply to ControlArea:\n1.  The control area orientation for net interchange is positive for an import, negative for an export.\n2.  The control area net interchange is determined by summing flows in Terminals. The Terminals are identified by creating a set of TieFlow objects associated with a ControlArea object. Each TieFlow object identifies one Terminal.\n3.  In a single network model, a tie between two control areas must be modelled in both control area specifications, such that the two representations of the tie flow sum to zero.\n4.  The normal orientation of Terminal flow is positive for flow into the conducting equipment that owns the Terminal. (i.e. flow from a bus into a device is positive.) However, the orientation of each flow in the control area specification must align with the control area convention, i.e. import is positive. If the orientation of the Terminal flow referenced by a TieFlow is positive into the control area, then this is confirmed by setting TieFlow.positiveFlowIn flag TRUE. If not, the orientation must be reversed by setting the TieFlow.positiveFlowIn flag FALSE." ;
+        rdfs:label              "ControlArea"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:Currency  rdf:type          rdfs:Class ;
+        rdfs:comment            "Monetary currencies.  ISO 4217 standard including 3-character currency code." ;
+        rdfs:label              "Currency"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:Currency.AED  rdf:type  cim:Currency ;
+        rdfs:comment     "United Arab Emirates dirham." ;
+        rdfs:label       "AED"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AFN  rdf:type  cim:Currency ;
+        rdfs:comment     "Afghan afghani." ;
+        rdfs:label       "AFN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ALL  rdf:type  cim:Currency ;
+        rdfs:comment     "Albanian lek." ;
+        rdfs:label       "ALL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AMD  rdf:type  cim:Currency ;
+        rdfs:comment     "Armenian dram." ;
+        rdfs:label       "AMD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ANG  rdf:type  cim:Currency ;
+        rdfs:comment     "Netherlands Antillean guilder." ;
+        rdfs:label       "ANG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AOA  rdf:type  cim:Currency ;
+        rdfs:comment     "Angolan kwanza." ;
+        rdfs:label       "AOA"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ARS  rdf:type  cim:Currency ;
+        rdfs:comment     "Argentine peso." ;
+        rdfs:label       "ARS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AUD  rdf:type  cim:Currency ;
+        rdfs:comment     "Australian dollar." ;
+        rdfs:label       "AUD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AWG  rdf:type  cim:Currency ;
+        rdfs:comment     "Aruban florin." ;
+        rdfs:label       "AWG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AZN  rdf:type  cim:Currency ;
+        rdfs:comment     "Azerbaijani manat." ;
+        rdfs:label       "AZN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BAM  rdf:type  cim:Currency ;
+        rdfs:comment     "Bosnia and Herzegovina convertible mark." ;
+        rdfs:label       "BAM"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BBD  rdf:type  cim:Currency ;
+        rdfs:comment     "Barbados dollar." ;
+        rdfs:label       "BBD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BDT  rdf:type  cim:Currency ;
+        rdfs:comment     "Bangladeshi taka." ;
+        rdfs:label       "BDT"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BGN  rdf:type  cim:Currency ;
+        rdfs:comment     "Bulgarian lev." ;
+        rdfs:label       "BGN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BHD  rdf:type  cim:Currency ;
+        rdfs:comment     "Bahraini dinar." ;
+        rdfs:label       "BHD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BIF  rdf:type  cim:Currency ;
+        rdfs:comment     "Burundian franc." ;
+        rdfs:label       "BIF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BMD  rdf:type  cim:Currency ;
+        rdfs:comment     "Bermudian dollar (customarily known as Bermuda dollar)." ;
+        rdfs:label       "BMD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BND  rdf:type  cim:Currency ;
+        rdfs:comment     "Brunei dollar." ;
+        rdfs:label       "BND"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BOB  rdf:type  cim:Currency ;
+        rdfs:comment     "Boliviano." ;
+        rdfs:label       "BOB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BOV  rdf:type  cim:Currency ;
+        rdfs:comment     "Bolivian Mvdol (funds code)." ;
+        rdfs:label       "BOV"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BRL  rdf:type  cim:Currency ;
+        rdfs:comment     "Brazilian real." ;
+        rdfs:label       "BRL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BSD  rdf:type  cim:Currency ;
+        rdfs:comment     "Bahamian dollar." ;
+        rdfs:label       "BSD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BTN  rdf:type  cim:Currency ;
+        rdfs:comment     "Bhutanese ngultrum." ;
+        rdfs:label       "BTN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BWP  rdf:type  cim:Currency ;
+        rdfs:comment     "Botswana pula." ;
+        rdfs:label       "BWP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BYR  rdf:type  cim:Currency ;
+        rdfs:comment     "Belarusian ruble." ;
+        rdfs:label       "BYR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BZD  rdf:type  cim:Currency ;
+        rdfs:comment     "Belize dollar." ;
+        rdfs:label       "BZD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CAD  rdf:type  cim:Currency ;
+        rdfs:comment     "Canadian dollar." ;
+        rdfs:label       "CAD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CDF  rdf:type  cim:Currency ;
+        rdfs:comment     "Congolese franc." ;
+        rdfs:label       "CDF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CHF  rdf:type  cim:Currency ;
+        rdfs:comment     "Swiss franc." ;
+        rdfs:label       "CHF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CLF  rdf:type  cim:Currency ;
+        rdfs:comment     "Unidad de Fomento (funds code), Chile." ;
+        rdfs:label       "CLF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CLP  rdf:type  cim:Currency ;
+        rdfs:comment     "Chilean peso." ;
+        rdfs:label       "CLP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CNY  rdf:type  cim:Currency ;
+        rdfs:comment     "Chinese yuan." ;
+        rdfs:label       "CNY"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.COP  rdf:type  cim:Currency ;
+        rdfs:comment     "Colombian peso." ;
+        rdfs:label       "COP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.COU  rdf:type  cim:Currency ;
+        rdfs:comment     "Unidad de Valor Real." ;
+        rdfs:label       "COU"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CRC  rdf:type  cim:Currency ;
+        rdfs:comment     "Costa Rican colon." ;
+        rdfs:label       "CRC"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CUC  rdf:type  cim:Currency ;
+        rdfs:comment     "Cuban convertible peso." ;
+        rdfs:label       "CUC"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CUP  rdf:type  cim:Currency ;
+        rdfs:comment     "Cuban peso." ;
+        rdfs:label       "CUP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CVE  rdf:type  cim:Currency ;
+        rdfs:comment     "Cape Verde escudo." ;
+        rdfs:label       "CVE"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CZK  rdf:type  cim:Currency ;
+        rdfs:comment     "Czech koruna." ;
+        rdfs:label       "CZK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.DJF  rdf:type  cim:Currency ;
+        rdfs:comment     "Djiboutian franc." ;
+        rdfs:label       "DJF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.DKK  rdf:type  cim:Currency ;
+        rdfs:comment     "Danish krone." ;
+        rdfs:label       "DKK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.DOP  rdf:type  cim:Currency ;
+        rdfs:comment     "Dominican peso." ;
+        rdfs:label       "DOP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.DZD  rdf:type  cim:Currency ;
+        rdfs:comment     "Algerian dinar." ;
+        rdfs:label       "DZD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.EEK  rdf:type  cim:Currency ;
+        rdfs:comment     "Estonian kroon." ;
+        rdfs:label       "EEK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.EGP  rdf:type  cim:Currency ;
+        rdfs:comment     "Egyptian pound." ;
+        rdfs:label       "EGP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ERN  rdf:type  cim:Currency ;
+        rdfs:comment     "Eritrean nakfa." ;
+        rdfs:label       "ERN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ETB  rdf:type  cim:Currency ;
+        rdfs:comment     "Ethiopian birr." ;
+        rdfs:label       "ETB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.EUR  rdf:type  cim:Currency ;
+        rdfs:comment     "Euro." ;
+        rdfs:label       "EUR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.FJD  rdf:type  cim:Currency ;
+        rdfs:comment     "Fiji dollar." ;
+        rdfs:label       "FJD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.FKP  rdf:type  cim:Currency ;
+        rdfs:comment     "Falkland Islands pound." ;
+        rdfs:label       "FKP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GBP  rdf:type  cim:Currency ;
+        rdfs:comment     "Pound sterling." ;
+        rdfs:label       "GBP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GEL  rdf:type  cim:Currency ;
+        rdfs:comment     "Georgian lari." ;
+        rdfs:label       "GEL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GHS  rdf:type  cim:Currency ;
+        rdfs:comment     "Ghanaian cedi." ;
+        rdfs:label       "GHS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GIP  rdf:type  cim:Currency ;
+        rdfs:comment     "Gibraltar pound." ;
+        rdfs:label       "GIP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GMD  rdf:type  cim:Currency ;
+        rdfs:comment     "Gambian dalasi." ;
+        rdfs:label       "GMD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GNF  rdf:type  cim:Currency ;
+        rdfs:comment     "Guinean franc." ;
+        rdfs:label       "GNF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GTQ  rdf:type  cim:Currency ;
+        rdfs:comment     "Guatemalan quetzal." ;
+        rdfs:label       "GTQ"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GYD  rdf:type  cim:Currency ;
+        rdfs:comment     "Guyanese dollar." ;
+        rdfs:label       "GYD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HKD  rdf:type  cim:Currency ;
+        rdfs:comment     "Hong Kong dollar." ;
+        rdfs:label       "HKD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HNL  rdf:type  cim:Currency ;
+        rdfs:comment     "Honduran lempira." ;
+        rdfs:label       "HNL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HRK  rdf:type  cim:Currency ;
+        rdfs:comment     "Croatian kuna." ;
+        rdfs:label       "HRK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HTG  rdf:type  cim:Currency ;
+        rdfs:comment     "Haitian gourde." ;
+        rdfs:label       "HTG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HUF  rdf:type  cim:Currency ;
+        rdfs:comment     "Hungarian forint." ;
+        rdfs:label       "HUF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.IDR  rdf:type  cim:Currency ;
+        rdfs:comment     "Indonesian rupiah." ;
+        rdfs:label       "IDR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ILS  rdf:type  cim:Currency ;
+        rdfs:comment     "Israeli new sheqel." ;
+        rdfs:label       "ILS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.INR  rdf:type  cim:Currency ;
+        rdfs:comment     "Indian rupee." ;
+        rdfs:label       "INR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.IQD  rdf:type  cim:Currency ;
+        rdfs:comment     "Iraqi dinar." ;
+        rdfs:label       "IQD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.IRR  rdf:type  cim:Currency ;
+        rdfs:comment     "Iranian rial." ;
+        rdfs:label       "IRR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ISK  rdf:type  cim:Currency ;
+        rdfs:comment     "Icelandic króna." ;
+        rdfs:label       "ISK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.JMD  rdf:type  cim:Currency ;
+        rdfs:comment     "Jamaican dollar." ;
+        rdfs:label       "JMD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.JOD  rdf:type  cim:Currency ;
+        rdfs:comment     "Jordanian dinar." ;
+        rdfs:label       "JOD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.JPY  rdf:type  cim:Currency ;
+        rdfs:comment     "Japanese yen." ;
+        rdfs:label       "JPY"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KES  rdf:type  cim:Currency ;
+        rdfs:comment     "Kenyan shilling." ;
+        rdfs:label       "KES"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KGS  rdf:type  cim:Currency ;
+        rdfs:comment     "Kyrgyzstani som." ;
+        rdfs:label       "KGS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KHR  rdf:type  cim:Currency ;
+        rdfs:comment     "Cambodian riel." ;
+        rdfs:label       "KHR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KMF  rdf:type  cim:Currency ;
+        rdfs:comment     "Comoro franc." ;
+        rdfs:label       "KMF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KPW  rdf:type  cim:Currency ;
+        rdfs:comment     "North Korean won." ;
+        rdfs:label       "KPW"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KRW  rdf:type  cim:Currency ;
+        rdfs:comment     "South Korean won." ;
+        rdfs:label       "KRW"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KWD  rdf:type  cim:Currency ;
+        rdfs:comment     "Kuwaiti dinar." ;
+        rdfs:label       "KWD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KYD  rdf:type  cim:Currency ;
+        rdfs:comment     "Cayman Islands dollar." ;
+        rdfs:label       "KYD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KZT  rdf:type  cim:Currency ;
+        rdfs:comment     "Kazakhstani tenge." ;
+        rdfs:label       "KZT"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LAK  rdf:type  cim:Currency ;
+        rdfs:comment     "Lao kip." ;
+        rdfs:label       "LAK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LBP  rdf:type  cim:Currency ;
+        rdfs:comment     "Lebanese pound." ;
+        rdfs:label       "LBP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LKR  rdf:type  cim:Currency ;
+        rdfs:comment     "Sri Lanka rupee." ;
+        rdfs:label       "LKR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LRD  rdf:type  cim:Currency ;
+        rdfs:comment     "Liberian dollar." ;
+        rdfs:label       "LRD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LSL  rdf:type  cim:Currency ;
+        rdfs:comment     "Lesotho loti." ;
+        rdfs:label       "LSL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LTL  rdf:type  cim:Currency ;
+        rdfs:comment     "Lithuanian litas." ;
+        rdfs:label       "LTL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LVL  rdf:type  cim:Currency ;
+        rdfs:comment     "Latvian lats." ;
+        rdfs:label       "LVL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LYD  rdf:type  cim:Currency ;
+        rdfs:comment     "Libyan dinar." ;
+        rdfs:label       "LYD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MAD  rdf:type  cim:Currency ;
+        rdfs:comment     "Moroccan dirham." ;
+        rdfs:label       "MAD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MDL  rdf:type  cim:Currency ;
+        rdfs:comment     "Moldovan leu." ;
+        rdfs:label       "MDL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MGA  rdf:type  cim:Currency ;
+        rdfs:comment     "Malagasy ariary." ;
+        rdfs:label       "MGA"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MKD  rdf:type  cim:Currency ;
+        rdfs:comment     "Macedonian denar." ;
+        rdfs:label       "MKD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MMK  rdf:type  cim:Currency ;
+        rdfs:comment     "Myanma kyat." ;
+        rdfs:label       "MMK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MNT  rdf:type  cim:Currency ;
+        rdfs:comment     "Mongolian tugrik." ;
+        rdfs:label       "MNT"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MOP  rdf:type  cim:Currency ;
+        rdfs:comment     "Macanese pataca." ;
+        rdfs:label       "MOP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MRO  rdf:type  cim:Currency ;
+        rdfs:comment     "Mauritanian ouguiya." ;
+        rdfs:label       "MRO"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MUR  rdf:type  cim:Currency ;
+        rdfs:comment     "Mauritian rupee." ;
+        rdfs:label       "MUR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MVR  rdf:type  cim:Currency ;
+        rdfs:comment     "Maldivian rufiyaa." ;
+        rdfs:label       "MVR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MWK  rdf:type  cim:Currency ;
+        rdfs:comment     "Malawian kwacha." ;
+        rdfs:label       "MWK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MXN  rdf:type  cim:Currency ;
+        rdfs:comment     "Mexican peso." ;
+        rdfs:label       "MXN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MYR  rdf:type  cim:Currency ;
+        rdfs:comment     "Malaysian ringgit." ;
+        rdfs:label       "MYR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MZN  rdf:type  cim:Currency ;
+        rdfs:comment     "Mozambican metical." ;
+        rdfs:label       "MZN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NAD  rdf:type  cim:Currency ;
+        rdfs:comment     "Namibian dollar." ;
+        rdfs:label       "NAD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NGN  rdf:type  cim:Currency ;
+        rdfs:comment     "Nigerian naira." ;
+        rdfs:label       "NGN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NIO  rdf:type  cim:Currency ;
+        rdfs:comment     "Cordoba oro." ;
+        rdfs:label       "NIO"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NOK  rdf:type  cim:Currency ;
+        rdfs:comment     "Norwegian krone." ;
+        rdfs:label       "NOK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NPR  rdf:type  cim:Currency ;
+        rdfs:comment     "Nepalese rupee." ;
+        rdfs:label       "NPR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NZD  rdf:type  cim:Currency ;
+        rdfs:comment     "New Zealand dollar." ;
+        rdfs:label       "NZD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.OMR  rdf:type  cim:Currency ;
+        rdfs:comment     "Omani rial." ;
+        rdfs:label       "OMR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PAB  rdf:type  cim:Currency ;
+        rdfs:comment     "Panamanian balboa." ;
+        rdfs:label       "PAB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PEN  rdf:type  cim:Currency ;
+        rdfs:comment     "Peruvian nuevo sol." ;
+        rdfs:label       "PEN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PGK  rdf:type  cim:Currency ;
+        rdfs:comment     "Papua New Guinean kina." ;
+        rdfs:label       "PGK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PHP  rdf:type  cim:Currency ;
+        rdfs:comment     "Philippine peso." ;
+        rdfs:label       "PHP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PKR  rdf:type  cim:Currency ;
+        rdfs:comment     "Pakistani rupee." ;
+        rdfs:label       "PKR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PLN  rdf:type  cim:Currency ;
+        rdfs:comment     "Polish zloty." ;
+        rdfs:label       "PLN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PYG  rdf:type  cim:Currency ;
+        rdfs:comment     "Paraguayan guaraní." ;
+        rdfs:label       "PYG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.QAR  rdf:type  cim:Currency ;
+        rdfs:comment     "Qatari rial." ;
+        rdfs:label       "QAR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.RON  rdf:type  cim:Currency ;
+        rdfs:comment     "Romanian new leu." ;
+        rdfs:label       "RON"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.RSD  rdf:type  cim:Currency ;
+        rdfs:comment     "Serbian dinar." ;
+        rdfs:label       "RSD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.RUB  rdf:type  cim:Currency ;
+        rdfs:comment     "Russian rouble." ;
+        rdfs:label       "RUB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.RWF  rdf:type  cim:Currency ;
+        rdfs:comment     "Rwandan franc." ;
+        rdfs:label       "RWF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SAR  rdf:type  cim:Currency ;
+        rdfs:comment     "Saudi riyal." ;
+        rdfs:label       "SAR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SBD  rdf:type  cim:Currency ;
+        rdfs:comment     "Solomon Islands dollar." ;
+        rdfs:label       "SBD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SCR  rdf:type  cim:Currency ;
+        rdfs:comment     "Seychelles rupee." ;
+        rdfs:label       "SCR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SDG  rdf:type  cim:Currency ;
+        rdfs:comment     "Sudanese pound." ;
+        rdfs:label       "SDG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SEK  rdf:type  cim:Currency ;
+        rdfs:comment     "Swedish krona/kronor." ;
+        rdfs:label       "SEK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SGD  rdf:type  cim:Currency ;
+        rdfs:comment     "Singapore dollar." ;
+        rdfs:label       "SGD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SHP  rdf:type  cim:Currency ;
+        rdfs:comment     "Saint Helena pound." ;
+        rdfs:label       "SHP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SLL  rdf:type  cim:Currency ;
+        rdfs:comment     "Sierra Leonean leone." ;
+        rdfs:label       "SLL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SOS  rdf:type  cim:Currency ;
+        rdfs:comment     "Somali shilling." ;
+        rdfs:label       "SOS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SRD  rdf:type  cim:Currency ;
+        rdfs:comment     "Surinamese dollar." ;
+        rdfs:label       "SRD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.STD  rdf:type  cim:Currency ;
+        rdfs:comment     "São Tomé and Príncipe dobra." ;
+        rdfs:label       "STD"@en ;
+        cims:stereotype  "enum" .
+cim:Currency.SYP  rdf:type  cim:Currency ;
+        rdfs:comment     "Syrian pound." ;
+        rdfs:label       "SYP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SZL  rdf:type  cim:Currency ;
+        rdfs:comment     "Lilangeni." ;
+        rdfs:label       "SZL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.THB  rdf:type  cim:Currency ;
+        rdfs:comment     "Thai baht." ;
+        rdfs:label       "THB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TJS  rdf:type  cim:Currency ;
+        rdfs:comment     "Tajikistani somoni." ;
+        rdfs:label       "TJS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TMT  rdf:type  cim:Currency ;
+        rdfs:comment     "Turkmenistani manat." ;
+        rdfs:label       "TMT"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TND  rdf:type  cim:Currency ;
+        rdfs:comment     "Tunisian dinar." ;
+        rdfs:label       "TND"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TOP  rdf:type  cim:Currency ;
+        rdfs:comment     "Tongan pa'anga." ;
+        rdfs:label       "TOP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TRY  rdf:type  cim:Currency ;
+        rdfs:comment     "Turkish lira." ;
+        rdfs:label       "TRY"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TTD  rdf:type  cim:Currency ;
+        rdfs:comment     "Trinidad and Tobago dollar." ;
+        rdfs:label       "TTD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TWD  rdf:type  cim:Currency ;
+        rdfs:comment     "New Taiwan dollar." ;
+        rdfs:label       "TWD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TZS  rdf:type  cim:Currency ;
+        rdfs:comment     "Tanzanian shilling." ;
+        rdfs:label       "TZS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.UAH  rdf:type  cim:Currency ;
+        rdfs:comment     "Ukrainian hryvnia." ;
+        rdfs:label       "UAH"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.UGX  rdf:type  cim:Currency ;
+        rdfs:comment     "Ugandan shilling." ;
+        rdfs:label       "UGX"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.USD  rdf:type  cim:Currency ;
+        rdfs:comment     "United States dollar." ;
+        rdfs:label       "USD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.UYU  rdf:type  cim:Currency ;
+        rdfs:comment     "Uruguayan peso." ;
+        rdfs:label       "UYU"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.UZS  rdf:type  cim:Currency ;
+        rdfs:comment     "Uzbekistan som." ;
+        rdfs:label       "UZS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.VEF  rdf:type  cim:Currency ;
+        rdfs:comment     "Venezuelan bolívar fuerte." ;
+        rdfs:label       "VEF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.VND  rdf:type  cim:Currency ;
+        rdfs:comment     "Vietnamese Dong." ;
+        rdfs:label       "VND"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.VUV  rdf:type  cim:Currency ;
+        rdfs:comment     "Vanuatu vatu." ;
+        rdfs:label       "VUV"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.WST  rdf:type  cim:Currency ;
+        rdfs:comment     "Samoan tala." ;
+        rdfs:label       "WST"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.XAF  rdf:type  cim:Currency ;
+        rdfs:comment     "CFA franc BEAC." ;
+        rdfs:label       "XAF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.XCD  rdf:type  cim:Currency ;
+        rdfs:comment     "East Caribbean dollar." ;
+        rdfs:label       "XCD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.XOF  rdf:type  cim:Currency ;
+        rdfs:comment     "CFA Franc BCEAO." ;
+        rdfs:label       "XOF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.XPF  rdf:type  cim:Currency ;
+        rdfs:comment     "CFP franc." ;
+        rdfs:label       "XPF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.YER  rdf:type  cim:Currency ;
+        rdfs:comment     "Yemeni rial." ;
+        rdfs:label       "YER"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ZAR  rdf:type  cim:Currency ;
+        rdfs:comment     "South African rand." ;
+        rdfs:label       "ZAR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ZMK  rdf:type  cim:Currency ;
+        rdfs:comment     "Zambian kwacha." ;
+        rdfs:label       "ZMK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ZWL  rdf:type  cim:Currency ;
+        rdfs:comment     "Zimbabwe dollar." ;
+        rdfs:label       "ZWL"@en ;
+        cims:stereotype  "enum" .
+
+cim:CurrentFlow  rdf:type       rdfs:Class ;
+        rdfs:comment            "Electrical current with sign convention: positive flow is out of the conducting equipment into the connectivity node. Can be both AC and DC." ;
+        rdfs:label              "CurrentFlow"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:CurrentFlow.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:CurrentFlow ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:CurrentFlow.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:CurrentFlow ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "A" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:CurrentFlow.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:CurrentFlow ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Curve  rdf:type             rdfs:Class ;
+        rdfs:comment            "A multi-purpose curve or functional relationship between an independent variable (X-axis) and dependent (Y-axis) variables. " ;
+        rdfs:label              "Curve"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile .
+
+cim:Curve.CurveDatas  rdf:type  rdf:Property ;
+        rdfs:comment          "The point data values that define this curve." ;
+        rdfs:domain           cim:Curve ;
+        rdfs:label            "CurveDatas"@en ;
+        rdfs:range            cim:CurveData ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:CurveData.Curve ;
+        cims:multiplicity     cims:M:1..n .
+
+cim:Curve.curveStyle  rdf:type  rdf:Property ;
+        rdfs:comment       "The style or shape of the curve." ;
+        rdfs:domain        cim:Curve ;
+        rdfs:label         "curveStyle"@en ;
+        rdfs:range         cim:CurveStyle ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Curve.xMultiplier
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Multiplier for X-axis." ;
+        rdfs:domain        cim:Curve ;
+        rdfs:label         "xMultiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Curve.xUnit  rdf:type  rdf:Property ;
+        rdfs:comment       "The X-axis units of measure." ;
+        rdfs:domain        cim:Curve ;
+        rdfs:label         "xUnit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Curve.y1Multiplier
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Multiplier for Y1-axis." ;
+        rdfs:domain        cim:Curve ;
+        rdfs:label         "y1Multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Curve.y1Unit  rdf:type  rdf:Property ;
+        rdfs:comment       "The Y1-axis units of measure." ;
+        rdfs:domain        cim:Curve ;
+        rdfs:label         "y1Unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Curve.y2Multiplier
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Multiplier for Y2-axis." ;
+        rdfs:domain        cim:Curve ;
+        rdfs:label         "y2Multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Curve.y2Unit  rdf:type  rdf:Property ;
+        rdfs:comment       "The Y2-axis units of measure." ;
+        rdfs:domain        cim:Curve ;
+        rdfs:label         "y2Unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:CurveData  rdf:type         rdfs:Class ;
+        rdfs:comment            "Multi-purpose data points for defining a curve.  The use of this generic class is discouraged if a more specific class can be used to specify the X and Y axis values along with their specific data types." ;
+        rdfs:label              "CurveData"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:CurveData.Curve  rdf:type  rdf:Property ;
+        rdfs:comment          "The curve of  this curve data point." ;
+        rdfs:domain           cim:CurveData ;
+        rdfs:label            "Curve"@en ;
+        rdfs:range            cim:Curve ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:Curve.CurveDatas ;
+        cims:multiplicity     cims:M:1 .
+
+cim:CurveData.xvalue  rdf:type  rdf:Property ;
+        rdfs:comment       "The data value of the X-axis variable,  depending on the X-axis units." ;
+        rdfs:domain        cim:CurveData ;
+        rdfs:label         "xvalue"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:CurveData.y1value
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The data value of the  first Y-axis variable, depending on the Y-axis units." ;
+        rdfs:domain        cim:CurveData ;
+        rdfs:label         "y1value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:CurveData.y2value
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The data value of the second Y-axis variable (if present), depending on the Y-axis units." ;
+        rdfs:domain        cim:CurveData ;
+        rdfs:label         "y2value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:CurveStyle  rdf:type        rdfs:Class ;
+        rdfs:comment            "Style or shape of curve." ;
+        rdfs:label              "CurveStyle"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:CurveStyle.constantYValue
+        rdf:type         cim:CurveStyle ;
+        rdfs:comment     "The Y-axis values are assumed constant until the next curve point and prior to the first curve point." ;
+        rdfs:label       "constantYValue"@en ;
+        cims:stereotype  "enum" .
+
+cim:CurveStyle.straightLineYValues
+        rdf:type         cim:CurveStyle ;
+        rdfs:comment     "The Y-axis values are assumed to be a straight line between values.  Also known as linear interpolation." ;
+        rdfs:label       "straightLineYValues"@en ;
+        cims:stereotype  "enum" .
+
+cim:DCBreaker  rdf:type         rdfs:Class ;
+        rdfs:comment            "A breaker within a DC system. " ;
+        rdfs:label              "DCBreaker"@en ;
+        rdfs:subClassOf         cim:DCSwitch ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:DCBusbar  rdf:type          rdfs:Class ;
+        rdfs:comment            "A busbar within a DC system." ;
+        rdfs:label              "DCBusbar"@en ;
+        rdfs:subClassOf         cim:DCConductingEquipment ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:DCChopper  rdf:type         rdfs:Class ;
+        rdfs:comment            "Low resistance equipment used in the internal DC circuit to balance voltages. It has typically positive and negative pole terminals and a ground." ;
+        rdfs:label              "DCChopper"@en ;
+        rdfs:subClassOf         cim:DCConductingEquipment ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:DCConductingEquipment
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The parts of the DC power system that are designed to carry current or that are conductively connected through DC terminals." ;
+        rdfs:label              "DCConductingEquipment"@en ;
+        rdfs:subClassOf         cim:Equipment ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile .
+
+cim:DCConductingEquipment.ratedCurrent
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The maximum continuous current carrying capacity in amps governed by the device material and construction.\nThe attribute shall be a positive value." ;
+        rdfs:domain        cim:DCConductingEquipment ;
+        rdfs:label         "ratedCurrent"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:DCConverterUnit  rdf:type   rdfs:Class ;
+        rdfs:comment            "Indivisible operative unit comprising all equipment between the point of common coupling on the AC side and the point of common coupling – DC side, essentially one or more converters, together with one or more converter transformers, converter control equipment, essential protective and switching devices and auxiliaries, if any, used for conversion." ;
+        rdfs:label              "DCConverterUnit"@en ;
+        rdfs:subClassOf         cim:DCEquipmentContainer ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:DCConverterUnit.Substation
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The containing substation of the DC converter unit." ;
+        rdfs:domain           cim:DCConverterUnit ;
+        rdfs:label            "Substation"@en ;
+        rdfs:range            cim:Substation ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:Substation.DCConverterUnit ;
+        cims:multiplicity     cims:M:0..1 .
+
+cim:DCDisconnector  rdf:type    rdfs:Class ;
+        rdfs:comment            "A disconnector within a DC system." ;
+        rdfs:label              "DCDisconnector"@en ;
+        rdfs:subClassOf         cim:DCSwitch ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:DCEquipmentContainer
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A modelling construct to provide a root class for containment of DC as well as AC equipment. The class differ from the EquipmentContaner for AC in that it may also contain DCNode-s. Hence it can contain both AC and DC equipment." ;
+        rdfs:label              "DCEquipmentContainer"@en ;
+        rdfs:subClassOf         cim:EquipmentContainer ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile .
+
+cim:DCGround  rdf:type          rdfs:Class ;
+        rdfs:comment            "A ground within a DC system." ;
+        rdfs:label              "DCGround"@en ;
+        rdfs:subClassOf         cim:DCConductingEquipment ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:DCLine  rdf:type            rdfs:Class ;
+        rdfs:comment            "Overhead lines and/or cables connecting two or more HVDC substations." ;
+        rdfs:label              "DCLine"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:DCLineSegment  rdf:type     rdfs:Class ;
+        rdfs:comment            "A wire or combination of wires not insulated from one another, with consistent electrical characteristics, used to carry direct current between points in the DC region of the power system." ;
+        rdfs:label              "DCLineSegment"@en ;
+        rdfs:subClassOf         cim:DCConductingEquipment ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:DCNode  rdf:type            rdfs:Class ;
+        rdfs:comment            "DC nodes are points where terminals of DC conducting equipment are connected together with zero impedance." ;
+        rdfs:label              "DCNode"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:DCSeriesDevice  rdf:type    rdfs:Class ;
+        rdfs:comment            "A series device within the DC system, typically a reactor used for filtering or smoothing.  Needed for transient and short circuit studies." ;
+        rdfs:label              "DCSeriesDevice"@en ;
+        rdfs:subClassOf         cim:DCConductingEquipment ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:DCShunt  rdf:type           rdfs:Class ;
+        rdfs:comment            "A shunt device within the DC system, typically used for filtering.  Needed for transient and short circuit studies." ;
+        rdfs:label              "DCShunt"@en ;
+        rdfs:subClassOf         cim:DCConductingEquipment ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:DCSwitch  rdf:type          rdfs:Class ;
+        rdfs:comment            "A switch within the DC system." ;
+        rdfs:label              "DCSwitch"@en ;
+        rdfs:subClassOf         cim:DCConductingEquipment ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:Date  rdf:type              rdfs:Class ;
+        rdfs:comment            "Date as \"yyyy-mm-dd\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddZ\". A local timezone relative UTC is specified as \"yyyy-mm-dd(+/-)hh:mm\"." ;
+        rdfs:label              "Date"@en ;
+        cims:belongsToCategory  er:Package_DocEquipmentReliabilityProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:DateTime  rdf:type          rdfs:Class ;
+        rdfs:comment            "Date and time as \"yyyy-mm-ddThh:mm:ss.sss\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddThh:mm:ss.sssZ\". A local timezone relative UTC is specified as \"yyyy-mm-ddThh:mm:ss.sss-hh:mm\". The second component (shown here as \"ss.sss\") could have any number of digits in its fractional part to allow any kind of precision beyond seconds." ;
+        rdfs:label              "DateTime"@en ;
+        cims:belongsToCategory  er:Package_DocEquipmentReliabilityProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Decimal  rdf:type           rdfs:Class ;
+        rdfs:comment            "Decimal is the base-10 notational system for representing real numbers." ;
+        rdfs:label              "Decimal"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Duration  rdf:type          rdfs:Class ;
+        rdfs:comment            "Duration as \"PnYnMnDTnHnMnS\" which conforms to ISO 8601, where nY expresses a number of years, nM a number of months, nD a number of days. The letter T separates the date expression from the time expression and, after it, nH identifies a number of hours, nM a number of minutes and nS a number of seconds. The number of seconds could be expressed as a decimal number, but all other numbers are integers." ;
+        rdfs:label              "Duration"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:EnergyConnection  rdf:type  rdfs:Class ;
+        rdfs:comment            "A connection of energy generation or consumption on the power system model." ;
+        rdfs:label              "EnergyConnection"@en ;
+        rdfs:subClassOf         cim:ConductingEquipment ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile .
+
+cim:EnergyConsumer  rdf:type    rdfs:Class ;
+        rdfs:comment            "Generic user of energy - a  point of consumption on the power system model.\nEnergyConsumer.pfixed, .qfixed, .pfixedPct and .qfixedPct have meaning only if there is no LoadResponseCharacteristic associated with EnergyConsumer or if LoadResponseCharacteristic.exponentModel is set to False." ;
+        rdfs:label              "EnergyConsumer"@en ;
+        rdfs:subClassOf         cim:EnergyConnection ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:Equipment  rdf:type         rdfs:Class ;
+        rdfs:comment            "The parts of a power system that are physical devices, electronic or mechanical." ;
+        rdfs:label              "Equipment"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" .
+
+cim:Equipment.AggregatedEquipment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "An aggregated representation of the detailed equipment." ;
+        rdfs:domain           cim:Equipment ;
+        rdfs:label            "AggregatedEquipment"@en ;
+        rdfs:range            cim:Equipment ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:Equipment.DetailedEquipment ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+cim:Equipment.DetailedEquipment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "A detailed representation of the aggregated equipment." ;
+        rdfs:domain           cim:Equipment ;
+        rdfs:label            "DetailedEquipment"@en ;
+        rdfs:range            cim:Equipment ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:Equipment.AggregatedEquipment ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+cim:EquipmentContainer
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A modelling construct to provide a root class for containing equipment. " ;
+        rdfs:label              "EquipmentContainer"@en ;
+        rdfs:subClassOf         cim:ConnectivityNodeContainer ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile .
+
+cim:EquivalentInjection
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "This class represents equivalent injections (generation or load).  Voltage regulation is allowed only at the point of connection." ;
+        rdfs:label              "EquivalentInjection"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:EquivalentInjection.ReactiveCapabilityCurve2
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The reactive capability curve used by this equivalent injection." ;
+        rdfs:domain           cim:EquivalentInjection ;
+        rdfs:label            "ReactiveCapabilityCurve2"@en ;
+        rdfs:range            cim:ReactiveCapabilityCurve ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:ReactiveCapabilityCurve.EquivalentInjection2 ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+cim:Feeder  rdf:type            rdfs:Class ;
+        rdfs:comment            "A collection of equipment for organizational purposes, used for grouping distribution resources.\nThe organization a feeder does not necessarily reflect connectivity or current operation state." ;
+        rdfs:label              "Feeder"@en ;
+        rdfs:subClassOf         cim:EquipmentContainer ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:Feeder.NamingSecondarySubstation
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The secondary substations that are normally energized from the feeder.  Used for naming purposes.   Should be consistent with the other associations for energizing terminal specification and the feeder energization specification." ;
+        rdfs:domain           cim:Feeder ;
+        rdfs:label            "NamingSecondarySubstation"@en ;
+        rdfs:range            cim:Substation ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:Substation.NamingFeeder ;
+        cims:multiplicity     cims:M:0..n .
+
+cim:Feeder.NormalEnergizedSubstation
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The substations that are normally energized by the feeder." ;
+        rdfs:domain           cim:Feeder ;
+        rdfs:label            "NormalEnergizedSubstation"@en ;
+        rdfs:range            cim:Substation ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:Substation.NormalEnergizingFeeder ;
+        cims:multiplicity     cims:M:0..n .
+
+cim:Feeder.NormalEnergizingSubstation
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The substation that nominally energizes the feeder.  Also used for naming purposes." ;
+        rdfs:domain           cim:Feeder ;
+        rdfs:label            "NormalEnergizingSubstation"@en ;
+        rdfs:range            cim:Substation ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:Substation.NormalEnergizedFeeder ;
+        cims:multiplicity     cims:M:0..1 .
+
+cim:Float  rdf:type             rdfs:Class ;
+        rdfs:comment            "A floating point number. The range is unspecified and not limited." ;
+        rdfs:label              "Float"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:FossilFuel  rdf:type        rdfs:Class ;
+        rdfs:comment            "The fossil fuel consumed by the non-nuclear thermal generating unit.   For example, coal, oil, gas, etc.   These are the specific fuels that the generating unit can consume." ;
+        rdfs:label              "FossilFuel"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:Frequency  rdf:type         rdfs:Class ;
+        rdfs:comment            "Cycles per second." ;
+        rdfs:label              "Frequency"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Frequency.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:Frequency ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Frequency.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Frequency ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "Hz" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Frequency.value  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Frequency ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:GeneratingUnit  rdf:type    rdfs:Class ;
+        rdfs:comment            "A single or set of synchronous machines for converting mechanical power into alternating-current power. For example, individual machines within a set may be defined for scheduling purposes while a single control signal is derived for the set. In this case there would be a GeneratingUnit for each member of the set and an additional GeneratingUnit corresponding to the set." ;
+        rdfs:label              "GeneratingUnit"@en ;
+        rdfs:subClassOf         cim:Equipment ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:GeneratingUnit.lowerRampRate
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The normal maximum rate the generating unit active power output can be lowered by control actions." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "lowerRampRate"@en ;
+        cims:dataType      cim:ActivePowerChangeRate ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:GeneratingUnit.maxEconomicP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum high economic active power limit, that should not exceed the maximum operating active power limit." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "maxEconomicP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:GeneratingUnit.minEconomicP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Low economic active power limit that shall be greater than or equal to the minimum operating active power limit." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "minEconomicP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:GeneratingUnit.minimumOffTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Minimum time interval between unit shutdown and startup." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "minimumOffTime"@en ;
+        cims:dataType      cim:Seconds ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:GeneratingUnit.raiseRampRate
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The normal maximum rate the generating unit active power output can be raised by control actions." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "raiseRampRate"@en ;
+        cims:dataType      cim:ActivePowerChangeRate ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:HydroPowerPlant  rdf:type   rdfs:Class ;
+        rdfs:comment            "A hydro power station which can generate or pump. When generating, the generator turbines receive water from an upper reservoir. When pumping, the pumps receive their water from a lower reservoir." ;
+        rdfs:label              "HydroPowerPlant"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:HydroPowerPlant.Reservoir
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Generators discharge water to or pumps are supplied water from a downstream reservoir." ;
+        rdfs:domain           cim:HydroPowerPlant ;
+        rdfs:label            "Reservoir"@en ;
+        rdfs:range            cim:Reservoir ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:Reservoir.HydroPowerPlants ;
+        cims:multiplicity     cims:M:0..1 .
+
+cim:HydroPump  rdf:type         rdfs:Class ;
+        rdfs:comment            "A synchronous motor-driven pump, typically associated with a pumped storage plant." ;
+        rdfs:label              "HydroPump"@en ;
+        rdfs:subClassOf         cim:Equipment ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:IdentifiedObject  rdf:type  rdfs:Class ;
+        rdfs:comment            "This is a root class to provide common identification for all classes needing identification and naming attributes." ;
+        rdfs:label              "IdentifiedObject"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile .
+
+cim:IdentifiedObject.description
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The description is a free human readable text describing or naming the object. It may be non unique and may not correlate to a naming hierarchy." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "description"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.name
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The name is any free human readable and possibly non unique text naming the object." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "name"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Impedance  rdf:type         rdfs:Class ;
+        rdfs:comment            "Ratio of voltage to current." ;
+        rdfs:label              "Impedance"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Impedance.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:Impedance ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Impedance.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Impedance ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "ohm" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Impedance.value  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Impedance ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Integer  rdf:type           rdfs:Class ;
+        rdfs:comment            "An integer number. The range is unspecified and not limited." ;
+        rdfs:label              "Integer"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Line  rdf:type              rdfs:Class ;
+        rdfs:comment            "Contains equipment beyond a substation belonging to a power transmission line. " ;
+        rdfs:label              "Line"@en ;
+        rdfs:subClassOf         cim:EquipmentContainer ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:Money  rdf:type             rdfs:Class ;
+        rdfs:comment            "Amount of money." ;
+        rdfs:label              "Money"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Money.multiplier  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Money ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Money.unit  rdf:type   rdf:Property ;
+        rdfs:domain        cim:Money ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:Currency ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Money.value  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Money ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Decimal ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:NuclearGeneratingUnit
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A nuclear generating unit." ;
+        rdfs:label              "NuclearGeneratingUnit"@en ;
+        rdfs:subClassOf         cim:GeneratingUnit ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:OperationalLimit  rdf:type  rdfs:Class ;
+        rdfs:comment            "A value and normal value associated with a specific kind of limit. \nThe sub class value and normalValue attributes vary inversely to the associated OperationalLimitType.acceptableDuration (acceptableDuration for short).  \nIf a particular piece of equipment has multiple operational limits of the same kind (apparent power, current, etc.), the limit with the greatest acceptableDuration shall have the smallest limit value and the limit with the smallest acceptableDuration shall have the largest limit value.  Note: A large current can only be allowed to flow through a piece of equipment for a short duration without causing damage, but a lesser current can be allowed to flow for a longer duration. " ;
+        rdfs:label              "OperationalLimit"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile .
+
+cim:OperationalLimit.OperationalLimitSet
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The limit set to which the limit values belong." ;
+        rdfs:domain           cim:OperationalLimit ;
+        rdfs:label            "OperationalLimitSet"@en ;
+        rdfs:range            cim:OperationalLimitSet ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:OperationalLimitSet.OperationalLimitValue ;
+        cims:multiplicity     cims:M:1 .
+
+cim:OperationalLimit.OperationalLimitType
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The limit type associated with this limit." ;
+        rdfs:domain           cim:OperationalLimit ;
+        rdfs:label            "OperationalLimitType"@en ;
+        rdfs:range            cim:OperationalLimitType ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:OperationalLimitType.OperationalLimit ;
+        cims:multiplicity     cims:M:1 .
+
+cim:OperationalLimitDirectionKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The direction attribute describes the side of  a limit that is a violation." ;
+        rdfs:label              "OperationalLimitDirectionKind"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:OperationalLimitDirectionKind.absoluteValue
+        rdf:type         cim:OperationalLimitDirectionKind ;
+        rdfs:comment     "An absoluteValue limit means that a monitored absolute value above the limit value is a violation." ;
+        rdfs:label       "absoluteValue"@en ;
+        cims:stereotype  "enum" .
+
+cim:OperationalLimitDirectionKind.high
+        rdf:type         cim:OperationalLimitDirectionKind ;
+        rdfs:comment     "High means that a monitored value above the limit value is a violation.   If applied to a terminal flow, the positive direction is into the terminal." ;
+        rdfs:label       "high"@en ;
+        cims:stereotype  "enum" .
+
+cim:OperationalLimitDirectionKind.low
+        rdf:type         cim:OperationalLimitDirectionKind ;
+        rdfs:comment     "Low means a monitored value below the limit is a violation.  If applied to a terminal flow, the positive direction is into the terminal." ;
+        rdfs:label       "low"@en ;
+        cims:stereotype  "enum" .
+
+cim:OperationalLimitSet
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A set of limits associated with equipment.  Sets of limits might apply to a specific temperature, or season for example. A set of limits may contain different severities of limit levels that would apply to the same equipment. The set may contain limits of different types such as apparent power and current limits or high and low voltage limits  that are logically applied together as a set." ;
+        rdfs:label              "OperationalLimitSet"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:OperationalLimitSet.OperationalLimitValue
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Values of equipment limits." ;
+        rdfs:domain           cim:OperationalLimitSet ;
+        rdfs:label            "OperationalLimitValue"@en ;
+        rdfs:range            cim:OperationalLimit ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:OperationalLimit.OperationalLimitSet ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+cim:OperationalLimitSet.Terminal
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The terminal where the operational limit set apply." ;
+        rdfs:domain           cim:OperationalLimitSet ;
+        rdfs:label            "Terminal"@en ;
+        rdfs:range            cim:ACDCTerminal ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:ACDCTerminal.OperationalLimitSet ;
+        cims:multiplicity     cims:M:1 .
+
+cim:OperationalLimitType
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The operational meaning of a category of limits." ;
+        rdfs:label              "OperationalLimitType"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:OperationalLimitType.OperationalLimit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The operational limits associated with this type of limit." ;
+        rdfs:domain           cim:OperationalLimitType ;
+        rdfs:label            "OperationalLimit"@en ;
+        rdfs:range            cim:OperationalLimit ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:OperationalLimit.OperationalLimitType ;
+        cims:multiplicity     cims:M:1..n .
+
+cim:OperationalLimitType.direction
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The direction of the limit." ;
+        rdfs:domain        cim:OperationalLimitType ;
+        rdfs:label         "direction"@en ;
+        rdfs:range         cim:OperationalLimitDirectionKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Organisation  rdf:type      rdfs:Class ;
+        rdfs:comment            "Organisation that might have roles as utility, contractor, supplier, manufacturer, customer, etc." ;
+        rdfs:label              "Organisation"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:Organisation.Roles
+        rdf:type              rdf:Property ;
+        rdfs:comment          "All roles of this organisation." ;
+        rdfs:domain           cim:Organisation ;
+        rdfs:label            "Roles"@en ;
+        rdfs:range            cim:OrganisationRole ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:OrganisationRole.Organisation ;
+        cims:multiplicity     cims:M:0..n .
+
+cim:OrganisationRole  rdf:type  rdfs:Class ;
+        rdfs:comment            "Identifies a way in which an organisation may participate in the utility enterprise (e.g., customer, manufacturer, etc)." ;
+        rdfs:label              "OrganisationRole"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile .
+
+cim:OrganisationRole.Organisation
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Organisation having this role." ;
+        rdfs:domain           cim:OrganisationRole ;
+        rdfs:label            "Organisation"@en ;
+        rdfs:range            cim:Organisation ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:Organisation.Roles ;
+        cims:multiplicity     cims:M:0..1 .
+
+cim:PU  rdf:type                rdfs:Class ;
+        rdfs:comment            "Per Unit - a positive or negative value referred to a defined base. Values typically range from -10 to +10." ;
+        rdfs:label              "PU"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:PU.multiplier  rdf:type  rdf:Property ;
+        rdfs:domain        cim:PU ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PU.unit  rdf:type      rdf:Property ;
+        rdfs:domain        cim:PU ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PU.value  rdf:type     rdf:Property ;
+        rdfs:domain        cim:PU ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent  rdf:type           rdfs:Class ;
+        rdfs:comment            "Percentage on a defined base.   For example, specify as 100 to indicate at the defined base." ;
+        rdfs:label              "PerCent"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:PerCent.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent.value  rdf:type  rdf:Property ;
+        rdfs:comment       "Normally 0 to 100 on a defined base." ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PowerElectronicsUnit
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A generating unit or battery or aggregation that connects to the AC network using power electronics rather than rotating machines." ;
+        rdfs:label              "PowerElectronicsUnit"@en ;
+        rdfs:subClassOf         cim:Equipment ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:PowerSystemResource
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A power system resource (PSR) can be an item of equipment such as a switch, an equipment container containing many individual items of equipment such as a substation, or an organisational entity such as sub-control area. Power system resources can have measurements associated." ;
+        rdfs:label              "PowerSystemResource"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile .
+
+cim:Pressure  rdf:type          rdfs:Class ;
+        rdfs:comment            "Pressure in pascals." ;
+        rdfs:label              "Pressure"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Pressure.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:Pressure ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "k" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Pressure.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Pressure ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "Pa" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Pressure.value  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Pressure ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Reactance  rdf:type         rdfs:Class ;
+        rdfs:comment            "Reactance (imaginary part of impedance), at rated frequency." ;
+        rdfs:label              "Reactance"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Reactance.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:Reactance ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Reactance.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Reactance ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "ohm" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Reactance.value  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Reactance ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ReactiveCapabilityCurve
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Reactive power rating envelope versus the synchronous machine's active power, in both the generating and motoring modes. For each active power value there is a corresponding high and low reactive power limit  value. Typically there will be a separate curve for each coolant condition, such as hydrogen pressure.  The Y1 axis values represent reactive minimum and the Y2 axis values represent reactive maximum." ;
+        rdfs:label              "ReactiveCapabilityCurve"@en ;
+        rdfs:subClassOf         cim:Curve ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:ReactiveCapabilityCurve.EquivalentInjection2
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The equivalent injection using this reactive capability curve." ;
+        rdfs:domain           cim:ReactiveCapabilityCurve ;
+        rdfs:label            "EquivalentInjection2"@en ;
+        rdfs:range            cim:EquivalentInjection ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:EquivalentInjection.ReactiveCapabilityCurve2 ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+cim:ReactiveCapabilityCurve.SynchronousMachine2
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Synchronous machine using this curve." ;
+        rdfs:domain           cim:ReactiveCapabilityCurve ;
+        rdfs:label            "SynchronousMachine2"@en ;
+        rdfs:range            cim:SynchronousMachine ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:SynchronousMachine.ReactiveCapabilityCurve2 ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+cim:ReactiveCapabilityCurve.coolantTemperature
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The machine's coolant temperature (e.g., ambient air or stator circulating water)." ;
+        rdfs:domain        cim:ReactiveCapabilityCurve ;
+        rdfs:label         "coolantTemperature"@en ;
+        cims:dataType      cim:Temperature ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ReactiveCapabilityCurve.hydrogenPressure
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The hydrogen coolant pressure." ;
+        rdfs:domain        cim:ReactiveCapabilityCurve ;
+        rdfs:label         "hydrogenPressure"@en ;
+        cims:dataType      cim:Pressure ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ReactivePower  rdf:type     rdfs:Class ;
+        rdfs:comment            "Product of RMS value of the voltage and the RMS value of the quadrature component of the current." ;
+        rdfs:label              "ReactivePower"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:ReactivePower.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ReactivePower ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ReactivePower.unit
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ReactivePower ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "VAr" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ReactivePower.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ReactivePower ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:RegulatingCondEq  rdf:type  rdfs:Class ;
+        rdfs:comment            "A type of conducting equipment that can regulate a quantity (i.e. voltage or flow) at a specific point in the network. " ;
+        rdfs:label              "RegulatingCondEq"@en ;
+        rdfs:subClassOf         cim:EnergyConnection ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile .
+
+cim:Reservoir  rdf:type         rdfs:Class ;
+        rdfs:comment            "A water storage facility within a hydro system, including: ponds, lakes, lagoons, and rivers. The storage is usually behind some type of dam." ;
+        rdfs:label              "Reservoir"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:Reservoir.HydroPowerPlants
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Generators discharge water to or pumps are supplied water from a downstream reservoir." ;
+        rdfs:domain           cim:Reservoir ;
+        rdfs:label            "HydroPowerPlants"@en ;
+        rdfs:range            cim:HydroPowerPlant ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:HydroPowerPlant.Reservoir ;
+        cims:multiplicity     cims:M:0..n .
+
+cim:Resistance  rdf:type        rdfs:Class ;
+        rdfs:comment            "Resistance (real part of impedance)." ;
+        rdfs:label              "Resistance"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Resistance.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:Resistance ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Resistance.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Resistance ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "ohm" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Resistance.value  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Resistance ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Seconds  rdf:type           rdfs:Class ;
+        rdfs:comment            "Time, in seconds." ;
+        rdfs:label              "Seconds"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Seconds.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:Seconds ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Seconds.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Seconds ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "s" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Seconds.value  rdf:type  rdf:Property ;
+        rdfs:comment       "Time, in seconds" ;
+        rdfs:domain        cim:Seconds ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:String  rdf:type            rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited." ;
+        rdfs:label              "String"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Substation  rdf:type        rdfs:Class ;
+        rdfs:comment            "A collection of equipment for purposes other than generation or utilization, through which electric energy in bulk is passed for the purposes of switching or modifying its characteristics. " ;
+        rdfs:label              "Substation"@en ;
+        rdfs:subClassOf         cim:EquipmentContainer ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:Substation.DCConverterUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The DC converter unit belonging of the substation." ;
+        rdfs:domain           cim:Substation ;
+        rdfs:label            "DCConverterUnit"@en ;
+        rdfs:range            cim:DCConverterUnit ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:DCConverterUnit.Substation ;
+        cims:multiplicity     cims:M:0..n .
+
+cim:Substation.NamingFeeder
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The primary feeder that normally energizes the secondary substation. Used for naming purposes.  Either this association or the substation to subgeographical region should be used for hierarchical containment specification." ;
+        rdfs:domain           cim:Substation ;
+        rdfs:label            "NamingFeeder"@en ;
+        rdfs:range            cim:Feeder ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:Feeder.NamingSecondarySubstation ;
+        cims:multiplicity     cims:M:0..1 .
+
+cim:Substation.NormalEnergizedFeeder
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The normal energized feeders of the substation. Also used for naming purposes." ;
+        rdfs:domain           cim:Substation ;
+        rdfs:label            "NormalEnergizedFeeder"@en ;
+        rdfs:range            cim:Feeder ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:Feeder.NormalEnergizingSubstation ;
+        cims:multiplicity     cims:M:0..n .
+
+cim:Substation.NormalEnergizingFeeder
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The feeders that potentially energize  the downstream substation.  Should be consistent with the associations that describe the naming hierarchy." ;
+        rdfs:domain           cim:Substation ;
+        rdfs:label            "NormalEnergizingFeeder"@en ;
+        rdfs:range            cim:Feeder ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:Feeder.NormalEnergizedSubstation ;
+        cims:multiplicity     cims:M:0..n .
+
+cim:SynchronousMachine
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "An electromechanical device that operates with shaft rotating synchronously with the network. It is a single machine operating either as a generator or synchronous condenser or pump." ;
+        rdfs:label              "SynchronousMachine"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile .
+
+cim:SynchronousMachine.ReactiveCapabilityCurve2
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Reactive capability curve for this synchronous machine." ;
+        rdfs:domain           cim:SynchronousMachine ;
+        rdfs:label            "ReactiveCapabilityCurve2"@en ;
+        rdfs:range            cim:ReactiveCapabilityCurve ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:ReactiveCapabilityCurve.SynchronousMachine2 ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+cim:TapChanger  rdf:type        rdfs:Class ;
+        rdfs:comment            "Mechanism for changing transformer winding tap positions." ;
+        rdfs:label              "TapChanger"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" .
+
+cim:Temperature  rdf:type       rdfs:Class ;
+        rdfs:comment            "Value of temperature in degrees Celsius." ;
+        rdfs:label              "Temperature"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Temperature.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:Temperature ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Temperature.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Temperature ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "degC" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Temperature.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:Temperature ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Terminal  rdf:type          rdfs:Class ;
+        rdfs:comment            "An AC electrical connection point to a piece of conducting equipment. Terminals are connected at physical connection points called connectivity nodes." ;
+        rdfs:label              "Terminal"@en ;
+        rdfs:subClassOf         cim:ACDCTerminal ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile .
+
+cim:TieFlow  rdf:type           rdfs:Class ;
+        rdfs:comment            "Defines the structure (in terms of location and direction) of the net interchange constraint for a control area. This constraint may be used by either AGC or power flow." ;
+        rdfs:label              "TieFlow"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:UnitMultiplier  rdf:type    rdfs:Class ;
+        rdfs:comment            "The unit multipliers defined for the CIM.  When applied to unit symbols, the unit symbol is treated as a derived unit. Regardless of the contents of the unit symbol text, the unit symbol shall be treated as if it were a single-character unit symbol. Unit symbols should not contain multipliers, and it should be left to the multiplier to define the multiple for an entire data type. \n\nFor example, if a unit symbol is \"m2Pers\" and the multiplier is \"k\", then the value is k(m**2/s), and the multiplier applies to the entire final value, not to any individual part of the value. This can be conceptualized by substituting a derived unit symbol for the unit type. If one imagines that the symbol \"Þ\" represents the derived unit \"m2Pers\", then applying the multiplier \"k\" can be conceptualized simply as \"kÞ\".\n\nFor example, the SI unit for mass is \"kg\" and not \"g\".  If the unit symbol is defined as \"kg\", then the multiplier is applied to \"kg\" as a whole and does not replace the \"k\" in front of the \"g\". In this case, the multiplier of \"m\" would be used with the unit symbol of \"kg\" to represent one gram.  As a text string, this violates the instructions in IEC 80000-1. However, because the unit symbol in CIM is treated as a derived unit instead of as an SI unit, it makes more sense to conceptualize the \"kg\" as if it were replaced by one of the proposed replacements for the SI mass symbol. If one imagines that the \"kg\" were replaced by a symbol \"Þ\", then it is easier to conceptualize the multiplier \"m\" as creating the proper unit \"mÞ\", and not the forbidden unit \"mkg\"." ;
+        rdfs:label              "UnitMultiplier"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitMultiplier.M  rdf:type  cim:UnitMultiplier ;
+        rdfs:comment     "Mega 10**6." ;
+        rdfs:label       "M"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitMultiplier.k  rdf:type  cim:UnitMultiplier ;
+        rdfs:comment     "Kilo 10**3." ;
+        rdfs:label       "k"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitMultiplier.none
+        rdf:type         cim:UnitMultiplier ;
+        rdfs:comment     "No multiplier or equivalently multiply by 1." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol  rdf:type        rdfs:Class ;
+        rdfs:comment            "The derived units defined for usage in the CIM. In some cases, the derived unit is equal to an SI unit. Whenever possible, the standard derived symbol is used instead of the formula for the derived unit. For example, the unit symbol Farad is defined as \"F\" instead of \"CPerV\". In cases where a standard symbol does not exist for a derived unit, the formula for the unit is used as the unit symbol. For example, density does not have a standard symbol and so it is represented as \"kgPerm3\". With the exception of the \"kg\", which is an SI unit, the unit symbols do not contain multipliers and therefore represent the base derived unit to which a multiplier can be applied as a whole. \nEvery unit symbol is treated as an unparseable text as if it were a single-letter symbol. The meaning of each unit symbol is defined by the accompanying descriptive text and not by the text contents of the unit symbol.\nTo allow the widest possible range of serializations without requiring special character handling, several substitutions are made which deviate from the format described in IEC 80000-1. The division symbol \"/\" is replaced by the letters \"Per\". Exponents are written in plain text after the unit as \"m3\" instead of being formatted as \"m\" with a superscript of 3  or introducing a symbol as in \"m^3\". The degree symbol \"°\" is replaced with the letters \"deg\". Any clarification of the meaning for a substitution is included in the description for the unit symbol.\nNon-SI units are included in list of unit symbols to allow sources of data to be correctly labelled with their non-SI units (for example, a GPS sensor that is reporting numbers that represent feet instead of meters). This allows software to use the unit symbol information correctly convert and scale the raw data of those sources into SI-based units. \nThe integer values are used for harmonization with IEC 61850." ;
+        rdfs:label              "UnitSymbol"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitSymbol.A  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Current in amperes." ;
+        rdfs:label       "A"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.Hz  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Frequency in hertz (1/s)." ;
+        rdfs:label       "Hz"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.Pa  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Pressure in pascals (N/m²). Note: the absolute or relative measurement of pressure is implied with this entry. See below for more explicit forms." ;
+        rdfs:label       "Pa"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.V  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Electric potential in volts (W/A)." ;
+        rdfs:label       "V"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.VAr  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Reactive power in volt amperes reactive. The “reactive” or “imaginary” component of electrical power (VIsin(phi)). (See also real power and apparent power).\nNote: Different meter designs use different methods to arrive at their results. Some meters may compute reactive power as an arithmetic value, while others compute the value vectorially. The data consumer should determine the method in use and the suitability of the measurement for the intended purpose." ;
+        rdfs:label       "VAr"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.VPerVAr
+        rdf:type         cim:UnitSymbol ;
+        rdfs:comment     "Power factor, PF, the ratio of the active power to the apparent power. Note: The sign convention used for power factor will differ between IEC meters and EEI (ANSI) meters. It is assumed that the data consumers understand the type of meter being used and agree on the sign convention in use at any given utility." ;
+        rdfs:label       "VPerVAr"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.W  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Real power in watts (J/s). Electrical power may have real and reactive components. The real portion of electrical power (I&#178;R or VIcos(phi)), is expressed in Watts. See also apparent power and reactive power." ;
+        rdfs:label       "W"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.WPerm2
+        rdf:type         cim:UnitSymbol ;
+        rdfs:comment     "Heat flux density, irradiance, watts per square metre." ;
+        rdfs:label       "WPerm2"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.WPers  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Ramp rate in watts per second." ;
+        rdfs:label       "WPers"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.deg  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Plane angle in degrees." ;
+        rdfs:label       "deg"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.degC  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Relative temperature in degrees Celsius.\nIn the SI unit system the symbol is °C. Electric charge is measured in coulomb that has the unit symbol C. To distinguish degree Celsius from coulomb the symbol used in the UML is degC. The reason for not using °C is that the special character ° is difficult to manage in software." ;
+        rdfs:label       "degC"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.none  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Dimension less quantity, e.g. count, per unit, etc." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.ohm  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Electric resistance in ohms (V/A)." ;
+        rdfs:label       "ohm"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.s  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Time in seconds." ;
+        rdfs:label       "s"@en ;
+        cims:stereotype  "enum" .
+
+cim:Voltage  rdf:type           rdfs:Class ;
+        rdfs:comment            "Electrical voltage, can be both AC and DC." ;
+        rdfs:label              "Voltage"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Voltage.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:Voltage ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "k" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Voltage.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Voltage ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "V" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Voltage.value  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Voltage ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:VoltagePerReactivePower
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Voltage variation with reactive power." ;
+        rdfs:label              "VoltagePerReactivePower"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:VoltagePerReactivePower.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:VoltagePerReactivePower ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "k" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:VoltagePerReactivePower.unit
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:VoltagePerReactivePower ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "VPerVAr" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:VoltagePerReactivePower.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:VoltagePerReactivePower ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:VsCapabilityCurve
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The P-Q capability curve for a voltage source converter, with P on X-axis and Qmin and Qmax on Y1-axis and Y2-axis." ;
+        rdfs:label              "VsCapabilityCurve"@en ;
+        rdfs:subClassOf         cim:Curve ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:VsCapabilityCurve.VsConverter
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Converter with this capability curve." ;
+        rdfs:domain           cim:VsCapabilityCurve ;
+        rdfs:label            "VsConverter"@en ;
+        rdfs:range            cim:VsConverter ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:VsConverter.CapabilityCurve2 ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+cim:VsConverter  rdf:type       rdfs:Class ;
+        rdfs:comment            "DC side of the voltage source converter (VSC)." ;
+        rdfs:label              "VsConverter"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile .
+
+cim:VsConverter.CapabilityCurve2
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Capability curve of this converter." ;
+        rdfs:domain           cim:VsConverter ;
+        rdfs:label            "CapabilityCurve2"@en ;
+        rdfs:range            cim:VsCapabilityCurve ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:VsCapabilityCurve.VsConverter ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+eu:IdentifiedObject.energyIdentCodeEic
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The attribute is used for an exchange of the EIC code (Energy identification Code). The length of the string is 16 characters as defined by the EIC code. For details on EIC scheme please refer to ENTSO-E web site." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "energyIdentCodeEic"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "deprecated" , "European" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ACDCConverter.ACDCConverterController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Direct current controller which controls the ACDC converter." ;
+        rdfs:domain           cim:ACDCConverter ;
+        rdfs:label            "ACDCConverterController"@en ;
+        rdfs:range            nc:ACDCConverterController ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ACDCConverterController.ACDCConverter ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ACDCConverterController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "ACDC converter unit control. According to IEC 60633, it is the control system used for the controlling, monitoring and protection of a single converter unit." ;
+        rdfs:label              "ACDCConverterController"@en ;
+        rdfs:subClassOf         nc:DirectCurrentEquipmentController ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ACDCConverterController.ACDCConverter
+        rdf:type              rdf:Property ;
+        rdfs:comment          "ACDC converter controlled by the direct current controller." ;
+        rdfs:domain           nc:ACDCConverterController ;
+        rdfs:label            "ACDCConverter"@en ;
+        rdfs:range            cim:ACDCConverter ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ACDCConverter.ACDCConverterController ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:ACDCConverterController.DirectCurrentPoleController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC pole controller that controls this ACDC controller." ;
+        rdfs:domain           nc:ACDCConverterController ;
+        rdfs:label            "DirectCurrentPoleController"@en ;
+        rdfs:range            nc:DirectCurrentPoleController ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DirectCurrentPoleController.ACDCConverterController ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ACDCTerminal.InfeedTerminal
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Infeed terminal that is associated with an ACDCTerminal." ;
+        rdfs:domain           cim:ACDCTerminal ;
+        rdfs:label            "InfeedTerminal"@en ;
+        rdfs:range            nc:InfeedTerminal ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:InfeedTerminal.ACDCTerminal ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ACEmulationControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The AC emulation control function is used when AC emulation model is activated for a DC system. It consists in computing the active power set point of the DC system as a function of the voltage angle difference between both points of common coupling with the AC network in order to mimic the behavior of an AC transmission line. This control mode enables the automatic adjustment of the active power reference following variations of the AC system operational point. \nThe setpoint of the DC system is calculated by Psetpoint=Pref+Kdc*(angle1-angle2), where\n- Pref is the existing active power setpoint; \n- Kdc is the control system gain and  \n- angle1 and angle2 are the phase angle measurement (measured at points of common coupling with the AC network) respectively at the side 1 and 2 of the DC system." ;
+        rdfs:label              "ACEmulationControlFunction"@en ;
+        rdfs:subClassOf         nc:ControlFunctionBlock ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ACPointOfCommonCoupling
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Point of interconnection of the DC converter station to the adjacent AC system (IEC 60633)." ;
+        rdfs:label              "ACPointOfCommonCoupling"@en ;
+        rdfs:subClassOf         nc:PointOfCommonCoupling ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ACPointOfCommonCoupling.ConnectivityNode
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Connectivity node which is a point of common coupling AC." ;
+        rdfs:domain           nc:ACPointOfCommonCoupling ;
+        rdfs:label            "ConnectivityNode"@en ;
+        rdfs:range            cim:ConnectivityNode ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ConnectivityNode.ACPointOfCommonCoupling ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:ACPointOfCommonCoupling.DCConverterUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC converter unit that has AC point of common coupling." ;
+        rdfs:domain           nc:ACPointOfCommonCoupling ;
+        rdfs:label            "DCConverterUnit"@en ;
+        rdfs:range            cim:DCConverterUnit ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DCConverterUnit.ACPointOfCommonCoupling ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ACTieCorridor  rdf:type      rdfs:Class ;
+        rdfs:comment            "A collection of one or more AC tie lines that connect two different control areas." ;
+        rdfs:label              "ACTieCorridor"@en ;
+        rdfs:subClassOf         nc:TieCorridor ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ACTieCorridor.Line
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Line that is part of the ACTieCorridor." ;
+        rdfs:domain           nc:ACTieCorridor ;
+        rdfs:label            "Line"@en ;
+        rdfs:range            cim:Line ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:Line.ACTieCorridor ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ActivePowerControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Active power control function is a function block that calculates operating point of the controlled equipment to achieve the target active power." ;
+        rdfs:label              "ActivePowerControlFunction"@en ;
+        rdfs:subClassOf         nc:ControlFunctionBlock ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AmbientTemperatureDependencyCurve
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A curve or functional relationship between the ambient temperature independent variable (X-axis) and relative temperature dependent (Y-axis) variables." ;
+        rdfs:label              "AmbientTemperatureDependencyCurve"@en ;
+        rdfs:subClassOf         nc:LimitDependencyCurve ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AmbientTemperatureDependencyCurve.OperationalLimitType
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The operational limit type that has this permanent ambient temperature dependency curve." ;
+        rdfs:domain           nc:AmbientTemperatureDependencyCurve ;
+        rdfs:label            "OperationalLimitType"@en ;
+        rdfs:range            cim:OperationalLimitType ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:OperationalLimitType.PermanentAmbientTemperatureDependencyCurve ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:AreaDispatchableUnit
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Allocates a given producing or consuming unit, including direct current corridor and collection of units, to a given control area (through the scheduling area) for supporting the control of the given area through dispatch instruction. " ;
+        rdfs:label              "AreaDispatchableUnit"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AreaDispatchableUnit.EnergyConsumer
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Energy consumer for this area dispatchable unit." ;
+        rdfs:domain           nc:AreaDispatchableUnit ;
+        rdfs:label            "EnergyConsumer"@en ;
+        rdfs:range            cim:EnergyConsumer ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EnergyConsumer.AreaDispatchableUnit ;
+        cims:multiplicity     cims:M:0..1 .
+
+nc:AreaDispatchableUnit.GeneratingUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The generating unit that belongs to area dispatchable unit." ;
+        rdfs:domain           nc:AreaDispatchableUnit ;
+        rdfs:label            "GeneratingUnit"@en ;
+        rdfs:range            cim:GeneratingUnit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GeneratingUnit.AreaDispatchableUnit ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AreaDispatchableUnit.HydroPump
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Hydro Pump which is associated with the area dispatchable unit." ;
+        rdfs:domain           nc:AreaDispatchableUnit ;
+        rdfs:label            "HydroPump"@en ;
+        rdfs:range            cim:HydroPump ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:HydroPump.AreaDispatchableUnit ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AreaDispatchableUnit.PowerElectronicsUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The power electronics unit that belongs to this area dispatchable unit." ;
+        rdfs:domain           nc:AreaDispatchableUnit ;
+        rdfs:label            "PowerElectronicsUnit"@en ;
+        rdfs:range            cim:PowerElectronicsUnit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerElectronicsUnit.AreaDispatchableUnit ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AreaDispatchableUnit.ScheduleResource
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The resource which is mFRR for the EnergySchedulingArea to which the AreaDispatchableUnit is connected. Note that this can be different than the area for the energy schedule." ;
+        rdfs:domain           nc:AreaDispatchableUnit ;
+        rdfs:label            "ScheduleResource"@en ;
+        rdfs:range            nc:ScheduleResource ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ScheduleResource.AreaDispatchableUnit ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AreaDispatchableUnit.SchedulingArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The scheduling area that has this area dispatchable unit." ;
+        rdfs:domain           nc:AreaDispatchableUnit ;
+        rdfs:label            "SchedulingArea"@en ;
+        rdfs:range            nc:SchedulingArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SchedulingArea.AreaDispatchableUnit ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AreaDispatchableUnit.TieCorridor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Tie Corridor which belongs to the Area Dispatchable Unit." ;
+        rdfs:domain           nc:AreaDispatchableUnit ;
+        rdfs:label            "TieCorridor"@en ;
+        rdfs:range            nc:TieCorridor ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:TieCorridor.AreaDispatchableUnit ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AreaDispatchableUnit.normalEnabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Identifies if the unit is normally enabled to accept a dispatch instruction. If true, the unit is enabled to accept a dispatch instruction. If false, the unit has the capability, but it is not enabled to receive a dispatch instruction." ;
+        rdfs:domain        nc:AreaDispatchableUnit ;
+        rdfs:label         "normalEnabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AreaInterchangeController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Area interchange control is set to control active power of an area." ;
+        rdfs:label              "AreaInterchangeController"@en ;
+        rdfs:subClassOf         nc:SystemControl ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AreaInterchangeController.BiddingZone
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Bidding zone which has an area interchange controller." ;
+        rdfs:domain           nc:AreaInterchangeController ;
+        rdfs:label            "BiddingZone"@en ;
+        rdfs:range            nc:BiddingZone ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:BiddingZone.AreaInterchangeController ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AreaInterchangeController.BiddingZoneBorder
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Bidding zone border that has an area interchange controller." ;
+        rdfs:domain           nc:AreaInterchangeController ;
+        rdfs:label            "BiddingZoneBorder"@en ;
+        rdfs:range            nc:BiddingZoneBorder ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:BiddingZoneBorder.AreaInterchangeController ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AreaInterchangeController.ControlArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Control area that has a area interchange controller." ;
+        rdfs:domain           nc:AreaInterchangeController ;
+        rdfs:label            "ControlArea"@en ;
+        rdfs:range            cim:ControlArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ControlArea.AreaInterchangeController ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AreaInterchangeController.pTolerance
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Active power net interchange tolerance. The attribute shall be a positive value or zero." ;
+        rdfs:domain        nc:AreaInterchangeController ;
+        rdfs:label         "pTolerance"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AutomationBlockGroup
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Grouping of function block that are operated with the same priority as settings." ;
+        rdfs:label              "AutomationBlockGroup"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AutomationBlockGroup.AutomationFunction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Automation function which has automation block group." ;
+        rdfs:domain           nc:AutomationBlockGroup ;
+        rdfs:label            "AutomationFunction"@en ;
+        rdfs:range            nc:AutomationFunction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AutomationFunction.AutomationBlockGroup ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:AutomationBlockGroup.FunctionBlock
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Function block which belongs to an automation block group." ;
+        rdfs:domain           nc:AutomationBlockGroup ;
+        rdfs:label            "FunctionBlock"@en ;
+        rdfs:range            nc:FunctionBlock ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:FunctionBlock.AutomationBlockGroup ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:AutomationBlockGroup.priority
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Value 0 means ignore priority. 1 means the highest priority, 2 is the second highest priority." ;
+        rdfs:domain        nc:AutomationBlockGroup ;
+        rdfs:label         "priority"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AutomationFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Automation function is a collection of functional block or other automation function that can be executed as a work cycle program as part of an automated system." ;
+        rdfs:label              "AutomationFunction"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:AutomationFunction.AutomationBlockGroup
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Automation block group which belongs to an automation function." ;
+        rdfs:domain           nc:AutomationFunction ;
+        rdfs:label            "AutomationBlockGroup"@en ;
+        rdfs:range            nc:AutomationBlockGroup ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AutomationBlockGroup.AutomationFunction ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:AutomationFunction.FunctionBlock
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Function block is part of this automation function." ;
+        rdfs:domain           nc:AutomationFunction ;
+        rdfs:label            "FunctionBlock"@en ;
+        rdfs:range            nc:FunctionBlock ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:FunctionBlock.AutomationFunction ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:AutomationFunction.HasPart
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Automation function has this automation function as a part." ;
+        rdfs:domain           nc:AutomationFunction ;
+        rdfs:label            "HasPart"@en ;
+        rdfs:range            nc:AutomationFunction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AutomationFunction.PartOf ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:AutomationFunction.PartOf
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Automation function is part of this automation function." ;
+        rdfs:domain           nc:AutomationFunction ;
+        rdfs:label            "PartOf"@en ;
+        rdfs:range            nc:AutomationFunction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AutomationFunction.HasPart ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AutomationFunction.normalEnabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "True, if the automation function is enabled (active). Otherwise false." ;
+        rdfs:domain        nc:AutomationFunction ;
+        rdfs:label         "normalEnabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AutomationFunction.type
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Type of automation function." ;
+        rdfs:domain        nc:AutomationFunction ;
+        rdfs:label         "type"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseOverloadLimitCurve
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A curve or functional relationship between \n- the relative loading - current loading over permanent loading (PATL) independent variable (X-axis), and \n- temporary overloading (TATL) limiting dependent (Y-axis) variables." ;
+        rdfs:label              "BaseOverloadLimitCurve"@en ;
+        rdfs:subClassOf         nc:LimitDependencyCurve ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:BaseOverloadLimitCurve.OperationalLimitType
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The operational limit type that has this temporary base overload limit curve." ;
+        rdfs:domain           nc:BaseOverloadLimitCurve ;
+        rdfs:label            "OperationalLimitType"@en ;
+        rdfs:range            cim:OperationalLimitType ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:OperationalLimitType.TemporaryBaseOverloadLimitCurve ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:BiddingZone  rdf:type        rdfs:Class ;
+        rdfs:comment            "A bidding zone is a market-based method for handling power transmission congestion. It consists of scheduling areas that include the relevant production (supply) and consumption (demand) to form an electrical area with the same market price without capacity allocation." ;
+        rdfs:label              "BiddingZone"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:BiddingZone.AreaInterchangeController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Area interchange controller for this bidding zone." ;
+        rdfs:domain           nc:BiddingZone ;
+        rdfs:label            "AreaInterchangeController"@en ;
+        rdfs:range            nc:AreaInterchangeController ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AreaInterchangeController.BiddingZone ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:BiddingZone.BiddingZoneBorderOne
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The primary side of the border." ;
+        rdfs:domain           nc:BiddingZone ;
+        rdfs:label            "BiddingZoneBorderOne"@en ;
+        rdfs:range            nc:BiddingZoneBorder ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:BiddingZoneBorder.BiddingZoneOne ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:BiddingZone.BiddingZoneBorderTwo
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The secondary side of the border." ;
+        rdfs:domain           nc:BiddingZone ;
+        rdfs:label            "BiddingZoneBorderTwo"@en ;
+        rdfs:range            nc:BiddingZoneBorder ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:BiddingZoneBorder.BiddingZoneTwo ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:BiddingZone.CapacityCalculationRegion
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The capacity calculation region related to this bidding zone." ;
+        rdfs:domain           nc:BiddingZone ;
+        rdfs:label            "CapacityCalculationRegion"@en ;
+        rdfs:range            nc:CapacityCalculationRegion ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:CapacityCalculationRegion.BiddingZone ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:BiddingZone.PowerCapacity
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power capacity whidh is asocciated to the bidding zone." ;
+        rdfs:domain           nc:BiddingZone ;
+        rdfs:label            "PowerCapacity"@en ;
+        rdfs:range            nc:PowerCapacity ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerCapacity.BiddingZone ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:BiddingZone.SchedulingArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The scheduling area that has bidding zone." ;
+        rdfs:domain           nc:BiddingZone ;
+        rdfs:label            "SchedulingArea"@en ;
+        rdfs:range            nc:SchedulingArea ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:SchedulingArea.BiddingZone ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:BiddingZone.isTradeEnabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Identifies the mechanism for determining the energy price for a given bidding zone. If true, the bid and the offer is expected to be provided for the bidding zone to create the market price. If false,  other mechanism determines the price of energy for a given bidding zone, e.g. virtual bidding zone." ;
+        rdfs:domain        nc:BiddingZone ;
+        rdfs:label         "isTradeEnabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BiddingZoneBorder  rdf:type  rdfs:Class ;
+        rdfs:comment            "Defines the aggregated connection capacity between two Bidding Zones." ;
+        rdfs:label              "BiddingZoneBorder"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:BiddingZoneBorder.AreaInterchangeController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Area interchange controller that relates to this bidding zone border." ;
+        rdfs:domain           nc:BiddingZoneBorder ;
+        rdfs:label            "AreaInterchangeController"@en ;
+        rdfs:range            nc:AreaInterchangeController ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AreaInterchangeController.BiddingZoneBorder ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:BiddingZoneBorder.BiddingZoneOne
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The bidding zone for the primary side." ;
+        rdfs:domain           nc:BiddingZoneBorder ;
+        rdfs:label            "BiddingZoneOne"@en ;
+        rdfs:range            nc:BiddingZone ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:BiddingZone.BiddingZoneBorderOne ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:BiddingZoneBorder.BiddingZoneTwo
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The bidding zone for the secondary side." ;
+        rdfs:domain           nc:BiddingZoneBorder ;
+        rdfs:label            "BiddingZoneTwo"@en ;
+        rdfs:range            nc:BiddingZone ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:BiddingZone.BiddingZoneBorderTwo ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:BiddingZoneBorder.CapacityCalculationRegion
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The capacity calculation region for which the capacity is derived from." ;
+        rdfs:domain           nc:BiddingZoneBorder ;
+        rdfs:label            "CapacityCalculationRegion"@en ;
+        rdfs:range            nc:CapacityCalculationRegion ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:CapacityCalculationRegion.BiddingZoneBorder ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:BiddingZoneBorder.TieCorridor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Tie corridor for a given bidding zone border." ;
+        rdfs:domain           nc:BiddingZoneBorder ;
+        rdfs:label            "TieCorridor"@en ;
+        rdfs:range            nc:TieCorridor ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:TieCorridor.BiddingZoneBorder ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:BipolarDCSystem  rdf:type    rdfs:Class ;
+        rdfs:comment            "Bipolar DC system (IEC 60633) consists of two poles of opposite polarity with respect to earth. The overhead lines, if any, of the two poles may be carried on common or separate towers." ;
+        rdfs:label              "BipolarDCSystem"@en ;
+        rdfs:subClassOf         nc:DCSystem ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:BipolarDCSystem.DCBiPole
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC bipole that belongs to a bipolar DC system." ;
+        rdfs:domain           nc:BipolarDCSystem ;
+        rdfs:label            "DCBiPole"@en ;
+        rdfs:range            nc:DCBiPole ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DCBiPole.BipolarDCSystem ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:BipolarDCSystem.isRigid
+        rdf:type           rdf:Property ;
+        rdfs:comment       "If true, the bipolar DC system is a rigid DC current bipolar system (IEC 60633). It is a bipolar DC system without neutral connection between both converter stations. Since only two (pole) conductors exist, no unbalance current between both poles is possible. In case of interruption of power transfer of one converter pole, the current of the other pole has to be interrupted as well (at least for a limited time to allow reconfiguration of the DC circuit)." ;
+        rdfs:domain        nc:BipolarDCSystem ;
+        rdfs:label         "isRigid"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CapacityCalculationRegion
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Capacity calculation region is a coherent part of the interconnected system that is used for calculating the transmission capacity for a bidding zone or between bidding zones." ;
+        rdfs:label              "CapacityCalculationRegion"@en ;
+        rdfs:subClassOf         nc:Region ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:CapacityCalculationRegion.BiddingZone
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The bidding zone for this capacity calculation region." ;
+        rdfs:domain           nc:CapacityCalculationRegion ;
+        rdfs:label            "BiddingZone"@en ;
+        rdfs:range            nc:BiddingZone ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:BiddingZone.CapacityCalculationRegion ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:CapacityCalculationRegion.BiddingZoneBorder
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The bidding zone border on which the capacity is calculated. " ;
+        rdfs:domain           nc:CapacityCalculationRegion ;
+        rdfs:label            "BiddingZoneBorder"@en ;
+        rdfs:range            nc:BiddingZoneBorder ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:BiddingZoneBorder.CapacityCalculationRegion ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:CapacityCalculationRegion.CoordinatedCapacityCalculator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Coordinated capacity calculator responsible for the capacity calculation of the region." ;
+        rdfs:domain           nc:CapacityCalculationRegion ;
+        rdfs:label            "CoordinatedCapacityCalculator"@en ;
+        rdfs:range            nc:CoordinatedCapacityCalculator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:CoordinatedCapacityCalculator.CapacityCalculationRegion ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:CapacityCalculationRegion.SecurityCoordinator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The security coordinator responsible for the capacity calculation region." ;
+        rdfs:domain           nc:CapacityCalculationRegion ;
+        rdfs:label            "SecurityCoordinator"@en ;
+        rdfs:range            nc:SecurityCoordinator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SecurityCoordinator.CapacityCalculationRegion ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ChargingUnit  rdf:type       rdfs:Class ;
+        rdfs:comment            "A unit that supplies electrical power for charging electrical non-stationary entities, e.g. electrical vehicle, trucks, buses, ferries, boats and airplanes. The characteristic is that the energy consumption is highly schedule dependent." ;
+        rdfs:label              "ChargingUnit"@en ;
+        rdfs:subClassOf         cim:PowerElectronicsUnit ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:Circuit  rdf:type            rdfs:Class ;
+        rdfs:comment            "A circuit is a collection of equipment in a network graph that provide common stability limits. The relevant equipment is in general given by the identifying terminal. A software application that can do topology processing shall calculate the equipment belonging to the circuit, if there are no stability limits associated to it. In case of stability limits, the containment reflects the equipments that were used in the calculation/analysis. " ;
+        rdfs:label              "Circuit"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:Circuit.CircuitShare
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The circuit share of the given power transfer corridor." ;
+        rdfs:domain           nc:Circuit ;
+        rdfs:label            "CircuitShare"@en ;
+        rdfs:range            nc:CircuitShare ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:CircuitShare.Circuit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Circuit.Equipment  rdf:type  rdf:Property ;
+        rdfs:comment          "The equipment which is part of the circuit. This includes all equipment related to the circuit (e.g. If the circuit is a transformer, the equipment could be all switching and auxiliary equipments related to the transformer). A BusbarSection shall not be part of the circuit." ;
+        rdfs:domain           nc:Circuit ;
+        rdfs:label            "Equipment"@en ;
+        rdfs:range            cim:Equipment ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:Equipment.Circuit ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:CircuitShare  rdf:type       rdfs:Class ;
+        rdfs:comment            "Defines the share of the circuit which is part of an associated power transfer corridor." ;
+        rdfs:label              "CircuitShare"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:CircuitShare.Circuit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The circuit that has a share of the power system corridor." ;
+        rdfs:domain           nc:CircuitShare ;
+        rdfs:label            "Circuit"@en ;
+        rdfs:range            nc:Circuit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Circuit.CircuitShare ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:CircuitShare.PowerTransferCorridor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The power transfer corridor that has this circuit share." ;
+        rdfs:domain           nc:CircuitShare ;
+        rdfs:label            "PowerTransferCorridor"@en ;
+        rdfs:range            nc:PowerTransferCorridor ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerTransferCorridor.CircuitShare ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:CircuitShare.normalContributionFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Normal contribution factor for the circuit which is part of a power transfer corridor.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:CircuitShare ;
+        rdfs:label         "normalContributionFactor"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ClosedDistributionSystemOperator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A system operator which distributes electricity (or gas) within a geographically confined industrial, commercial or shared services and does not supply household customers." ;
+        rdfs:label              "ClosedDistributionSystemOperator"@en ;
+        rdfs:subClassOf         nc:SystemOperator ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:CompensatorController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Compensator controller is controlling the equipment to optimize the use of the compensators. " ;
+        rdfs:label              "CompensatorController"@en ;
+        rdfs:subClassOf         nc:EquipmentController ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ConnectivityNode.ACPointOfCommonCoupling
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Identifies this ConnectivityNode as a point of common coupling AC." ;
+        rdfs:domain           cim:ConnectivityNode ;
+        rdfs:label            "ACPointOfCommonCoupling"@en ;
+        rdfs:range            nc:ACPointOfCommonCoupling ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ACPointOfCommonCoupling.ConnectivityNode ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ControlArea.AreaInterchangeController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Area interchange controller for this control area." ;
+        rdfs:domain           cim:ControlArea ;
+        rdfs:label            "AreaInterchangeController"@en ;
+        rdfs:range            nc:AreaInterchangeController ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AreaInterchangeController.ControlArea ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ControlArea.OutageCoordinationRegion
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The outage coordination region that has this control area." ;
+        rdfs:domain           cim:ControlArea ;
+        rdfs:label            "OutageCoordinationRegion"@en ;
+        rdfs:range            nc:OutageCoordinationRegion ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:OutageCoordinationRegion.ControlArea ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ControlArea.PowerFrequencyController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power frequency controller for this control area." ;
+        rdfs:domain           cim:ControlArea ;
+        rdfs:label            "PowerFrequencyController"@en ;
+        rdfs:range            nc:PowerFrequencyController ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerFrequencyController.ControlArea ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ControlArea.SchedulingArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The scheduling area related to a control area." ;
+        rdfs:domain           cim:ControlArea ;
+        rdfs:label            "SchedulingArea"@en ;
+        rdfs:range            nc:SchedulingArea ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:SchedulingArea.ControlArea ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:ControlArea.SystemOperator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The system operator that operates this control area." ;
+        rdfs:domain           cim:ControlArea ;
+        rdfs:label            "SystemOperator"@en ;
+        rdfs:range            nc:SystemOperator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SystemOperator.ControlArea ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ControlFunctionBlock
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Control function block is a function block that contains an algorithm for controlling the equipment." ;
+        rdfs:label              "ControlFunctionBlock"@en ;
+        rdfs:subClassOf         nc:FunctionBlock ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:ControlFunctionBlock.isDiscrete
+        rdf:type           rdf:Property ;
+        rdfs:comment       "True, if the control function is discrete. This applies to equipment with discrete controls, e.g. tap changers and shunt compensators." ;
+        rdfs:domain        nc:ControlFunctionBlock ;
+        rdfs:label         "isDiscrete"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ControlFunctionBlock.maxAllowedTargetValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum allowed target value given by the percent of target value.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:ControlFunctionBlock ;
+        rdfs:label         "maxAllowedTargetValue"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ControlFunctionBlock.minAllowedTargetValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Minimum allowed target value given by the percent of target value.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:ControlFunctionBlock ;
+        rdfs:label         "minAllowedTargetValue"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ControlFunctionBlock.targetDeadband
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Target deadband is used with discrete control to avoid excessive update of controls like tap changers and shunt compensator banks while regulating.  The attribute shall be a positive value or zero. If isDiscrete is set to \"false\", the targetDeadband is to be ignored.\nNote that for instance, if the targetValue is 100 kV and the targetDeadband is 2 kV the range is from 99 to 101 kV." ;
+        rdfs:domain        nc:ControlFunctionBlock ;
+        rdfs:label         "targetDeadband"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CoordinatedCapacityCalculator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A role that coordinates and executes the task of calculating transmission capacity." ;
+        rdfs:label              "CoordinatedCapacityCalculator"@en ;
+        rdfs:subClassOf         nc:SystemOperationCoordinator ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:CoordinatedCapacityCalculator.CapacityCalculationRegion
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Capacity calculation region in which the capacity is calculated by the coordinated capacity calculator." ;
+        rdfs:domain           nc:CoordinatedCapacityCalculator ;
+        rdfs:label            "CapacityCalculationRegion"@en ;
+        rdfs:range            nc:CapacityCalculationRegion ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:CapacityCalculationRegion.CoordinatedCapacityCalculator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:CurrentControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Current control function is a function block that calculates the operating point of the controlled equipment  to achieve the target current." ;
+        rdfs:label              "CurrentControlFunction"@en ;
+        rdfs:subClassOf         nc:ControlFunctionBlock ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:CurrentDroopControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Current droop control function is a function block that calculates the operating point of the controlled equipment to achieve the target current." ;
+        rdfs:label              "CurrentDroopControlFunction"@en ;
+        rdfs:subClassOf         nc:ControlFunctionBlock ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:CurrentDroopControlFunction.droopCapacitive
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Droop in capacitive region. The unit is V/A." ;
+        rdfs:domain        nc:CurrentDroopControlFunction ;
+        rdfs:label         "droopCapacitive"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CurrentDroopControlFunction.droopInductive
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Droop in inductive region. The unit is V/A." ;
+        rdfs:domain        nc:CurrentDroopControlFunction ;
+        rdfs:label         "droopInductive"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CurrentDroopControlFunction.offsetCapacitive
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Offset in capacitive region." ;
+        rdfs:domain        nc:CurrentDroopControlFunction ;
+        rdfs:label         "offsetCapacitive"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CurrentDroopControlFunction.offsetInductive
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Offset in capacitive region." ;
+        rdfs:domain        nc:CurrentDroopControlFunction ;
+        rdfs:label         "offsetInductive"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CurrentDroopOverride
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Current droop override uses the following logic:\n- When the current exceeds a threshold the device executes the following transitions: 1) When injecting an inductive voltage or in monitoring mode the device tends to inject a voltage proportional to the difference between the line current and the aforementioned threshold. 2) When injecting a capacitive voltage the device transitions to monitoring mode. \n- If the aforementioned proportional voltage is lower than the initial one, the voltage injection remains unchanged. \nCurrent droop override is not applied when the device operates in currentDroop mode." ;
+        rdfs:label              "CurrentDroopOverride"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:CurrentDroopOverride.SSSCController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The SSSC controller to which this CurrentDroopOverride applies to." ;
+        rdfs:domain           nc:CurrentDroopOverride ;
+        rdfs:label            "SSSCController"@en ;
+        rdfs:range            nc:SSSCController ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SSSCController.CurrentDroopOverride ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:CurrentDroopOverride.droopCapacitive
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Droop in capacitive region. The unit is V/A." ;
+        rdfs:domain        nc:CurrentDroopOverride ;
+        rdfs:label         "droopCapacitive"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CurrentDroopOverride.droopInductive
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Droop in inductive region. The unit is V/A." ;
+        rdfs:domain        nc:CurrentDroopOverride ;
+        rdfs:label         "droopInductive"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CurrentDroopOverride.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:CurrentDroopOverride ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CurrentDroopOverride.offsetCapacitiveI
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Offset in capacitive region." ;
+        rdfs:domain        nc:CurrentDroopOverride ;
+        rdfs:label         "offsetCapacitiveI"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CurrentDroopOverride.offsetInductiveI
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Offset in capacitive region." ;
+        rdfs:domain        nc:CurrentDroopOverride ;
+        rdfs:label         "offsetInductiveI"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCBiPole  rdf:type           rdfs:Class ;
+        rdfs:comment            "DC system bipole (IEC 60633), which is part of an DC system consisting of two independently operable DC system poles, which during normal operation, exhibit opposite direct voltage polarities with respect to earth." ;
+        rdfs:label              "DCBiPole"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCBiPole.BipolarDCSystem
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Bipolar DC system that has this DC bipole." ;
+        rdfs:domain           nc:DCBiPole ;
+        rdfs:label            "BipolarDCSystem"@en ;
+        rdfs:range            nc:BipolarDCSystem ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:BipolarDCSystem.DCBiPole ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DCBiPole.DCPole  rdf:type  rdf:Property ;
+        rdfs:comment          "DC pole part of the DC system bipole." ;
+        rdfs:domain           nc:DCBiPole ;
+        rdfs:label            "DCPole"@en ;
+        rdfs:range            nc:DCPole ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DCPole.DCBiPole ;
+        cims:multiplicity     cims:M:1..2 ;
+        cims:stereotype       "NC" .
+
+nc:DCBypassSwitch  rdf:type     rdfs:Class ;
+        rdfs:comment            "By-pass switch (IEC 60633) is a high-speed DC switch connected across each converter valve group in DC schemes using more than one independent converter per pole, designed to close rapidly to bypass a converter group that is being taken out of service and commutate the current back into a valve group that is being taken back in service. A by-pass switch may also be used for prolonged shunting of the bridge(s)." ;
+        rdfs:label              "DCBypassSwitch"@en ;
+        rdfs:subClassOf         nc:DCHighSpeedSwitch ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCCommutationSwitch
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "DC commutation switch (IEC 60633) is a type of high-speed DC switch specifically designed to commutate load current into an alternative parallel current path." ;
+        rdfs:label              "DCCommutationSwitch"@en ;
+        rdfs:subClassOf         nc:DCHighSpeedSwitch ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:DCConverterParallelingSwitch
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Converter paralleling switch (IEC 60633) is a high-speed DC switch connected in series with each converter at the DC terminal in DC schemes where two or more converters are connected in parallel onto a common pole conductor, designed to allow additional converter(s) to be connected in parallel or disconnected without affecting the load current in the other converter." ;
+        rdfs:label              "DCConverterParallelingSwitch"@en ;
+        rdfs:subClassOf         nc:DCHighSpeedSwitch ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCConverterUnit.ACPointOfCommonCoupling
+        rdf:type              rdf:Property ;
+        rdfs:comment          "AC point of common coupling for this DC converter unit." ;
+        rdfs:domain           cim:DCConverterUnit ;
+        rdfs:label            "ACPointOfCommonCoupling"@en ;
+        rdfs:range            nc:ACPointOfCommonCoupling ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ACPointOfCommonCoupling.DCConverterUnit ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:DCConverterUnit.DCPointOfCommonCoupling
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DCNode that is the point of common coupling at DC side of this DCConverterUnit." ;
+        rdfs:domain           cim:DCConverterUnit ;
+        rdfs:label            "DCPointOfCommonCoupling"@en ;
+        rdfs:range            nc:DCPointOfCommonCoupling ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DCPointOfCommonCoupling.DCConverterUnit ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:DCConverterUnit.DCPole
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The DC pole that has this DC converter unit." ;
+        rdfs:domain           cim:DCConverterUnit ;
+        rdfs:label            "DCPole"@en ;
+        rdfs:range            nc:DCPole ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DCPole.DCConverterUnit ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DCConverterUnit.DCSubstation
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC substation that has one or more DC converter units." ;
+        rdfs:domain           cim:DCConverterUnit ;
+        rdfs:label            "DCSubstation"@en ;
+        rdfs:range            nc:DCSubstation ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DCSubstation.DCConverterUnit ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DCCurrentControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "DC current control function is a function block that calculates the operating point of the controlled equipment  to achieve the target current." ;
+        rdfs:label              "DCCurrentControlFunction"@en ;
+        rdfs:subClassOf         nc:ControlFunctionBlock ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCCurrentControlFunction.droop
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Droop constant. The pu value is obtained as D [kV/MW] x Sb / Ubdc. The attribute shall be a positive value." ;
+        rdfs:domain        nc:DCCurrentControlFunction ;
+        rdfs:label         "droop"@en ;
+        cims:dataType      cim:PU ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCCurrentControlFunction.droopCompensation
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Compensation constant. Used to compensate for voltage drop when controlling voltage at a distant bus. The attribute shall be a positive value." ;
+        rdfs:domain        nc:DCCurrentControlFunction ;
+        rdfs:label         "droopCompensation"@en ;
+        cims:dataType      cim:Resistance ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCEarthReturnTransferSwitch
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Earth return transfer switch (IEC 60633) DC commutation switch used to transfer DC current from a metallic return path to an earth return path. In some applications, this function is performed by a by-pass switch. Although the term \"earth return transfer breaker\" has been widely used in the industry for many years, it is misleading since such switches have no ability to interrupt fault current." ;
+        rdfs:label              "DCEarthReturnTransferSwitch"@en ;
+        rdfs:subClassOf         nc:DCCommutationSwitch ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCHarmonicFilter  rdf:type   rdfs:Class ;
+        rdfs:comment            "DC harmonic filter (IEC 60633) is a filter which, in conjunction with the DC reactor(s) and with the DC surge capacitor(s), if any, serves the primary function of reducing (current or voltage) ripple on the DC transmission line and/or earth electrode line." ;
+        rdfs:label              "DCHarmonicFilter"@en ;
+        rdfs:subClassOf         cim:DCSeriesDevice ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCHighSpeedSwitch  rdf:type  rdfs:Class ;
+        rdfs:comment            "High-speed DC switch (IEC 60633) is a type of switchgear used on a DC scheme, required to open or close rapidly (&lt; 1 s), including in some cases the need to commutate load current into a parallel conducting path, but with no requirement to interrupt fault or load current. DC switchgear is usually based on a single-phase unit of an AC circuit-breaker, appropriately modified for their DC applications. Their capabilities to perform faster opening and closing than disconnect switches are used but the function of breaking short-circuit currents is not required." ;
+        rdfs:label              "DCHighSpeedSwitch"@en ;
+        rdfs:subClassOf         cim:DCSwitch ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:DCLine.DCPole  rdf:type    rdf:Property ;
+        rdfs:comment          "The DC pole that has this DC line." ;
+        rdfs:domain           cim:DCLine ;
+        rdfs:label            "DCPole"@en ;
+        rdfs:range            nc:DCPole ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DCPole.DCLine ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DCLineParallelingSwitch
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Line paralleling switch (IEC 60633) DC commutation switch placed in series with one or more high-voltage pole conductors, allowing two or more lines to be connected in parallel or to revert to single-line operation while conducting load current." ;
+        rdfs:label              "DCLineParallelingSwitch"@en ;
+        rdfs:subClassOf         nc:DCCommutationSwitch ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCMetalicReturnSwitch
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Metallic return transfer switch (IEC 60633) is a DC commutation switch used to transfer DC current from an earth return path to a metallic return path. Although the term \"metallic return transfer breaker\" has been widely used in the industry for many years, it is misleading since such switches have no ability to interrupt fault current." ;
+        rdfs:label              "DCMetalicReturnSwitch"@en ;
+        rdfs:subClassOf         nc:DCCommutationSwitch ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCNeutralBusGroundingSwitch
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Neutral bus grounding switch (IEC 60633) or a neutral bus earthing switch is a DC commutation switch connected from the neutral bus to the station earth mat on a bipolar DC scheme, designed to provide a temporary earth connection in the event of an open circuit fault on the electrode line until the imbalance of current between the two poles can be reduced to a safe minimum level or the electrode line connection can be restored." ;
+        rdfs:label              "DCNeutralBusGroundingSwitch"@en ;
+        rdfs:subClassOf         nc:DCCommutationSwitch ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCNeutralBusSwitch
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Neutral bus switch (IEC 60633) is a DC commutation switch connected in series with the neutral bus on a bipolar DC scheme, designed to commutate current out of the pole conductor or neutral bus and into the electrode line or dedicated metallic return conductor or earth in response to a fault in a converter or neutral bus." ;
+        rdfs:label              "DCNeutralBusSwitch"@en ;
+        rdfs:subClassOf         nc:DCCommutationSwitch ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCNode.DCPointOfCommonCoupling
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Identifies that this DC node is a point of common coupling DC." ;
+        rdfs:domain           cim:DCNode ;
+        rdfs:label            "DCPointOfCommonCoupling"@en ;
+        rdfs:range            nc:DCPointOfCommonCoupling ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DCPointOfCommonCoupling.DCNode ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DCPointOfCommonCoupling
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Point of interconnection of the DC converter station to the DC transmission line (IEC 60633)." ;
+        rdfs:label              "DCPointOfCommonCoupling"@en ;
+        rdfs:subClassOf         nc:PointOfCommonCoupling ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCPointOfCommonCoupling.DCConverterUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC converter unit that has DC point of common coupling." ;
+        rdfs:domain           nc:DCPointOfCommonCoupling ;
+        rdfs:label            "DCConverterUnit"@en ;
+        rdfs:range            cim:DCConverterUnit ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DCConverterUnit.DCPointOfCommonCoupling ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DCPointOfCommonCoupling.DCNode
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The DCNode that is a point of common coupling DC." ;
+        rdfs:domain           nc:DCPointOfCommonCoupling ;
+        rdfs:label            "DCNode"@en ;
+        rdfs:range            cim:DCNode ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DCNode.DCPointOfCommonCoupling ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:DCPole  rdf:type             rdfs:Class ;
+        rdfs:comment            "The direct current (DC) system pole (IEC 60633) is part of a DC system consisting of all the equipment in the DC substations and the interconnecting transmission lines, if any, which during normal operation exhibit a common direct voltage polarity with respect to earth." ;
+        rdfs:label              "DCPole"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCPole.AsymmetricMonopolarDCSystem
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Asymmetric monopolar DC system that has this DC pole." ;
+        rdfs:domain           nc:DCPole ;
+        rdfs:label            "AsymmetricMonopolarDCSystem"@en ;
+        rdfs:range            nc:MonopolarDCSystem ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:MonopolarDCSystem.DCPole ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DCPole.DCBiPole  rdf:type  rdf:Property ;
+        rdfs:comment          "DC system bipole that has two independently operatable DC system poles." ;
+        rdfs:domain           nc:DCPole ;
+        rdfs:label            "DCBiPole"@en ;
+        rdfs:range            nc:DCBiPole ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DCBiPole.DCPole ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DCPole.DCConverterUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The DC converter unit that relates to this DC pole." ;
+        rdfs:domain           nc:DCPole ;
+        rdfs:label            "DCConverterUnit"@en ;
+        rdfs:range            cim:DCConverterUnit ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DCConverterUnit.DCPole ;
+        cims:multiplicity     cims:M:0..2 ;
+        cims:stereotype       "NC" .
+
+nc:DCPole.DCLine  rdf:type    rdf:Property ;
+        rdfs:comment          "The DC line that is related to this DC pole." ;
+        rdfs:domain           nc:DCPole ;
+        rdfs:label            "DCLine"@en ;
+        rdfs:range            cim:DCLine ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DCLine.DCPole ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DCPole.DCTieCorridor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The DCTieCorridor that has this DC pole." ;
+        rdfs:domain           nc:DCPole ;
+        rdfs:label            "DCTieCorridor"@en ;
+        rdfs:range            nc:DCTieCorridor ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DCTieCorridor.DCPole ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DCPole.DirectCurrentPoleController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC pole controller that controls this DC pole." ;
+        rdfs:domain           nc:DCPole ;
+        rdfs:label            "DirectCurrentPoleController"@en ;
+        rdfs:range            nc:DirectCurrentPoleController ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DirectCurrentPoleController.DCPole ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DCPole.normalParticipationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Normal participation factor describing the entity part of the active power provided by a collection of entities (e.g. an active power forecast to a collection of entities is divided to each of the member entity according to the participation factor). Must be a positive value.\nIn the case of a sharing strategy, the distribution is following entities value (V) equals aggregated value (T) divided by sum of participation factors (PF), i.e. V=T/sum(PF). \nIn the case of priority strategy, the item with the lowest number gets allocated energy first." ;
+        rdfs:domain        nc:DCPole ;
+        rdfs:label         "normalParticipationFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCSmoothingReactor
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Reactor (IEC 60633) connected in series with a converter unit or converter units on the DC side for the primary purpose of smoothing the direct current and reducing current transients." ;
+        rdfs:label              "DCSmoothingReactor"@en ;
+        rdfs:subClassOf         cim:DCSeriesDevice ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCSmoothingReactorArrester
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Arrester (IEC 60633) connected between the terminals of a smoothing reactor." ;
+        rdfs:label              "DCSmoothingReactorArrester"@en ;
+        rdfs:subClassOf         cim:DCSeriesDevice ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCSubstation  rdf:type       rdfs:Class ;
+        rdfs:comment            "DC substation or DC converter station (IEC 60633) is part of an DC system which consists of one or more converter units installed in a single location together with buildings, reactors, filters, reactive power supply, control, monitoring, protective, measuring and auxiliary equipment. A DC substation forming part of an DC transmission system may be referred to as an DC transmission substation." ;
+        rdfs:label              "DCSubstation"@en ;
+        rdfs:subClassOf         cim:DCEquipmentContainer ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCSubstation.DCConverterUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC converter unit that belongs to this DC substation." ;
+        rdfs:domain           nc:DCSubstation ;
+        rdfs:label            "DCConverterUnit"@en ;
+        rdfs:range            cim:DCConverterUnit ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DCConverterUnit.DCSubstation ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:DCSubstation.DCSubstationBipole
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC substation bipole which is part of the DC substation. " ;
+        rdfs:domain           nc:DCSubstation ;
+        rdfs:label            "DCSubstationBipole"@en ;
+        rdfs:range            nc:DCSubstationBipole ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DCSubstationBipole.DCSubstation ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:DCSubstation.DCSubstationPole
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC substation pole which is part of the DC substation. " ;
+        rdfs:domain           nc:DCSubstation ;
+        rdfs:label            "DCSubstationPole"@en ;
+        rdfs:range            nc:DCSubstationPole ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DCSubstationPole.DCSubstation ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:DCSubstation.Substation
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Substation that contains this DC susbstation." ;
+        rdfs:domain           nc:DCSubstation ;
+        rdfs:label            "Substation"@en ;
+        rdfs:range            cim:Substation ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Substation.DCSubstation ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DCSubstation.isTapping
+        rdf:type           rdf:Property ;
+        rdfs:comment       "DC tapping substation (IEC 60633) is a DC substation, mainly used for inversion, with a rating which is a small fraction of that of the rectifier(s) in the system." ;
+        rdfs:domain        nc:DCSubstation ;
+        rdfs:label         "isTapping"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCSubstationBipole
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Part of a bipolar DC system (IEC 60633) contained within a DC substation." ;
+        rdfs:label              "DCSubstationBipole"@en ;
+        rdfs:subClassOf         cim:DCEquipmentContainer ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCSubstationBipole.DCSubstation
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC substation that contains this DC substation bipole part." ;
+        rdfs:domain           nc:DCSubstationBipole ;
+        rdfs:label            "DCSubstation"@en ;
+        rdfs:range            nc:DCSubstation ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DCSubstation.DCSubstationBipole ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DCSubstationBipole.DirectCurrentSubstationBipoleController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC substation bipole controller controlling this DC substation bipole." ;
+        rdfs:domain           nc:DCSubstationBipole ;
+        rdfs:label            "DirectCurrentSubstationBipoleController"@en ;
+        rdfs:range            nc:DirectCurrentSubstationBipoleController ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DirectCurrentSubstationBipoleController.DCSubstationBipole ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DCSubstationPole  rdf:type   rdfs:Class ;
+        rdfs:comment            "Part of an DC system pole (IEC 60633) which is contained within a DC substation." ;
+        rdfs:label              "DCSubstationPole"@en ;
+        rdfs:subClassOf         cim:DCEquipmentContainer ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCSubstationPole.DCSubstation
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC substation that contains this DC substation pole part." ;
+        rdfs:domain           nc:DCSubstationPole ;
+        rdfs:label            "DCSubstation"@en ;
+        rdfs:range            nc:DCSubstation ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DCSubstation.DCSubstationPole ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DCSubstationPole.DirectCurrentSubstationPoleController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC substation pole controller controlling this DC substation pole." ;
+        rdfs:domain           nc:DCSubstationPole ;
+        rdfs:label            "DirectCurrentSubstationPoleController"@en ;
+        rdfs:range            nc:DirectCurrentSubstationPoleController ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DirectCurrentSubstationPoleController.DCSubstationPole ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DCSystem  rdf:type           rdfs:Class ;
+        rdfs:comment            "Electrical power system which transfers energy in the form of direct current between two or more AC buses (defined in IEC 60633)." ;
+        rdfs:label              "DCSystem"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:DCSystem.directionKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Direction kind of the DC system." ;
+        rdfs:domain        nc:DCSystem ;
+        rdfs:label         "directionKind"@en ;
+        rdfs:range         nc:DCSystemDirectionKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCSystem.transmissionKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Transmission kind of the DC system." ;
+        rdfs:domain        nc:DCSystem ;
+        rdfs:label         "transmissionKind"@en ;
+        rdfs:range         nc:DCSystemTransmissionKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCSystemDirectionKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Direction kinds of the DC system." ;
+        rdfs:label              "DCSystemDirectionKind"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:DCSystemDirectionKind.bidirectional
+        rdf:type         nc:DCSystemDirectionKind ;
+        rdfs:comment     "Bidirectional DC system used for the transfer of energy in either direction. According to IEC 60633 a multiterminal DC system is bidirectional if one or more substations are bidirectional." ;
+        rdfs:label       "bidirectional"@en ;
+        cims:stereotype  "enum" .
+
+nc:DCSystemDirectionKind.unidirectional
+        rdf:type         nc:DCSystemDirectionKind ;
+        rdfs:comment     "Unidirectional DC system used for the transfer of energy in only one direction. According to IEC 60633, most DC systems are inherently bidirectional. However, some systems may be optimized to transmit power in only one preferred direction. Such systems may still be considered as \"bidirectional\"." ;
+        rdfs:label       "unidirectional"@en ;
+        cims:stereotype  "enum" .
+
+nc:DCSystemTransmissionKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "DC system transmission kind." ;
+        rdfs:label              "DCSystemTransmissionKind"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:DCSystemTransmissionKind.backToBack
+        rdf:type         nc:DCSystemTransmissionKind ;
+        rdfs:comment     "DC back-to-back system (IEC 60633) is a DC system which transfers energy between AC buses at the same location." ;
+        rdfs:label       "backToBack"@en ;
+        cims:stereotype  "enum" .
+
+nc:DCSystemTransmissionKind.multiTerminal
+        rdf:type         nc:DCSystemTransmissionKind ;
+        rdfs:comment     "Multiterminal DC transmission system (IEC 60633) consisting of more than two separated DC substations and the interconnecting DC transmission lines." ;
+        rdfs:label       "multiTerminal"@en ;
+        cims:stereotype  "enum" .
+
+nc:DCSystemTransmissionKind.twoTerminal
+        rdf:type         nc:DCSystemTransmissionKind ;
+        rdfs:comment     "Two-terminal DC transmission system (IEC 60633), consisting of two DC substations and the connecting DC transmission line(s)." ;
+        rdfs:label       "twoTerminal"@en ;
+        cims:stereotype  "enum" .
+
+nc:DCTieCorridor  rdf:type      rdfs:Class ;
+        rdfs:comment            "A collection of one or more direct current poles that connect two different control areas." ;
+        rdfs:label              "DCTieCorridor"@en ;
+        rdfs:subClassOf         nc:TieCorridor ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCTieCorridor.DCPole
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The DCPole which is part of the DC corridor." ;
+        rdfs:domain           nc:DCTieCorridor ;
+        rdfs:label            "DCPole"@en ;
+        rdfs:range            nc:DCPole ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DCPole.DCTieCorridor ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:DCTieCorridor.DirectCurrentMasterController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Direct current master controller for this DCTieCorridor." ;
+        rdfs:domain           nc:DCTieCorridor ;
+        rdfs:label            "DirectCurrentMasterController"@en ;
+        rdfs:range            nc:DirectCurrentMasterController ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DirectCurrentMasterController.DCTieCorridor ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DCTieCorridor.SchedulingArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The scheduling area that has this DC tie corridor." ;
+        rdfs:domain           nc:DCTieCorridor ;
+        rdfs:label            "SchedulingArea"@en ;
+        rdfs:range            nc:SchedulingArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SchedulingArea.DCTieCorridor ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DCTieCorridor.maxRegulatingReserve
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum regulating reserve." ;
+        rdfs:domain        nc:DCTieCorridor ;
+        rdfs:label         "maxRegulatingReserve"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCTieCorridor.minRegulatingReserve
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Minimum regulating reserve." ;
+        rdfs:domain        nc:DCTieCorridor ;
+        rdfs:label         "minRegulatingReserve"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCTieCorridor.rampingKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Ramping principle is used to define a transition from one scheduled value to next one." ;
+        rdfs:domain        nc:DCTieCorridor ;
+        rdfs:label         "rampingKind"@en ;
+        rdfs:range         nc:RampingPrincipleKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCVoltageControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "DC voltage control function is a function block that calculate the operating point of the controlled equipment to achieve the target voltage." ;
+        rdfs:label              "DCVoltageControlFunction"@en ;
+        rdfs:subClassOf         nc:ControlFunctionBlock ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DirectCurrentBipoleController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "DC system bipole control that is the control system of a bipole in accordance with IEC 60633." ;
+        rdfs:label              "DirectCurrentBipoleController"@en ;
+        rdfs:subClassOf         nc:DirectCurrentEquipmentController ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DirectCurrentBipoleController.DirectCurrentMasterController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Direct current master controller which has direct current bipole controllers." ;
+        rdfs:domain           nc:DirectCurrentBipoleController ;
+        rdfs:label            "DirectCurrentMasterController"@en ;
+        rdfs:range            nc:DirectCurrentMasterController ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DirectCurrentMasterController.DirectCurrentBipoleController ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DirectCurrentBipoleController.DirectCurrentPoleController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC pole controller that is controlled by a DC bipole controller." ;
+        rdfs:domain           nc:DirectCurrentBipoleController ;
+        rdfs:label            "DirectCurrentPoleController"@en ;
+        rdfs:range            nc:DirectCurrentPoleController ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DirectCurrentPoleController.DirectCurrentBipoleController ;
+        cims:multiplicity     cims:M:2..2 ;
+        cims:stereotype       "NC" .
+
+nc:DirectCurrentCircuit
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A direct current circuit is a circuit consists of direct current equipment." ;
+        rdfs:label              "DirectCurrentCircuit"@en ;
+        rdfs:subClassOf         nc:Circuit ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DirectCurrentEquipmentController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Direct current equipment controller used to control different parts of the hierarchical structure of the DC control system defined by IEC 60633." ;
+        rdfs:label              "DirectCurrentEquipmentController"@en ;
+        rdfs:subClassOf         nc:EquipmentController ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:DirectCurrentMasterController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Direct current system control is a control system which governs the operation of an entire DC system consisting of more than one DC substation and performs those functions of controlling, monitoring and protection which require information from more than one substation. This can also be a multiterminal control which is a DC system control for more that two DC substations or a DC master control, which is a general concept for control coordination of a DC system. The DC master control may be implemented at the bipole and/or pole level as defined in IEC 60633. \nThe DC system control/multiterminal control/master control is part of the hierarchical structure of an HVDC control system that has an integrated AC/DC system control as the highest level of control which governs the integrated operation of AC and DC systems of a power system. This control system is under the responsibility of the system operator." ;
+        rdfs:label              "DirectCurrentMasterController"@en ;
+        rdfs:subClassOf         nc:DirectCurrentEquipmentController ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DirectCurrentMasterController.DCTieCorridor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DCTieCorridor controlled by this direct current master controller." ;
+        rdfs:domain           nc:DirectCurrentMasterController ;
+        rdfs:label            "DCTieCorridor"@en ;
+        rdfs:range            nc:DCTieCorridor ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DCTieCorridor.DirectCurrentMasterController ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DirectCurrentMasterController.DirectCurrentBipoleController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Direct current bipole controller which belongs to a direct current master controller." ;
+        rdfs:domain           nc:DirectCurrentMasterController ;
+        rdfs:label            "DirectCurrentBipoleController"@en ;
+        rdfs:range            nc:DirectCurrentBipoleController ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DirectCurrentBipoleController.DirectCurrentMasterController ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:DirectCurrentMasterController.DirectCurrentPoleController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC pole controller that is controlled by this DC master controller." ;
+        rdfs:domain           nc:DirectCurrentMasterController ;
+        rdfs:label            "DirectCurrentPoleController"@en ;
+        rdfs:range            nc:DirectCurrentPoleController ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DirectCurrentPoleController.DirectCurrentMasterController ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:DirectCurrentMasterController.DirectCurrentSubstationController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC substation controller controlled by a multiterminal control." ;
+        rdfs:domain           nc:DirectCurrentMasterController ;
+        rdfs:label            "DirectCurrentSubstationController"@en ;
+        rdfs:range            nc:DirectCurrentSubstationController ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DirectCurrentSubstationController.MultiterminalControl ;
+        cims:multiplicity     cims:M:2..n ;
+        cims:stereotype       "NC" .
+
+nc:DirectCurrentPoleController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "DC system pole control, which is the control system of a pole in accordance with IEC 60633." ;
+        rdfs:label              "DirectCurrentPoleController"@en ;
+        rdfs:subClassOf         nc:DirectCurrentEquipmentController ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DirectCurrentPoleController.ACDCConverterController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "ACDC converter controller that is controlled by a DC pole controller." ;
+        rdfs:domain           nc:DirectCurrentPoleController ;
+        rdfs:label            "ACDCConverterController"@en ;
+        rdfs:range            nc:ACDCConverterController ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ACDCConverterController.DirectCurrentPoleController ;
+        cims:multiplicity     cims:M:2..2 ;
+        cims:stereotype       "NC" .
+
+nc:DirectCurrentPoleController.DCPole
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC pole that is controlled by a DC pole controller." ;
+        rdfs:domain           nc:DirectCurrentPoleController ;
+        rdfs:label            "DCPole"@en ;
+        rdfs:range            nc:DCPole ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DCPole.DirectCurrentPoleController ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:DirectCurrentPoleController.DirectCurrentBipoleController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC bipole controller that controls this DC pole controller." ;
+        rdfs:domain           nc:DirectCurrentPoleController ;
+        rdfs:label            "DirectCurrentBipoleController"@en ;
+        rdfs:range            nc:DirectCurrentBipoleController ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DirectCurrentBipoleController.DirectCurrentPoleController ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DirectCurrentPoleController.DirectCurrentMasterController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC master controller that has a DC pole controller." ;
+        rdfs:domain           nc:DirectCurrentPoleController ;
+        rdfs:label            "DirectCurrentMasterController"@en ;
+        rdfs:range            nc:DirectCurrentMasterController ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DirectCurrentMasterController.DirectCurrentPoleController ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DirectCurrentSubstationBipoleController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Control system of a substation bipole (IEC 60633)." ;
+        rdfs:label              "DirectCurrentSubstationBipoleController"@en ;
+        rdfs:subClassOf         nc:DirectCurrentSubstationController ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DirectCurrentSubstationBipoleController.DCSubstationBipole
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC substation bipole that is controlled by a DC substation bipole controller." ;
+        rdfs:domain           nc:DirectCurrentSubstationBipoleController ;
+        rdfs:label            "DCSubstationBipole"@en ;
+        rdfs:range            nc:DCSubstationBipole ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DCSubstationBipole.DirectCurrentSubstationBipoleController ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:DirectCurrentSubstationController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Control system used for the controlling, monitoring and protection within a DC substation (IEC 60633). A DC substation control may be implemented at the bipole and/or pole level and may be referred to as local control." ;
+        rdfs:label              "DirectCurrentSubstationController"@en ;
+        rdfs:subClassOf         nc:DirectCurrentEquipmentController ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:DirectCurrentSubstationController.MultiterminalControl
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Multiterminal control that controls more than two DC substation controllers." ;
+        rdfs:domain           nc:DirectCurrentSubstationController ;
+        rdfs:label            "MultiterminalControl"@en ;
+        rdfs:range            nc:DirectCurrentMasterController ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DirectCurrentMasterController.DirectCurrentSubstationController ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DirectCurrentSubstationPoleController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Control system of a substation pole (IEC 60633)." ;
+        rdfs:label              "DirectCurrentSubstationPoleController"@en ;
+        rdfs:subClassOf         nc:DirectCurrentSubstationController ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DirectCurrentSubstationPoleController.DCSubstationPole
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC substation pole that is controlled by a DC substation pole controller." ;
+        rdfs:domain           nc:DirectCurrentSubstationPoleController ;
+        rdfs:label            "DCSubstationPole"@en ;
+        rdfs:range            nc:DCSubstationPole ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DCSubstationPole.DirectCurrentSubstationPoleController ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:DirectCurrentSystemOperator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "System operator of the direct current pole. There are typically one or two system operators that are operating either the control area at one side or the control areas at both sides of the direct current pole. In some cases it is operated by an operator from the connected control areas." ;
+        rdfs:label              "DirectCurrentSystemOperator"@en ;
+        rdfs:subClassOf         nc:SystemOperator ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DistributionSystemOperator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A system operator that is responsible for operating of energy distribution network from transmission level down to low voltage levels including the connection to household." ;
+        rdfs:label              "DistributionSystemOperator"@en ;
+        rdfs:subClassOf         nc:SystemOperator ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DurationOverloadLimitCurve
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A curve or functional relationship between\n- the overload duration independent variable (X-axis), and \n- temporary overloading (TATL) limiting dependent (Y-axis) variables." ;
+        rdfs:label              "DurationOverloadLimitCurve"@en ;
+        rdfs:subClassOf         nc:LimitDependencyCurve ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DurationOverloadLimitCurve.OperationalLimitType
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The operational limit type that has this temporary duration overload limit curve." ;
+        rdfs:domain           nc:DurationOverloadLimitCurve ;
+        rdfs:label            "OperationalLimitType"@en ;
+        rdfs:range            cim:OperationalLimitType ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:OperationalLimitType.TemporaryDurationOverloadLimitCurve ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EnergyAlignmentCoordinator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A role that is responsible for alignment of forecast and schedule energy to a given energy coordination region." ;
+        rdfs:label              "EnergyAlignmentCoordinator"@en ;
+        rdfs:subClassOf         nc:SystemOperationCoordinator ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EnergyAlignmentCoordinator.EnergyCoordinationRegion
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The energy coordination region that has this energy alignment coordinator." ;
+        rdfs:domain           nc:EnergyAlignmentCoordinator ;
+        rdfs:label            "EnergyCoordinationRegion"@en ;
+        rdfs:range            nc:EnergyCoordinationRegion ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EnergyCoordinationRegion.EnergyAlignmentCoordinator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EnergyBlockComponent
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Energy block component where the energy group is distributed according to the energy block order of each energy component in an energy group." ;
+        rdfs:label              "EnergyBlockComponent"@en ;
+        rdfs:subClassOf         nc:EnergyComponent ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EnergyBlockComponent.EnergyBlockOrder
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The energy block order for this energy block component." ;
+        rdfs:domain           nc:EnergyBlockComponent ;
+        rdfs:label            "EnergyBlockOrder"@en ;
+        rdfs:range            nc:EnergyBlockOrder ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EnergyBlockOrder.EnergyBlockComponent ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:EnergyBlockOrder  rdf:type   rdfs:Class ;
+        rdfs:comment            "The energy block order is a block (an amount) of energy that forms the sequence of orders that are going to be distributed to an energy block component." ;
+        rdfs:label              "EnergyBlockOrder"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EnergyBlockOrder.EnergyBlockComponent
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The energy block component that has this energy block order." ;
+        rdfs:domain           nc:EnergyBlockOrder ;
+        rdfs:label            "EnergyBlockComponent"@en ;
+        rdfs:range            nc:EnergyBlockComponent ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EnergyBlockComponent.EnergyBlockOrder ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:EnergyBlockOrder.normalParticipationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Normal participation factor." ;
+        rdfs:domain        nc:EnergyBlockOrder ;
+        rdfs:label         "normalParticipationFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EnergyBlockOrder.normalSequence
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Normal sequence represents the local order of the power block order.\n\nThe sequence order for a given block dispatch instruction. The sequence number need to be unique for a given block dispatch instruction, e.g. two order in the same instruction cannot have the same sequence. " ;
+        rdfs:domain        nc:EnergyBlockOrder ;
+        rdfs:label         "normalSequence"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EnergyBlockOrder.powerDuration
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Duration for the active power." ;
+        rdfs:domain        nc:EnergyBlockOrder ;
+        rdfs:label         "powerDuration"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EnergyComponent  rdf:type    rdfs:Class ;
+        rdfs:comment            "The energy component for a producer or a consumer that has the same energy characteristic, e.g. fuel type and technology." ;
+        rdfs:label              "EnergyComponent"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:EnergyComponent.EnergyConsumer
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The energy consumer that relates to this energy component." ;
+        rdfs:domain           nc:EnergyComponent ;
+        rdfs:label            "EnergyConsumer"@en ;
+        rdfs:range            cim:EnergyConsumer ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EnergyConsumer.EnergyComponent ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:EnergyComponent.EnergyGroup
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The energy group that has this energy component." ;
+        rdfs:domain           nc:EnergyComponent ;
+        rdfs:label            "EnergyGroup"@en ;
+        rdfs:range            nc:EnergyGroup ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EnergyGroup.EnergyComponent ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:EnergyComponent.GeneratingUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The generating unit that is part of this energy component." ;
+        rdfs:domain           nc:EnergyComponent ;
+        rdfs:label            "GeneratingUnit"@en ;
+        rdfs:range            cim:GeneratingUnit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GeneratingUnit.EnergyComponent ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:EnergyComponent.HydroPump
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The hydro pump that relates to this energy component." ;
+        rdfs:domain           nc:EnergyComponent ;
+        rdfs:label            "HydroPump"@en ;
+        rdfs:range            cim:HydroPump ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:HydroPump.EnergyComponent ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:EnergyComponent.PowerElectronicsUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The power electronics unit that relates to this energy component." ;
+        rdfs:domain           nc:EnergyComponent ;
+        rdfs:label            "PowerElectronicsUnit"@en ;
+        rdfs:range            cim:PowerElectronicsUnit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerElectronicsUnit.EnergyComponent ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:EnergyConsumer.AreaDispatchableUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Area dispatchable unit that has this energy consumer." ;
+        rdfs:domain           cim:EnergyConsumer ;
+        rdfs:label            "AreaDispatchableUnit"@en ;
+        rdfs:range            nc:AreaDispatchableUnit ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AreaDispatchableUnit.EnergyConsumer ;
+        cims:multiplicity     cims:M:0..1 .
+
+nc:EnergyConsumer.EnergyComponent
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The energy component that has this energy consumer." ;
+        rdfs:domain           cim:EnergyConsumer ;
+        rdfs:label            "EnergyComponent"@en ;
+        rdfs:range            nc:EnergyComponent ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EnergyComponent.EnergyConsumer ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EnergyConsumer.maxEconomicP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum high economic active power limit, that should not exceed the maximum operating active power limit." ;
+        rdfs:domain        cim:EnergyConsumer ;
+        rdfs:label         "maxEconomicP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EnergyConsumer.minEconomicP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Low economic active power limit that shall be greater than or equal to the minimum operating active power limit." ;
+        rdfs:domain        cim:EnergyConsumer ;
+        rdfs:label         "minEconomicP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EnergyConsumer.normalParticipationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Participation factor describing the entity part of the active power provided by a collection of entities (e.g. an active power forecast to a collection of entities is divided to each of the member entity according to the participation factor). Must be a positive value.\nIn the case of a sharing strategy, the distribution is following entities value (V) equals aggregated value (T) divided by sum of participation factors (PF), i.e. V=T/sum(PF). \nIn the case of priority strategy, the item with the lowest number gets allocated energy first." ;
+        rdfs:domain        cim:EnergyConsumer ;
+        rdfs:label         "normalParticipationFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EnergyCoordinationRegion
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A region that has a common organisation or a service that is responsible for alignment of forecast and scheduling of energy." ;
+        rdfs:label              "EnergyCoordinationRegion"@en ;
+        rdfs:subClassOf         nc:Region ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EnergyCoordinationRegion.EnergyAlignmentCoordinator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The energy alignment coordinator that operates this energy coordination region." ;
+        rdfs:domain           nc:EnergyCoordinationRegion ;
+        rdfs:label            "EnergyAlignmentCoordinator"@en ;
+        rdfs:range            nc:EnergyAlignmentCoordinator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EnergyAlignmentCoordinator.EnergyCoordinationRegion ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:EnergyCoordinationRegion.SchedulingArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The scheduling area that is part of this energy coordination region." ;
+        rdfs:domain           nc:EnergyCoordinationRegion ;
+        rdfs:label            "SchedulingArea"@en ;
+        rdfs:range            nc:SchedulingArea ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:SchedulingArea.EnergyCoordinationRegion ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EnergyGroup  rdf:type        rdfs:Class ;
+        rdfs:comment            "An energy group is an aggregation of energy components which have the same energy characteristic, e.g. fuel type and technology. It can be used to allocate energy. " ;
+        rdfs:label              "EnergyGroup"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EnergyGroup.EnergyComponent
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The energy component that is part of this power group." ;
+        rdfs:domain           nc:EnergyGroup ;
+        rdfs:label            "EnergyComponent"@en ;
+        rdfs:range            nc:EnergyComponent ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EnergyComponent.EnergyGroup ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EnergyGroup.EnergyType
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The energy type that the energy group are defined by." ;
+        rdfs:domain           nc:EnergyGroup ;
+        rdfs:label            "EnergyType"@en ;
+        rdfs:range            nc:EnergyType ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EnergyType.EnergyGroup ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:EnergyGroup.SchedulingArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The scheduling area that has this energy group." ;
+        rdfs:domain           nc:EnergyGroup ;
+        rdfs:label            "SchedulingArea"@en ;
+        rdfs:range            nc:SchedulingArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SchedulingArea.EnergyGroup ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:EnergyGroup.normalParticipationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Normal participation factor for the power group in relation to scheduling area. Must be a positive value." ;
+        rdfs:domain        nc:EnergyGroup ;
+        rdfs:label         "normalParticipationFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EnergyGroup.powerDuration
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Duration for the active power." ;
+        rdfs:domain        nc:EnergyGroup ;
+        rdfs:label         "powerDuration"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EnergyKind  rdf:type         rdfs:Class ;
+        rdfs:comment            "Categories of energy used for energy groups." ;
+        rdfs:label              "EnergyKind"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:EnergyKind.battery
+        rdf:type         nc:EnergyKind ;
+        rdfs:comment     "Battery storage." ;
+        rdfs:label       "battery"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyKind.biomass
+        rdf:type         nc:EnergyKind ;
+        rdfs:comment     "Biomass." ;
+        rdfs:label       "biomass"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyKind.bufferConsumption
+        rdf:type         nc:EnergyKind ;
+        rdfs:comment     "Flexibility in operation but bound to some buffering capability e.g. battery, electrical vehicle, cooling system, freezer." ;
+        rdfs:label       "bufferConsumption"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyKind.fossil  rdf:type  nc:EnergyKind ;
+        rdfs:comment     "Fossil." ;
+        rdfs:label       "fossil"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyKind.geothermal
+        rdf:type         nc:EnergyKind ;
+        rdfs:comment     "Geothermal." ;
+        rdfs:label       "geothermal"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyKind.hydroPump
+        rdf:type         nc:EnergyKind ;
+        rdfs:comment     "Hydro pump." ;
+        rdfs:label       "hydroPump"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyKind.hydroRunOfRiver
+        rdf:type         nc:EnergyKind ;
+        rdfs:comment     "Hydro run of river." ;
+        rdfs:label       "hydroRunOfRiver"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyKind.hydroWaterReservoir
+        rdf:type         nc:EnergyKind ;
+        rdfs:comment     "Hydro water reservoir." ;
+        rdfs:label       "hydroWaterReservoir"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyKind.marine  rdf:type  nc:EnergyKind ;
+        rdfs:comment     "Marine." ;
+        rdfs:label       "marine"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyKind.nuclear
+        rdf:type         nc:EnergyKind ;
+        rdfs:comment     "Nuclear." ;
+        rdfs:label       "nuclear"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyKind.other  rdf:type  nc:EnergyKind ;
+        rdfs:comment     "Other." ;
+        rdfs:label       "other"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyKind.solar  rdf:type  nc:EnergyKind ;
+        rdfs:comment     "Solar." ;
+        rdfs:label       "solar"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyKind.timeShiftConsumption
+        rdf:type         nc:EnergyKind ;
+        rdfs:comment     "Operation can be shifted in time but can have a deadline e.g. washing machine, dishwasher." ;
+        rdfs:label       "timeShiftConsumption"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyKind.unconstrainedConsumption
+        rdf:type         nc:EnergyKind ;
+        rdfs:comment     "Consumption is not constrained by any buffer and provides full flexibility. It is difficult to measure and to provide forecast. The consumption can be provided by local production. e.g. gas generator, diesel generator wood fire, etc." ;
+        rdfs:label       "unconstrainedConsumption"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyKind.uncontrollableConsumption
+        rdf:type         nc:EnergyKind ;
+        rdfs:comment     "Consumption where there is no flexibility and it is measurable and under possibility to provide a forecast. e.g. TV, indoor lightning." ;
+        rdfs:label       "uncontrollableConsumption"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyKind.waste  rdf:type  nc:EnergyKind ;
+        rdfs:comment     "Waste." ;
+        rdfs:label       "waste"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyKind.wind  rdf:type  nc:EnergyKind ;
+        rdfs:comment     "Wind." ;
+        rdfs:label       "wind"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergySourceReference
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "An energy source reference refers to a set of  fuel types characteristic for reporting, e.g. European Energy Certificate System (EECS). The kind of energy should be possible to be linked with different type of energy forecast, e.g. wind production for a given area based on wind forecast." ;
+        rdfs:label              "EnergySourceReference"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:EnergySourceReference.EnergyTypeReference
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Energy type reference which belong to an energy source reference." ;
+        rdfs:domain           nc:EnergySourceReference ;
+        rdfs:label            "EnergyTypeReference"@en ;
+        rdfs:range            nc:EnergyType ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EnergyType.EnergySourceReference ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EnergyType  rdf:type         rdfs:Class ;
+        rdfs:comment            "A source of the energy.\n\nAn energy type reference refers to an energy characteristic that is needed for reporting, e.g. European Energy Certificate System (EECS). The kind of energy should be possible to be linked with different type of energy forecast, e.g. wind production for a given area based on wind forecast." ;
+        rdfs:label              "EnergyType"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EnergyType.EnergyGroup
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The energy group that has this energy type." ;
+        rdfs:domain           nc:EnergyType ;
+        rdfs:label            "EnergyGroup"@en ;
+        rdfs:range            nc:EnergyGroup ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EnergyGroup.EnergyType ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EnergyType.EnergySourceReference
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Energy source refrence which has energy type references." ;
+        rdfs:domain           nc:EnergyType ;
+        rdfs:label            "EnergySourceReference"@en ;
+        rdfs:range            nc:EnergySourceReference ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EnergySourceReference.EnergyTypeReference ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:EnergyType.ScheduleResource
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Schedule resource unit that has an energy reference type." ;
+        rdfs:domain           nc:EnergyType ;
+        rdfs:label            "ScheduleResource"@en ;
+        rdfs:range            nc:ScheduleResource ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ScheduleResource.PrimaryEnergySource ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EnergyType.kind  rdf:type  rdf:Property ;
+        rdfs:comment       "The kind of energy type." ;
+        rdfs:domain        nc:EnergyType ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         nc:EnergyKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Equipment.Circuit  rdf:type  rdf:Property ;
+        rdfs:comment          "The circuit that containts its member equipment." ;
+        rdfs:domain           cim:Equipment ;
+        rdfs:label            "Circuit"@en ;
+        rdfs:range            nc:Circuit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Circuit.Equipment ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:Equipment.PTCTriggeredEquipment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The equipment that can trigger the power transfer corridor." ;
+        rdfs:domain           cim:Equipment ;
+        rdfs:label            "PTCTriggeredEquipment"@en ;
+        rdfs:range            nc:PTCTriggeredEquipment ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PTCTriggeredEquipment.Equipment ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EquipmentController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Equipment controller is an automation function that can control one or multiple equipment function to achieve all the targets inside the given tolerance. " ;
+        rdfs:label              "EquipmentController"@en ;
+        rdfs:subClassOf         nc:AutomationFunction ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:EquipmentController.RegulatingCondEq
+        rdf:type              rdf:Property ;
+        rdfs:comment          "All regulating conducting equipment that belongs to this equipment controller." ;
+        rdfs:domain           nc:EquipmentController ;
+        rdfs:label            "RegulatingCondEq"@en ;
+        rdfs:range            cim:RegulatingCondEq ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RegulatingCondEq.EquipmentController ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EquipmentController.SystemControl
+        rdf:type              rdf:Property ;
+        rdfs:comment          "System control which controls this equipment controller." ;
+        rdfs:domain           nc:EquipmentController ;
+        rdfs:label            "SystemControl"@en ;
+        rdfs:range            nc:SystemControl ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:SystemControl.EquipmentController ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:EquivalentInjection.InjectionController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Injection controller which controls the equivalent injection." ;
+        rdfs:domain           cim:EquivalentInjection ;
+        rdfs:label            "InjectionController"@en ;
+        rdfs:range            nc:InjectionController ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:InjectionController.EquivalentInjection ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ExceptionalPowerTransferCorridor
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Potential power transfer corridor that can be triggered by equipment which changes its in service status or it is operating in an island.  " ;
+        rdfs:label              "ExceptionalPowerTransferCorridor"@en ;
+        rdfs:subClassOf         nc:PowerTransferCorridor ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ExceptionalPowerTransferCorridor.PTCTriggeredEquipment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The equipment that triggers this exceptional power transfer corridor." ;
+        rdfs:domain           nc:ExceptionalPowerTransferCorridor ;
+        rdfs:label            "PTCTriggeredEquipment"@en ;
+        rdfs:range            nc:PTCTriggeredEquipment ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PTCTriggeredEquipment.ExceptionalPowerTransferCorridor ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:FACTSEquipment  rdf:type     rdfs:Class ;
+        rdfs:comment            "Flexible Alternating Current Transmission System regulating equipment." ;
+        rdfs:label              "FACTSEquipment"@en ;
+        rdfs:subClassOf         cim:RegulatingCondEq ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:FACTSEquipment.LossCurve
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The loss curve for the FACTS equipment." ;
+        rdfs:domain           nc:FACTSEquipment ;
+        rdfs:label            "LossCurve"@en ;
+        rdfs:range            nc:LossCurve ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:LossCurve.FACTSEquipment ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:FACTSEquipment.capacitiveRating
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Capacitive reactance at maximum reactive power.  Shall always be positive." ;
+        rdfs:domain        nc:FACTSEquipment ;
+        rdfs:label         "capacitiveRating"@en ;
+        cims:dataType      cim:Reactance ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:FACTSEquipment.inductiveRating
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Inductive rating at maximum inductive reactive power.  Shall always be negative.  " ;
+        rdfs:domain        nc:FACTSEquipment ;
+        rdfs:label         "inductiveRating"@en ;
+        cims:dataType      cim:Reactance ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:FACTSEquipment.slope
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The characteristics slope which defines how the reactive power output changes in proportion to the difference between the regulated bus voltage and the voltage setpoint.\nThe attribute shall be a positive value or zero." ;
+        rdfs:domain        nc:FACTSEquipment ;
+        rdfs:label         "slope"@en ;
+        cims:dataType      cim:VoltagePerReactivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Feeder.SubSchedulingArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The subscheduling area that has this feeder." ;
+        rdfs:domain           cim:Feeder ;
+        rdfs:label            "SubSchedulingArea"@en ;
+        rdfs:range            nc:SubSchedulingArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SubSchedulingArea.Feeder ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:FlexibleEnergyUnit
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Flexible consumer or embedded producer of energy. The unit cannot be a net producer." ;
+        rdfs:label              "FlexibleEnergyUnit"@en ;
+        rdfs:subClassOf         cim:PowerElectronicsUnit ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:FlexibleEnergyUnit.buffer
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The active power, that has the flexibility to operate as production and/or consumption. The buffer is bound. Example are heat pump, cooling system, embedded batteries including electric vehicle. Load sign convention is used, i.e. positive sign means flow out from a node." ;
+        rdfs:domain        nc:FlexibleEnergyUnit ;
+        rdfs:label         "buffer"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:FlexibleEnergyUnit.timeShift
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The active power, that can be shifted from one pricing interval (market time unit) to another. It is expected to be a limited on the length of the shift. Example from household could be washing machine or dishwasher. Example from industry is the possible to shut down a machine for the relevant period. Load sign convention is used, i.e. positive sign means flow out from a node." ;
+        rdfs:domain        nc:FlexibleEnergyUnit ;
+        rdfs:label         "timeShift"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:FlexibleEnergyUnit.unconstrained
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The active power, that has the flexibility to operate as production without any bound by a buffer. Example are alternative heating (wood, gas, diesel etc) or power generators. Load sign convention is used, i.e. positive sign means flow out from a node." ;
+        rdfs:domain        nc:FlexibleEnergyUnit ;
+        rdfs:label         "unconstrained"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:FlexibleEnergyUnit.uncontrollable
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The active power, that forms the base consumption for the unit. This is measured and expected consumption. Load sign convention is used, i.e. positive sign means flow out from a node." ;
+        rdfs:domain        nc:FlexibleEnergyUnit ;
+        rdfs:label         "uncontrollable"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:FossilFuel.FuelStorage
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Fuel storage that store fossil fuels." ;
+        rdfs:domain           cim:FossilFuel ;
+        rdfs:label            "FuelStorage"@en ;
+        rdfs:range            nc:FuelStorage ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:FuelStorage.FossilFuel ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:FrequencyControlFuntion
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Frequency control function is a function block that calculate the operating point of the controlled equipment to achieve the target frequency." ;
+        rdfs:label              "FrequencyControlFuntion"@en ;
+        rdfs:subClassOf         nc:ControlFunctionBlock ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:FrequencyMonitoringTerminal
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Frequency monitoring terminal provides location in the model where the frequency is monitored for the purpose of power frequency control." ;
+        rdfs:label              "FrequencyMonitoringTerminal"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:FrequencyMonitoringTerminal.PowerFrequencyController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power frequency controller that has this frequency monitoring terminal." ;
+        rdfs:domain           nc:FrequencyMonitoringTerminal ;
+        rdfs:label            "PowerFrequencyController"@en ;
+        rdfs:range            nc:PowerFrequencyController ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerFrequencyController.FrequencyMonitoringTerminal ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:FrequencyMonitoringTerminal.Terminal
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The terminal for this frequency monitoring terminal." ;
+        rdfs:domain           nc:FrequencyMonitoringTerminal ;
+        rdfs:label            "Terminal"@en ;
+        rdfs:range            cim:Terminal ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Terminal.FrequencyMonitoringTerminal ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:FrequencyMonitoringTerminal.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:FrequencyMonitoringTerminal ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:FrequencyMonitoringTerminal.priority
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Value 0 means ignore priority. 1 means the highest priority, 2 is the second highest priority." ;
+        rdfs:domain        nc:FrequencyMonitoringTerminal ;
+        rdfs:label         "priority"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:FuelStorage  rdf:type        rdfs:Class ;
+        rdfs:comment            "Fuel storage. e.g. pile of coal that can be shared between multiple thermal generating units." ;
+        rdfs:label              "FuelStorage"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:FuelStorage.FossilFuel
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Fossil fuel stored in a fuel storage." ;
+        rdfs:domain           nc:FuelStorage ;
+        rdfs:label            "FossilFuel"@en ;
+        rdfs:range            cim:FossilFuel ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:FossilFuel.FuelStorage ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:FunctionBlock  rdf:type      rdfs:Class ;
+        rdfs:comment            "Function block is a function described as a set of elementary blocks. The blocks describe the function between input variables and output variables." ;
+        rdfs:label              "FunctionBlock"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:FunctionBlock.AutomationBlockGroup
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Automation block group which has function blocks." ;
+        rdfs:domain           nc:FunctionBlock ;
+        rdfs:label            "AutomationBlockGroup"@en ;
+        rdfs:range            nc:AutomationBlockGroup ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AutomationBlockGroup.FunctionBlock ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:FunctionBlock.AutomationFunction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Automation function describe automation that this function block is part of." ;
+        rdfs:domain           nc:FunctionBlock ;
+        rdfs:label            "AutomationFunction"@en ;
+        rdfs:range            nc:AutomationFunction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AutomationFunction.FunctionBlock ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:FunctionBlock.FunctionOutputVariable
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Function output variable describe the output or codomain to the function block." ;
+        rdfs:domain           nc:FunctionBlock ;
+        rdfs:label            "FunctionOutputVariable"@en ;
+        rdfs:range            nc:FunctionOutputVariable ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:FunctionOutputVariable.FunctionBlock ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:FunctionBlock.Input
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Function input variable describe the input or domain to the function block." ;
+        rdfs:domain           nc:FunctionBlock ;
+        rdfs:label            "Input"@en ;
+        rdfs:range            nc:FunctionInputVariable ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:FunctionInputVariable.Function ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:FunctionBlock.normalEnabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "True, if the function block is enabled (active). Otherwise false." ;
+        rdfs:domain        nc:FunctionBlock ;
+        rdfs:label         "normalEnabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:FunctionInputVariable
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Functional input variable defines the domain of the function." ;
+        rdfs:label              "FunctionInputVariable"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:FunctionInputVariable.Function
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Function block describe the function that function input variable provides the domain for." ;
+        rdfs:domain           nc:FunctionInputVariable ;
+        rdfs:label            "Function"@en ;
+        rdfs:range            nc:FunctionBlock ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:FunctionBlock.Input ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:FunctionOutputVariable
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Functional output variable defines the codomain of the function." ;
+        rdfs:label              "FunctionOutputVariable"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:FunctionOutputVariable.FunctionBlock
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Function block describe the function that function output variable provides the codomain for." ;
+        rdfs:domain           nc:FunctionOutputVariable ;
+        rdfs:label            "FunctionBlock"@en ;
+        rdfs:range            nc:FunctionBlock ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:FunctionBlock.FunctionOutputVariable ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:FunctionOutputVariable.PropertyReference
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Property reference refers to a given class and property that is populated by the function output variable." ;
+        rdfs:domain           nc:FunctionOutputVariable ;
+        rdfs:label            "PropertyReference"@en ;
+        rdfs:range            nc:PropertyReference ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PropertyReference.FunctionOutputVariable ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:GateInputPin  rdf:type       rdfs:Class ;
+        rdfs:comment            "Input pin for a logical gate. The condition described in the input pin gives a logical true or false. The result from measurement and calculation are converted to a true or false." ;
+        rdfs:label              "GateInputPin"@en ;
+        rdfs:subClassOf         nc:FunctionInputVariable ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:GateInputPin.absoluteValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Indicates if the absolute value is used for comparison. If true, use the absolute value. If false, use the complex value (vector). " ;
+        rdfs:domain        nc:GateInputPin ;
+        rdfs:label         "absoluteValue"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GateInputPin.duration
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time duration for which the condition is satisfied before acting. Default is 0 seconds." ;
+        rdfs:domain        nc:GateInputPin ;
+        rdfs:label         "duration"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GateInputPin.logicKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The logical operator kind used for comparison." ;
+        rdfs:domain        nc:GateInputPin ;
+        rdfs:label         "logicKind"@en ;
+        rdfs:range         nc:LogicalOperatorsKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GateInputPin.negate
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Invert/negate the result of the comparison." ;
+        rdfs:domain        nc:GateInputPin ;
+        rdfs:label         "negate"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GateInputPin.thresholdPercentage
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The threshold percentage that should be used for compare with the percentage change between input value and threshold value.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:GateInputPin ;
+        rdfs:label         "thresholdPercentage"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GateInputPin.thresholdValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The threshold value that should be used for compare with the input value." ;
+        rdfs:domain        nc:GateInputPin ;
+        rdfs:label         "thresholdValue"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GeneratingUnit.AreaDispatchableUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The area dispatchable unit for this generating unit. " ;
+        rdfs:domain           cim:GeneratingUnit ;
+        rdfs:label            "AreaDispatchableUnit"@en ;
+        rdfs:range            nc:AreaDispatchableUnit ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AreaDispatchableUnit.GeneratingUnit ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:GeneratingUnit.EnergyComponent
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The energy component that has this generating unit." ;
+        rdfs:domain           cim:GeneratingUnit ;
+        rdfs:label            "EnergyComponent"@en ;
+        rdfs:range            nc:EnergyComponent ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EnergyComponent.GeneratingUnit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:GeneratingUnit.ScheduleResource
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The schedule resource that has this generating unit." ;
+        rdfs:domain           cim:GeneratingUnit ;
+        rdfs:label            "ScheduleResource"@en ;
+        rdfs:range            nc:ScheduleResource ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ScheduleResource.GeneratingUnit ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:GeneratingUnit.coolDownTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Time it takes from a unit shutdown until it is considered cold." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "coolDownTime"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GeneratingUnit.maxStartupLoad
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum consumption by the generating unit as part of the startup process." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "maxStartupLoad"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GeneratingUnit.minimumUpTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time that a generating unit has to stay running after it has been switched on by the Remedial Action Optimizer." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "minimumUpTime"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GeneratingUnit.normalMustRunP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Normal minimum active power injection that is needed to meet must-run requirement. This value can be higher or equal to minimum operational limit. Load sign convention is used, i.e. positive sign means flow out from a node." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "normalMustRunP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GeneratingUnit.normalMustRunQ
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Normal minimum reactive power injection that is needed to meet must-run requirement. This value can be higher or equal to minimum operational limit. Load sign convention is used, i.e. positive sign means flow out from a node." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "normalMustRunQ"@en ;
+        cims:dataType      cim:ReactivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GeneratingUnit.normalStartupCost
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The normal initial startup cost incurred for each start of the GeneratingUnit." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "normalStartupCost"@en ;
+        cims:dataType      cim:Money ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GeneratingUnit.normalWarmStartupCost
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The normal warm startup cost incurred for each start of the GeneratingUnit." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "normalWarmStartupCost"@en ;
+        cims:dataType      cim:Money ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GeneratingUnit.runningLeadTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Time it takes to change the schedule when the unit is operating due to technical configuration of a supporting system, e.g. gas pipeline. " ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "runningLeadTime"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GeneratingUnit.shutdownCost
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The shutdown cost incurred for each shutdown of the GeneratingUnit." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "shutdownCost"@en ;
+        cims:dataType      cim:Money ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GeneratingUnit.shutdownTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Time it takes to shutdown the unit." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "shutdownTime"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GeneratingUnit.startupRampRate
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The startup ramp rate of the generating unit which describes the speed of change of active power from zero to the minimum active power.\nWhen the ramp is not provided, the optimisation process shall consider the change as an instant change of active power from zero to minimum active power." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "startupRampRate"@en ;
+        cims:dataType      cim:ActivePowerChangeRate ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GeneratingUnit.warmStartupTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Time it takes to startup the unit when it is warm." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "warmStartupTime"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GeothermalGeneratingUnit
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Generating unit that is generating electrical power from geothermal energy." ;
+        rdfs:label              "GeothermalGeneratingUnit"@en ;
+        rdfs:subClassOf         cim:GeneratingUnit ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:GeothermalGeneratingUnit.kind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of geothermal generating unit." ;
+        rdfs:domain        nc:GeothermalGeneratingUnit ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         nc:GeothermalUnitKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GeothermalUnitKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of geothermal." ;
+        rdfs:label              "GeothermalUnitKind"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:GeothermalUnitKind.binaryCycle
+        rdf:type         nc:GeothermalUnitKind ;
+        rdfs:comment     "The moderately hot geothermal water is passed by a secondary fluid with a much lower boiling point than water. " ;
+        rdfs:label       "binaryCycle"@en ;
+        cims:stereotype  "enum" .
+
+nc:GeothermalUnitKind.drySteam
+        rdf:type         nc:GeothermalUnitKind ;
+        rdfs:comment     "Uses geothermal steam of 150 degree Celsius or greater to turn turbines." ;
+        rdfs:label       "drySteam"@en ;
+        cims:stereotype  "enum" .
+
+nc:GeothermalUnitKind.flashSteam
+        rdf:type         nc:GeothermalUnitKind ;
+        rdfs:comment     "Pull deep, high-pressure hot water into lower-pressure tanks and use the resulting flashed steam to drive turbines." ;
+        rdfs:label       "flashSteam"@en ;
+        cims:stereotype  "enum" .
+
+nc:GeothermalUnitKind.other
+        rdf:type         nc:GeothermalUnitKind ;
+        rdfs:comment     "Other type of geothermal generating unit." ;
+        rdfs:label       "other"@en ;
+        cims:stereotype  "enum" .
+
+nc:HydroPump.AreaDispatchableUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Area dispatchable unit associated with a Hydro Pump." ;
+        rdfs:domain           cim:HydroPump ;
+        rdfs:label            "AreaDispatchableUnit"@en ;
+        rdfs:range            nc:AreaDispatchableUnit ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AreaDispatchableUnit.HydroPump ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:HydroPump.EnergyComponent
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The energy component that has this hydro pump." ;
+        rdfs:domain           cim:HydroPump ;
+        rdfs:label            "EnergyComponent"@en ;
+        rdfs:range            nc:EnergyComponent ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EnergyComponent.HydroPump ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:HydroPump.ScheduleResource
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The schedule resource that has this hydro pump." ;
+        rdfs:domain           cim:HydroPump ;
+        rdfs:label            "ScheduleResource"@en ;
+        rdfs:range            nc:ScheduleResource ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ScheduleResource.HydroPump ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:HydroPump.maxEconomicP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum high economic active power limit, that should not exceed the maximum operating active power limit." ;
+        rdfs:domain        cim:HydroPump ;
+        rdfs:label         "maxEconomicP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:HydroPump.maxOperatingP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "This is the maximum operating active power limit the dispatcher can enter for this unit." ;
+        rdfs:domain        cim:HydroPump ;
+        rdfs:label         "maxOperatingP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:HydroPump.minEconomicP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Low economic active power limit that shall be greater than or equal to the minimum operating active power limit." ;
+        rdfs:domain        cim:HydroPump ;
+        rdfs:label         "minEconomicP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:HydroPump.minOperatingP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "This is the minimum operating active power limit the dispatcher can enter for this unit." ;
+        rdfs:domain        cim:HydroPump ;
+        rdfs:label         "minOperatingP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:HydroPump.normalParticipationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Participation factor describing the entity part of the active power provided by a collection of entities (e.g. an active power forecast to a collection of entities is divided to each of the member entity according to the participation factor). Must be a positive value.\nIn the case of a sharing strategy, the distribution is following entities value (V) equals aggregated value (T) divided by sum of participation factors (PF), i.e. V=T/sum(PF). \nIn the case of priority strategy, the item with the lowest number gets allocated energy first." ;
+        rdfs:domain        cim:HydroPump ;
+        rdfs:label         "normalParticipationFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ImpedanceControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Impedance control function is a function block that calculates the operating point of the controlled equipment to achieve the target impedance." ;
+        rdfs:label              "ImpedanceControlFunction"@en ;
+        rdfs:subClassOf         nc:ControlFunctionBlock ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:InfeedLimit  rdf:type        rdfs:Class ;
+        rdfs:comment            "Infeed limit set constraints fed in to the network by two or more terminals." ;
+        rdfs:label              "InfeedLimit"@en ;
+        rdfs:subClassOf         cim:OperationalLimit ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:InfeedLimit.InfeedTerminal
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Infeed terminal that has infeed constraints." ;
+        rdfs:domain           nc:InfeedLimit ;
+        rdfs:label            "InfeedTerminal"@en ;
+        rdfs:range            nc:InfeedTerminal ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:InfeedTerminal.InfeedConstraint ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:InfeedLimit.normalValueA
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The normal current limit. The attribute shall be a positive value or zero." ;
+        rdfs:domain        nc:InfeedLimit ;
+        rdfs:label         "normalValueA"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:InfeedLimit.normalValueW
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The normal value of active power limit. The attribute shall be a positive value or zero." ;
+        rdfs:domain        nc:InfeedLimit ;
+        rdfs:label         "normalValueW"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:InfeedTerminal  rdf:type     rdfs:Class ;
+        rdfs:comment            "Infeed terminal defines the terminals that are linked to an infeed limit." ;
+        rdfs:label              "InfeedTerminal"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:InfeedTerminal.ACDCTerminal
+        rdf:type              rdf:Property ;
+        rdfs:comment          "ACDCTerminal which is connected to an infeed terminal." ;
+        rdfs:domain           nc:InfeedTerminal ;
+        rdfs:label            "ACDCTerminal"@en ;
+        rdfs:range            cim:ACDCTerminal ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ACDCTerminal.InfeedTerminal ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:InfeedTerminal.InfeedConstraint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Infeed constraint which belongs to an infeed terminal." ;
+        rdfs:domain           nc:InfeedTerminal ;
+        rdfs:label            "InfeedConstraint"@en ;
+        rdfs:range            nc:InfeedLimit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:InfeedLimit.InfeedTerminal ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:InfeedTerminal.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:InfeedTerminal ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:InjectionController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Injection controller is controlling the equipment which represents an injection or an external network." ;
+        rdfs:label              "InjectionController"@en ;
+        rdfs:subClassOf         nc:EquipmentController ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:InjectionController.EquivalentInjection
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Equivalent injection controlled by the injection controller." ;
+        rdfs:domain           nc:InjectionController ;
+        rdfs:label            "EquivalentInjection"@en ;
+        rdfs:range            cim:EquivalentInjection ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EquivalentInjection.InjectionController ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:LimitDependencyCurve
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A curve or functional relationship between an independent variable (X-axis) and limiting dependent (Y-axis) variables." ;
+        rdfs:label              "LimitDependencyCurve"@en ;
+        rdfs:subClassOf         cim:Curve ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:Line.ACTieCorridor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "ACTieCorridor that the line is part of." ;
+        rdfs:domain           cim:Line ;
+        rdfs:label            "ACTieCorridor"@en ;
+        rdfs:range            nc:ACTieCorridor ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ACTieCorridor.Line ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:Line.SchedulingArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The scheduling area that has this line." ;
+        rdfs:domain           cim:Line ;
+        rdfs:label            "SchedulingArea"@en ;
+        rdfs:range            nc:SchedulingArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SchedulingArea.Line ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:LineCircuit  rdf:type        rdfs:Class ;
+        rdfs:comment            "A line circuit is a circuit that has at least one ACLineSegment and may or may not include related switching and/or auxiliary equipment." ;
+        rdfs:label              "LineCircuit"@en ;
+        rdfs:subClassOf         nc:Circuit ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:LoadFrequencyControlArea
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A part of a synchronous area or an entire synchronous area, physically demarcated by points of measurement at interconnectors to other load frequency control (LFC) areas, operated by one or more TSOs fulfilling the obligations of load-frequency control." ;
+        rdfs:label              "LoadFrequencyControlArea"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:LoadFrequencyControlArea.FrequencyControlOperator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The frequency control operator that operates this frequency control area." ;
+        rdfs:domain           nc:LoadFrequencyControlArea ;
+        rdfs:label            "FrequencyControlOperator"@en ;
+        rdfs:range            nc:LoadFrequencyControlOperator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:LoadFrequencyControlOperator.FrequencyControlArea ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:LoadFrequencyControlArea.LoadFrequencyControlBlock
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The load frequency control block that has this load frequency control area." ;
+        rdfs:domain           nc:LoadFrequencyControlArea ;
+        rdfs:label            "LoadFrequencyControlBlock"@en ;
+        rdfs:range            nc:LoadFrequencyControlBlock ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:LoadFrequencyControlBlock.LoadFrequencyControlArea ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:LoadFrequencyControlArea.SchedulingArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The scheduling area that is part of this load frequency control area." ;
+        rdfs:domain           nc:LoadFrequencyControlArea ;
+        rdfs:label            "SchedulingArea"@en ;
+        rdfs:range            nc:SchedulingArea ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:SchedulingArea.LoadFrequencyControlArea ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:LoadFrequencyControlArea.TieCorridor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "TieCorridor controlled by the LoadFrequencyControlArea." ;
+        rdfs:domain           nc:LoadFrequencyControlArea ;
+        rdfs:label            "TieCorridor"@en ;
+        rdfs:range            nc:TieCorridor ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:TieCorridor.LoadFrequencyControlArea ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:LoadFrequencyControlArea.deficientGenerationLimit
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Percentage of average dispatch target plus average regulation used to calculate  Deficient Generation Limit. The value shall be a positive value between 0 and 100." ;
+        rdfs:domain        nc:LoadFrequencyControlArea ;
+        rdfs:label         "deficientGenerationLimit"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:LoadFrequencyControlArea.frequencyBiasFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Frequency bias in MW/Hz." ;
+        rdfs:domain        nc:LoadFrequencyControlArea ;
+        rdfs:label         "frequencyBiasFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:LoadFrequencyControlArea.frequencyRestorationReserveDelay
+        rdf:type           rdf:Property ;
+        rdfs:comment       "FRR delay expressed in seconds. Must be a positive multiple of AGC's cycle duration." ;
+        rdfs:domain        nc:LoadFrequencyControlArea ;
+        rdfs:label         "frequencyRestorationReserveDelay"@en ;
+        cims:dataType      cim:Seconds ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:LoadFrequencyControlArea.frequencyRestorationReserveMaxRamp
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum authorized ramp for both FRR dispatching and ramp to zero." ;
+        rdfs:domain        nc:LoadFrequencyControlArea ;
+        rdfs:label         "frequencyRestorationReserveMaxRamp"@en ;
+        cims:dataType      cim:ActivePowerChangeRate ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:LoadFrequencyControlArea.frequencyRestorationReserveThreshold
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Authorized threshold for both FRR dispatching and ramp to zero." ;
+        rdfs:domain        nc:LoadFrequencyControlArea ;
+        rdfs:label         "frequencyRestorationReserveThreshold"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:LoadFrequencyControlArea.includeFrequencyBias
+        rdf:type           rdf:Property ;
+        rdfs:comment       "True means the frequency bias that is taken into consideration in the frequency bias computation." ;
+        rdfs:domain        nc:LoadFrequencyControlArea ;
+        rdfs:label         "includeFrequencyBias"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:LoadFrequencyControlBlock
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A part of a synchronous area or an entire synchronous area, physically demarcated by points of measurement at interconnectors to other load frequency control (LFC) blocks, consisting of one or more LFC areas, operated by one or more TSOs fulfilling the obligations of load-frequency control." ;
+        rdfs:label              "LoadFrequencyControlBlock"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:LoadFrequencyControlBlock.LoadFrequencyControlArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The load frequency control area that is part of this load frequency control block. " ;
+        rdfs:domain           nc:LoadFrequencyControlBlock ;
+        rdfs:label            "LoadFrequencyControlArea"@en ;
+        rdfs:range            nc:LoadFrequencyControlArea ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:LoadFrequencyControlArea.LoadFrequencyControlBlock ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:LoadFrequencyControlBlock.SynchronousArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The synchronous area that has this load frequency control block." ;
+        rdfs:domain           nc:LoadFrequencyControlBlock ;
+        rdfs:label            "SynchronousArea"@en ;
+        rdfs:range            nc:SynchronousArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SynchronousArea.LoadFrequencyControlBlock ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:LoadFrequencyControlOperator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A role that is responsible for operational security by operating the load frequency control (LFC) mechanism." ;
+        rdfs:label              "LoadFrequencyControlOperator"@en ;
+        rdfs:subClassOf         nc:PowerSystemOrganisationRole ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:LoadFrequencyControlOperator.FrequencyControlArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The frequency control area that has this frequency control operator." ;
+        rdfs:domain           nc:LoadFrequencyControlOperator ;
+        rdfs:label            "FrequencyControlArea"@en ;
+        rdfs:range            nc:LoadFrequencyControlArea ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:LoadFrequencyControlArea.FrequencyControlOperator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:LogicalOperatorsKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kinds of logical operators for comparison." ;
+        rdfs:label              "LogicalOperatorsKind"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:LogicalOperatorsKind.equals
+        rdf:type         nc:LogicalOperatorsKind ;
+        rdfs:comment     "Equals (like) comparison operation." ;
+        rdfs:label       "equals"@en ;
+        cims:stereotype  "enum" .
+
+nc:LogicalOperatorsKind.greaterThan
+        rdf:type         nc:LogicalOperatorsKind ;
+        rdfs:comment     "Greater than comparison operation." ;
+        rdfs:label       "greaterThan"@en ;
+        cims:stereotype  "enum" .
+
+nc:LogicalOperatorsKind.greaterThanOrEquals
+        rdf:type         nc:LogicalOperatorsKind ;
+        rdfs:comment     "Greater than or equals comparison operation." ;
+        rdfs:label       "greaterThanOrEquals"@en ;
+        cims:stereotype  "enum" .
+
+nc:LogicalOperatorsKind.lessThan
+        rdf:type         nc:LogicalOperatorsKind ;
+        rdfs:comment     "Less than comparison operation." ;
+        rdfs:label       "lessThan"@en ;
+        cims:stereotype  "enum" .
+
+nc:LogicalOperatorsKind.lessThanOrEquals
+        rdf:type         nc:LogicalOperatorsKind ;
+        rdfs:comment     "Less than or equals comparison operation." ;
+        rdfs:label       "lessThanOrEquals"@en ;
+        cims:stereotype  "enum" .
+
+nc:LogicalOperatorsKind.notEqual
+        rdf:type         nc:LogicalOperatorsKind ;
+        rdfs:comment     "Not equal (unlike) comparison operation." ;
+        rdfs:label       "notEqual"@en ;
+        cims:stereotype  "enum" .
+
+nc:LossCurve  rdf:type          rdfs:Class ;
+        rdfs:comment            "Represents the losses in the equipment due to operation position." ;
+        rdfs:label              "LossCurve"@en ;
+        rdfs:subClassOf         cim:Curve ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:LossCurve.FACTSEquipment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The FACTS equipment which has a loss curve." ;
+        rdfs:domain           nc:LossCurve ;
+        rdfs:label            "FACTSEquipment"@en ;
+        rdfs:range            nc:FACTSEquipment ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:FACTSEquipment.LossCurve ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:MarineUnitKind  rdf:type     rdfs:Class ;
+        rdfs:comment            "Kind of marine energy capture." ;
+        rdfs:label              "MarineUnitKind"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:MarineUnitKind.currents
+        rdf:type         nc:MarineUnitKind ;
+        rdfs:comment     "Capture energy from ocean current which are caused by forces like breaking waves, wind, coriolis effect etc." ;
+        rdfs:label       "currents"@en ;
+        cims:stereotype  "enum" .
+
+nc:MarineUnitKind.other
+        rdf:type         nc:MarineUnitKind ;
+        rdfs:comment     "Other way of capture energy from marine elements." ;
+        rdfs:label       "other"@en ;
+        cims:stereotype  "enum" .
+
+nc:MarineUnitKind.pressure
+        rdf:type         nc:MarineUnitKind ;
+        rdfs:comment     "Capture energy from pressure." ;
+        rdfs:label       "pressure"@en ;
+        cims:stereotype  "enum" .
+
+nc:MarineUnitKind.tidal
+        rdf:type         nc:MarineUnitKind ;
+        rdfs:comment     "Capture energy from tidal power, which captures the energy of the current caused by the gravitational pull of the Sun and Moon." ;
+        rdfs:label       "tidal"@en ;
+        cims:stereotype  "enum" .
+
+nc:MarineUnitKind.wave
+        rdf:type         nc:MarineUnitKind ;
+        rdfs:comment     "Capture energy from wind waves." ;
+        rdfs:label       "wave"@en ;
+        cims:stereotype  "enum" .
+
+nc:ModularStaticSynchronousSeriesCompensator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Modular static synchronous series compensator (MSSSC) is a type of flexible AC transmission system regulating equipment which consists of solid-state voltage source inverter connected in series with a transmission line. This is similar to static synchronous series compensator (SSSC), but without injection transformer. This enables the MSSSC to be truly modular with the ability to simply install a number of equipment in series to provide a desired maximum level of impedance. MSSSC can be dispersed into multiple location in a circuit working collectively under the same controller scheme." ;
+        rdfs:label              "ModularStaticSynchronousSeriesCompensator"@en ;
+        rdfs:subClassOf         nc:FACTSEquipment ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:MonitoringArea  rdf:type     rdfs:Class ;
+        rdfs:comment            "A coherent part of the interconnected electrical power system, that includes the system operators' responsibility area and the surrounding parts of other system operators' responsibility area, that need to be monitored for security assessment." ;
+        rdfs:label              "MonitoringArea"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:MonitoringArea.PowerFrequencyController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power frequency controller that applied to this monitoring area." ;
+        rdfs:domain           nc:MonitoringArea ;
+        rdfs:label            "PowerFrequencyController"@en ;
+        rdfs:range            nc:PowerFrequencyController ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerFrequencyController.MonitoringArea ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:MonopolarDCSystem  rdf:type  rdfs:Class ;
+        rdfs:comment            "Monopolar DC system (IEC 60633) is a DC system with only one pole." ;
+        rdfs:label              "MonopolarDCSystem"@en ;
+        rdfs:subClassOf         nc:DCSystem ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:MonopolarDCSystem.DCPole
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC pole part of the asymmetric DC system." ;
+        rdfs:domain           nc:MonopolarDCSystem ;
+        rdfs:label            "DCPole"@en ;
+        rdfs:range            nc:DCPole ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DCPole.AsymmetricMonopolarDCSystem ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:MonopolarDCSystem.isSymmetrical
+        rdf:type           rdf:Property ;
+        rdfs:comment       "if true, the monopolar DC system is symmetrical monopolar DC system (IEC 60633). It is a DC system with only one symmetrical monopole. A symmetrical monopole is part of an DC system consisting of all the equipment in the DC substations and the interconnecting transmission lines, if any, which during normal operation exhibits equal and opposite direct voltage polarities with respect to earth but without series connection of converters in each converter station. The term \"symmetrical monopole\" is used even though there are two polarities with DC voltages, because with only one converter it is not possible to provide the redundancy which is normally associated with the term \"bipole\"." ;
+        rdfs:domain        nc:MonopolarDCSystem ;
+        rdfs:label         "isSymmetrical"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:NuclearGeneratingUnit.reactorKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of nuclear reactor." ;
+        rdfs:domain        cim:NuclearGeneratingUnit ;
+        rdfs:label         "reactorKind"@en ;
+        rdfs:range         nc:NuclearReactorKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:NuclearReactorKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of nuclear reactor." ;
+        rdfs:label              "NuclearReactorKind"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:NuclearReactorKind.breeder
+        rdf:type         nc:NuclearReactorKind ;
+        rdfs:comment     "Reactor whose heat source is a nuclear reactor that generates more fissile material than it consumes." ;
+        rdfs:label       "breeder"@en ;
+        cims:stereotype  "enum" .
+
+nc:NuclearReactorKind.graphite
+        rdf:type         nc:NuclearReactorKind ;
+        rdfs:comment     "Reactor whose heat source is a graphite-moderated reactor that is a nuclear reactor that uses carbon as a neutron moderator, which allows natural uranium to be used as nuclear fuel." ;
+        rdfs:label       "graphite"@en ;
+        cims:stereotype  "enum" .
+
+nc:NuclearReactorKind.heavyWater
+        rdf:type         nc:NuclearReactorKind ;
+        rdfs:comment     "Reactor whose heat source is a pressurized heavy-water reactor (PHWR) that uses heavy water (deuterium oxide D2O) as its coolant and neutron moderator." ;
+        rdfs:label       "heavyWater"@en ;
+        cims:stereotype  "enum" .
+
+nc:NuclearReactorKind.lightWater
+        rdf:type         nc:NuclearReactorKind ;
+        rdfs:comment     "Reactor whose heat source is a light-water reactor (LWR) that is a type of thermal-neutron reactor that uses normal water, as both its coolant and neutron moderator – furthermore a solid form of fissile elements is used as fuel. " ;
+        rdfs:label       "lightWater"@en ;
+        cims:stereotype  "enum" .
+
+nc:NuclearReactorKind.liquidMetal
+        rdf:type         nc:NuclearReactorKind ;
+        rdfs:comment     "Reactor whose liquid metal cooled nuclear reactor, liquid metal fast reactor or LMFR is an advanced type of nuclear reactor where the primary coolant is a liquid metal." ;
+        rdfs:label       "liquidMetal"@en ;
+        cims:stereotype  "enum" .
+
+nc:NuclearReactorKind.other
+        rdf:type         nc:NuclearReactorKind ;
+        rdfs:comment     "Other type of nuclear reactors." ;
+        rdfs:label       "other"@en ;
+        cims:stereotype  "enum" .
+
+nc:OperationalLimitSet.PowerTransferCorridor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The power transfer corridor that has this operational limit set." ;
+        rdfs:domain           cim:OperationalLimitSet ;
+        rdfs:label            "PowerTransferCorridor"@en ;
+        rdfs:range            nc:PowerTransferCorridor ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerTransferCorridor.OperationalLimitSet ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:OperationalLimitType.PermanentAmbientTemperatureDependencyCurve
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The permanent ambient temperature dependency curve for this operational limit type." ;
+        rdfs:domain           cim:OperationalLimitType ;
+        rdfs:label            "PermanentAmbientTemperatureDependencyCurve"@en ;
+        rdfs:range            nc:AmbientTemperatureDependencyCurve ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AmbientTemperatureDependencyCurve.OperationalLimitType ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:OperationalLimitType.PermanentSolarRadiationCurve
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The permanent solar radiation curve for this operational limit type." ;
+        rdfs:domain           cim:OperationalLimitType ;
+        rdfs:label            "PermanentSolarRadiationCurve"@en ;
+        rdfs:range            nc:SolarRadiationDependencyCurve ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SolarRadiationDependencyCurve.OperationalLimitType ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:OperationalLimitType.RecoveryOverloadLimitCurve
+        rdf:type              rdf:Property ;
+        rdfs:comment          "This is the curve which provides the recovery time information for this limit type." ;
+        rdfs:domain           cim:OperationalLimitType ;
+        rdfs:label            "RecoveryOverloadLimitCurve"@en ;
+        rdfs:range            nc:RecoveryOverloadLimitCurve ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RecoveryOverloadLimitCurve.OperationalLimitType ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:OperationalLimitType.TemporaryBaseOverloadLimitCurve
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The temporary base overload limit curve for this operational limit type." ;
+        rdfs:domain           cim:OperationalLimitType ;
+        rdfs:label            "TemporaryBaseOverloadLimitCurve"@en ;
+        rdfs:range            nc:BaseOverloadLimitCurve ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:BaseOverloadLimitCurve.OperationalLimitType ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:OperationalLimitType.TemporaryDurationOverloadLimitCurve
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The temporary duration overload limit curve for this operational limit type." ;
+        rdfs:domain           cim:OperationalLimitType ;
+        rdfs:label            "TemporaryDurationOverloadLimitCurve"@en ;
+        rdfs:range            nc:DurationOverloadLimitCurve ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DurationOverloadLimitCurve.OperationalLimitType ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:OperationalLimitType.isMinimum
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Defines if the operational limit type is minimum. If true, the value is a minimum value of the same kind. This applies to stability and PATL. If false, the limit has the normal behaviour. OperationalLimitType.direction attribute shall be absoluteValue." ;
+        rdfs:domain        cim:OperationalLimitType ;
+        rdfs:label         "isMinimum"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:OrdinaryPowerTransferCorridor
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Power transfer corridor defined for normal operating network." ;
+        rdfs:label              "OrdinaryPowerTransferCorridor"@en ;
+        rdfs:subClassOf         nc:PowerTransferCorridor ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:OrganisationRole.globalLocationNumber
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The Global Location Number (GLN) is part of the GS1 systems of standards. GLN is a 13-digit number structured that include GS1 Company Prefix, Location Reference (N1-N12) and Check Digit (N13).\nGS1 is a neutral, not-for-profit, international organisation that develops and maintains standards for supply and demand chains across multiple sectors." ;
+        rdfs:domain        cim:OrganisationRole ;
+        rdfs:label         "globalLocationNumber"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:OutageCoordinationRegion
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A region that has a common organisation or service responsible for outage planning and coordination and its impact on grid operation." ;
+        rdfs:label              "OutageCoordinationRegion"@en ;
+        rdfs:subClassOf         nc:Region ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:OutageCoordinationRegion.ControlArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The control area that is part of this outage coordination region." ;
+        rdfs:domain           nc:OutageCoordinationRegion ;
+        rdfs:label            "ControlArea"@en ;
+        rdfs:range            cim:ControlArea ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ControlArea.OutageCoordinationRegion ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:OutageCoordinationRegion.OutageCoordinator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The outage coordinator responsible for this outage coordination region." ;
+        rdfs:domain           nc:OutageCoordinationRegion ;
+        rdfs:label            "OutageCoordinator"@en ;
+        rdfs:range            nc:OutageCoordinator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:OutageCoordinator.OutageCoordinationRegion ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:OutageCoordinationRegion.SecurityCoordinator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The security coordinator that is responsible for this outage coordination region." ;
+        rdfs:domain           nc:OutageCoordinationRegion ;
+        rdfs:label            "SecurityCoordinator"@en ;
+        rdfs:range            nc:SecurityCoordinator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SecurityCoordinator.OutageCoordinationRegion ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:OutageCoordinator  rdf:type  rdfs:Class ;
+        rdfs:comment            "A role that coordinates the planned availability status of relevant power system equipment to meet the need by the asset owner or operator and the security of the power system." ;
+        rdfs:label              "OutageCoordinator"@en ;
+        rdfs:subClassOf         nc:SystemOperationCoordinator ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:OutageCoordinator.OutageCoordinationRegion
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The outage coordination region that has this outage coordinator." ;
+        rdfs:domain           nc:OutageCoordinator ;
+        rdfs:label            "OutageCoordinationRegion"@en ;
+        rdfs:range            nc:OutageCoordinationRegion ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:OutageCoordinationRegion.OutageCoordinator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:OutagePlanningAgent
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "An entity with the task of planning the availability status of a relevant power generating module, a relevant demand facility or a relevant grid element." ;
+        rdfs:label              "OutagePlanningAgent"@en ;
+        rdfs:subClassOf         nc:PowerSystemOrganisationRole ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:OverlappingZone  rdf:type    rdfs:Class ;
+        rdfs:comment            "A collection of all the overlapping cross border assessed elements which have the same sets of impacted and impacting regions." ;
+        rdfs:label              "OverlappingZone"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:OverlappingZone.ImpactedRegion
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The region that is impacted by this overlapping zone." ;
+        rdfs:domain           nc:OverlappingZone ;
+        rdfs:label            "ImpactedRegion"@en ;
+        rdfs:range            nc:Region ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:Region.OverlappingZone ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PTCTriggeredEquipment
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Power Transfer Corridor triggered equipment connects the equipment that will create the exceptional power transfer corridor when taking out of service. e.g. A system with three lines gets an exceptional power transfer corridor when one of the lines is taken out of service." ;
+        rdfs:label              "PTCTriggeredEquipment"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PTCTriggeredEquipment.Equipment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The equipment which is part of power transfer corridor triggering." ;
+        rdfs:domain           nc:PTCTriggeredEquipment ;
+        rdfs:label            "Equipment"@en ;
+        rdfs:range            cim:Equipment ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Equipment.PTCTriggeredEquipment ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PTCTriggeredEquipment.ExceptionalPowerTransferCorridor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The power transfer corridor which is triggered by this equipment." ;
+        rdfs:domain           nc:PTCTriggeredEquipment ;
+        rdfs:label            "ExceptionalPowerTransferCorridor"@en ;
+        rdfs:range            nc:ExceptionalPowerTransferCorridor ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ExceptionalPowerTransferCorridor.PTCTriggeredEquipment ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PhaseControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Phase control function is a function block that calculate the operating point of the controlled equipment to achieve the target voltage." ;
+        rdfs:label              "PhaseControlFunction"@en ;
+        rdfs:subClassOf         nc:ControlFunctionBlock ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PinTerminal  rdf:type        rdfs:Class ;
+        rdfs:comment            "Input pin associated with a Terminal. It is used for comparison." ;
+        rdfs:label              "PinTerminal"@en ;
+        rdfs:subClassOf         nc:GateInputPin ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PinTerminal.Terminal
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The Terminal that is used in the input pin." ;
+        rdfs:domain           nc:PinTerminal ;
+        rdfs:label            "Terminal"@en ;
+        rdfs:range            cim:Terminal ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Terminal.PinTerminal ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PinTerminal.kind  rdf:type  rdf:Property ;
+        rdfs:comment       "The kind of quantity which is used as an input value." ;
+        rdfs:domain        nc:PinTerminal ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         nc:PinTerminalKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PinTerminalKind  rdf:type    rdfs:Class ;
+        rdfs:comment            "The kind of quantities that can serve as an input value for the pin." ;
+        rdfs:label              "PinTerminalKind"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:PinTerminalKind.activePower
+        rdf:type         nc:PinTerminalKind ;
+        rdfs:comment     "Active power on the Terminal." ;
+        rdfs:label       "activePower"@en ;
+        cims:stereotype  "enum" .
+
+nc:PinTerminalKind.apparentPower
+        rdf:type         nc:PinTerminalKind ;
+        rdfs:comment     "Apparent power on the Terminal." ;
+        rdfs:label       "apparentPower"@en ;
+        cims:stereotype  "enum" .
+
+nc:PinTerminalKind.current
+        rdf:type         nc:PinTerminalKind ;
+        rdfs:comment     "Current on the Terminal." ;
+        rdfs:label       "current"@en ;
+        cims:stereotype  "enum" .
+
+nc:PinTerminalKind.reactivePower
+        rdf:type         nc:PinTerminalKind ;
+        rdfs:comment     "Reactive power on the Terminal." ;
+        rdfs:label       "reactivePower"@en ;
+        cims:stereotype  "enum" .
+
+nc:PinTerminalKind.voltageAngle
+        rdf:type         nc:PinTerminalKind ;
+        rdfs:comment     "Voltage angle on the Terminal." ;
+        rdfs:label       "voltageAngle"@en ;
+        cims:stereotype  "enum" .
+
+nc:PinTerminalKind.voltageMagnitude
+        rdf:type         nc:PinTerminalKind ;
+        rdfs:comment     "Voltage magnitude on the Terminal." ;
+        rdfs:label       "voltageMagnitude"@en ;
+        cims:stereotype  "enum" .
+
+nc:PointOfCommonCoupling
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Point of Common Coupling (PCC) refers to the location where multiple electrical sources or loads are electrically connected and provide a reference point where the voltages and currents from different parts of the system are considered to be common. The PCC is used to support system analysis, control, and monitoring, as it provides a reference for understanding the interactions and power flow between various components within the system. It is also relevant to define the requirement and responsibility between different actors in operating a power system." ;
+        rdfs:label              "PointOfCommonCoupling"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:PowerBlockKind  rdf:type     rdfs:Class ;
+        rdfs:comment            "Power block kind describes the increase and/or decrease of power." ;
+        rdfs:label              "PowerBlockKind"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:PowerBlockKind.powerDecrease
+        rdf:type         nc:PowerBlockKind ;
+        rdfs:comment     "Decrease in the power. The block represents action for decreased power." ;
+        rdfs:label       "powerDecrease"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerBlockKind.powerIncrease
+        rdf:type         nc:PowerBlockKind ;
+        rdfs:comment     "Increase in the power. The block represents action for increased power." ;
+        rdfs:label       "powerIncrease"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerBlockKind.powerIncreaseAndDecrease
+        rdf:type         nc:PowerBlockKind ;
+        rdfs:comment     "Increase and decrease in the power. The block represents action for increased and decreased power." ;
+        rdfs:label       "powerIncreaseAndDecrease"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerCapacity  rdf:type      rdfs:Class ;
+        rdfs:comment            "Power capacity defines the capacity in regard to generation, consumption and transmission (import and export) for a relevant power system resource, e.g. bidding zone, including maximum and minimum electrical power capacity and any capacity allocation." ;
+        rdfs:label              "PowerCapacity"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerCapacity.BiddingZone
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Bidding zone which has a power capacity." ;
+        rdfs:domain           nc:PowerCapacity ;
+        rdfs:label            "BiddingZone"@en ;
+        rdfs:range            nc:BiddingZone ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:BiddingZone.PowerCapacity ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerElectricalChemicalUnit
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A unit capable of either generating electrical energy from chemical reactions or using electrical energy to cause chemical reactions." ;
+        rdfs:label              "PowerElectricalChemicalUnit"@en ;
+        rdfs:subClassOf         cim:PowerElectronicsUnit ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerElectricalChemicalUnit.kind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of power electrical chemical unit." ;
+        rdfs:domain        nc:PowerElectricalChemicalUnit ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         nc:PowerElectricalChemicalUnitKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerElectricalChemicalUnitKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of power electrical chemical unit." ;
+        rdfs:label              "PowerElectricalChemicalUnitKind"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:PowerElectricalChemicalUnitKind.electrolyticCell
+        rdf:type         nc:PowerElectricalChemicalUnitKind ;
+        rdfs:comment     "An electrolytic cell is an electrochemical cell that drives a non-spontaneous redox reaction through the application of electrical energy. Example are the decomposition of water into hydrogen and oxygen. " ;
+        rdfs:label       "electrolyticCell"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerElectricalChemicalUnitKind.fuelCell
+        rdf:type         nc:PowerElectricalChemicalUnitKind ;
+        rdfs:comment     "A fuel cell is an electrochemical cell that converts the chemical energy from a fuel into electricity through an electrochemical reaction of hydrogen fuel with oxygen or another oxidizing agent." ;
+        rdfs:label       "fuelCell"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerElectricalChemicalUnitKind.other
+        rdf:type         nc:PowerElectricalChemicalUnitKind ;
+        rdfs:comment     "Other type of cell used in chemical reactions." ;
+        rdfs:label       "other"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerElectronicsConnectionController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Power electronics connection controller is controlling the equipment to optimize the power electronics connection. " ;
+        rdfs:label              "PowerElectronicsConnectionController"@en ;
+        rdfs:subClassOf         nc:EquipmentController ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerElectronicsConnectionController.PowerElectronicsUnitController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power electronics unit controller that has this power electronics connection controller." ;
+        rdfs:domain           nc:PowerElectronicsConnectionController ;
+        rdfs:label            "PowerElectronicsUnitController"@en ;
+        rdfs:range            nc:PowerElectronicsUnitController ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerElectronicsUnitController.PowerElectronicsConnectionController ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerElectronicsMarineUnit
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A unit that capture energy from marine sources, e.g. waves, for generating electrical power." ;
+        rdfs:label              "PowerElectronicsMarineUnit"@en ;
+        rdfs:subClassOf         cim:PowerElectronicsUnit ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerElectronicsMarineUnit.kind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of marine unit." ;
+        rdfs:domain        nc:PowerElectronicsMarineUnit ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         nc:MarineUnitKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerElectronicsUnit.AreaDispatchableUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The area dispatchable unit for this power electronics unit." ;
+        rdfs:domain           cim:PowerElectronicsUnit ;
+        rdfs:label            "AreaDispatchableUnit"@en ;
+        rdfs:range            nc:AreaDispatchableUnit ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AreaDispatchableUnit.PowerElectronicsUnit ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:PowerElectronicsUnit.EnergyComponent
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The energy component that has this power electronics unit." ;
+        rdfs:domain           cim:PowerElectronicsUnit ;
+        rdfs:label            "EnergyComponent"@en ;
+        rdfs:range            nc:EnergyComponent ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EnergyComponent.PowerElectronicsUnit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerElectronicsUnit.PowerElectronicsUnitController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power electronics unit controller for this power electronics unit." ;
+        rdfs:domain           cim:PowerElectronicsUnit ;
+        rdfs:label            "PowerElectronicsUnitController"@en ;
+        rdfs:range            nc:PowerElectronicsUnitController ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerElectronicsUnitController.PowerElectronicsUnit ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerElectronicsUnit.ScheduleResource
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The schedule resource that has this power electronics unit." ;
+        rdfs:domain           cim:PowerElectronicsUnit ;
+        rdfs:label            "ScheduleResource"@en ;
+        rdfs:range            nc:ScheduleResource ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ScheduleResource.PowerElectronicsUnit ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerElectronicsUnit.maxEconomicP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum high economic active power limit, that should not exceed the maximum operating active power limit." ;
+        rdfs:domain        cim:PowerElectronicsUnit ;
+        rdfs:label         "maxEconomicP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerElectronicsUnit.minEconomicP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Low economic active power limit that shall be greater than or equal to the minimum operating active power limit." ;
+        rdfs:domain        cim:PowerElectronicsUnit ;
+        rdfs:label         "minEconomicP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerElectronicsUnit.normalParticipationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Participation factor describing the entity part of the active power provided by a collection of entities (e.g. an active power forecast to a collection of entities is divided to each of the member entity according to the participation factor). Must be a positive value.\nIn the case of a sharing strategy, the distribution is following entities value (V) equals aggregated value (T) divided by sum of participation factors (PF), i.e. V=T/sum(PF). \nIn the case of priority strategy, the item with the lowest number gets allocated energy first." ;
+        rdfs:domain        cim:PowerElectronicsUnit ;
+        rdfs:label         "normalParticipationFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerElectronicsUnitController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Power electronics unit controller is controlling the equipment to optimize the power electronics unit. " ;
+        rdfs:label              "PowerElectronicsUnitController"@en ;
+        rdfs:subClassOf         nc:EquipmentController ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerElectronicsUnitController.PowerElectronicsConnectionController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power electronics connection controller for the power electronics unit controller." ;
+        rdfs:domain           nc:PowerElectronicsUnitController ;
+        rdfs:label            "PowerElectronicsConnectionController"@en ;
+        rdfs:range            nc:PowerElectronicsConnectionController ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerElectronicsConnectionController.PowerElectronicsUnitController ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerElectronicsUnitController.PowerElectronicsUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power electronics unit that has this power electronics unit controller." ;
+        rdfs:domain           nc:PowerElectronicsUnitController ;
+        rdfs:label            "PowerElectronicsUnit"@en ;
+        rdfs:range            cim:PowerElectronicsUnit ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerElectronicsUnit.PowerElectronicsUnitController ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerFactorControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Power factor control function is a function block that calculates the operating point of the controlled equipment to achieve the target power factor." ;
+        rdfs:label              "PowerFactorControlFunction"@en ;
+        rdfs:subClassOf         nc:ControlFunctionBlock ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerFrequencyControlKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kinds of power frequency control modes." ;
+        rdfs:label              "PowerFrequencyControlKind"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:PowerFrequencyControlKind.activePower
+        rdf:type         nc:PowerFrequencyControlKind ;
+        rdfs:comment     "Active power control mode." ;
+        rdfs:label       "activePower"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerFrequencyControlKind.activePowerAndFrequency
+        rdf:type         nc:PowerFrequencyControlKind ;
+        rdfs:comment     "Active power and frequency control mode." ;
+        rdfs:label       "activePowerAndFrequency"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerFrequencyControlKind.frequency
+        rdf:type         nc:PowerFrequencyControlKind ;
+        rdfs:comment     "Frequency control mode." ;
+        rdfs:label       "frequency"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerFrequencyController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Power frequency controller is controlling the active power balance as typically done by the secondary control. If an unbalance between the scheduled active power values of each generation unit and the loads plus losses occurs, primary control will adapt (increase/decrease) the active power production of each unit (depending on the power shift key strategy), leading to an over- or under-frequency situation. The secondary frequency controller will then control the frequency back to its nominal value, re- establishing a cost-efficient generation delivered by each unit." ;
+        rdfs:label              "PowerFrequencyController"@en ;
+        rdfs:subClassOf         nc:SystemControl ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerFrequencyController.ControlArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Control area which has a power frequency controller." ;
+        rdfs:domain           nc:PowerFrequencyController ;
+        rdfs:label            "ControlArea"@en ;
+        rdfs:range            cim:ControlArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ControlArea.PowerFrequencyController ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerFrequencyController.FrequencyMonitoringTerminal
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Frequency monitoring terminal for this power frequency controller." ;
+        rdfs:domain           nc:PowerFrequencyController ;
+        rdfs:label            "FrequencyMonitoringTerminal"@en ;
+        rdfs:range            nc:FrequencyMonitoringTerminal ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:FrequencyMonitoringTerminal.PowerFrequencyController ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerFrequencyController.MonitoringArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Monitoring area that has this power frequency controller." ;
+        rdfs:domain           nc:PowerFrequencyController ;
+        rdfs:label            "MonitoringArea"@en ;
+        rdfs:range            nc:MonitoringArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:MonitoringArea.PowerFrequencyController ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerFrequencyController.PowerShiftKeyStrategy
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power shift key strategy for this power frequency controller." ;
+        rdfs:domain           nc:PowerFrequencyController ;
+        rdfs:label            "PowerShiftKeyStrategy"@en ;
+        rdfs:range            nc:PowerShiftKeyStrategy ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerShiftKeyStrategy.PowerFrequencyController ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerFrequencyController.mode
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Mode of the power frequency controller." ;
+        rdfs:domain        nc:PowerFrequencyController ;
+        rdfs:label         "mode"@en ;
+        rdfs:range         nc:PowerFrequencyControlKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerPlantController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Power plant controller is controlling the equipment of a power plant. " ;
+        rdfs:label              "PowerPlantController"@en ;
+        rdfs:subClassOf         nc:EquipmentController ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerShiftKeyKind  rdf:type  rdfs:Class ;
+        rdfs:comment            "Kind of generating and load shift keys strategy." ;
+        rdfs:label              "PowerShiftKeyKind"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:PowerShiftKeyKind.consumptionsFlat
+        rdf:type         nc:PowerShiftKeyKind ;
+        rdfs:comment     "Flat adjustment, equal amount of power, on all active consumption units (Energy Consumers and Power Electronics like FlexibleEnergyUnit). e.g. 100 MW decrease adjustment on 4 loads, it means that each of them get reduced 25 MW, as long as no other constraints are violated." ;
+        rdfs:label       "consumptionsFlat"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerShiftKeyKind.consumptionsP
+        rdf:type         nc:PowerShiftKeyKind ;
+        rdfs:comment     "The distribution is based on the consumptions active power in the given case." ;
+        rdfs:label       "consumptionsP"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerShiftKeyKind.explicitDistribution
+        rdf:type         nc:PowerShiftKeyKind ;
+        rdfs:comment     "The distribution is explicitly done according to the power shift key  distribution in the power bid Schedule." ;
+        rdfs:label       "explicitDistribution"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerShiftKeyKind.explicitInstruction
+        rdf:type         nc:PowerShiftKeyKind ;
+        rdfs:comment     "The distribution is done according to the individual participation factor on the unit." ;
+        rdfs:label       "explicitInstruction"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerShiftKeyKind.generatorsAndConsumptionsP
+        rdf:type         nc:PowerShiftKeyKind ;
+        rdfs:comment     "The distribution is based on the generator and consumption active power in the given case." ;
+        rdfs:label       "generatorsAndConsumptionsP"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerShiftKeyKind.generatorsFlat
+        rdf:type         nc:PowerShiftKeyKind ;
+        rdfs:comment     "Flat adjustment, equal amount of power, on all active generators. e.g. 100 MW increase adjustment on 4 generators, it means that each of them get increased 25 MW, as long as no other constraints are violated." ;
+        rdfs:label       "generatorsFlat"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerShiftKeyKind.generatorsP
+        rdf:type         nc:PowerShiftKeyKind ;
+        rdfs:comment     "The distribution is based on the generators active power in the given case." ;
+        rdfs:label       "generatorsP"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerShiftKeyKind.generatorsPmax
+        rdf:type         nc:PowerShiftKeyKind ;
+        rdfs:comment     "The distribution is relative to the maximum p of the generator." ;
+        rdfs:label       "generatorsPmax"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerShiftKeyKind.generatorsPmin
+        rdf:type         nc:PowerShiftKeyKind ;
+        rdfs:comment     "The distribution is relative to the minimum p of the generator." ;
+        rdfs:label       "generatorsPmin"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerShiftKeyKind.generatorsRemainingCapacity
+        rdf:type         nc:PowerShiftKeyKind ;
+        rdfs:comment     "The distribution is based on the remaining capacity for generators in the given case." ;
+        rdfs:label       "generatorsRemainingCapacity"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerShiftKeyKind.generatorsUsedCapacity
+        rdf:type         nc:PowerShiftKeyKind ;
+        rdfs:comment     "The distribution is based on the used capacity, the difference between the minimum operation and operating p (GeneratingUnit.minOperatingP)" ;
+        rdfs:label       "generatorsUsedCapacity"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerShiftKeyKind.nonConformLoadP
+        rdf:type         nc:PowerShiftKeyKind ;
+        rdfs:comment     "The distribution is based on the non conform load active power in the given case." ;
+        rdfs:label       "nonConformLoadP"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerShiftKeyKind.storageFlat
+        rdf:type         nc:PowerShiftKeyKind ;
+        rdfs:comment     "Flat adjustment, equal amount of power, on all the batteries and any operating hydro pumps. e.g. 100 MW increase or decrease adjustment on 4 batteries, it means that each of them get increased or reduced 25 MW, as long as no other constraints are violated." ;
+        rdfs:label       "storageFlat"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerShiftKeyKind.storageP
+        rdf:type         nc:PowerShiftKeyKind ;
+        rdfs:comment     "The distribution is based on the batteries and any operating hydro pumps active power in the given case." ;
+        rdfs:label       "storageP"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerShiftKeyStrategy
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Strategy of the power shift key." ;
+        rdfs:label              "PowerShiftKeyStrategy"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerShiftKeyStrategy.PowerFrequencyController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power frequency controller that has power shift key strategy." ;
+        rdfs:domain           nc:PowerShiftKeyStrategy ;
+        rdfs:label            "PowerFrequencyController"@en ;
+        rdfs:range            nc:PowerFrequencyController ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerFrequencyController.PowerShiftKeyStrategy ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerShiftKeyStrategy.SchedulingArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Scheduling area associated with power shift key strategy." ;
+        rdfs:domain           nc:PowerShiftKeyStrategy ;
+        rdfs:label            "SchedulingArea"@en ;
+        rdfs:range            nc:SchedulingArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SchedulingArea.PowerShiftKeyStrategy ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerShiftKeyStrategy.dispatchableUnitOnly
+        rdf:type           rdf:Property ;
+        rdfs:comment       "If true, only dispatchable units are included in the power shift key strategy. A unit is considered dispatchable if it is associated with an area dispatchable unit that is linked to the same scheduling area as the power shift key strategy.\nExceptions are done for units that are included in explicit or distributed strategies." ;
+        rdfs:domain        nc:PowerShiftKeyStrategy ;
+        rdfs:label         "dispatchableUnitOnly"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerShiftKeyStrategy.method
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Shift method used for the power shift strategy." ;
+        rdfs:domain        nc:PowerShiftKeyStrategy ;
+        rdfs:label         "method"@en ;
+        rdfs:range         nc:ShiftMethodKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerShiftKeyStrategy.normalEnabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "If true, the assessed element shall be considered under normal operating conditions." ;
+        rdfs:domain        nc:PowerShiftKeyStrategy ;
+        rdfs:label         "normalEnabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerShiftKeyStrategy.normalParticipationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Normal participation factor describing the entities part of the power shift strategy. Must be a positive value." ;
+        rdfs:domain        nc:PowerShiftKeyStrategy ;
+        rdfs:label         "normalParticipationFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerShiftKeyStrategy.powerBlockKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Power block kind creates block (one or more) of power shift key strategy to address increase and/or decrease of power for a given scheduling area." ;
+        rdfs:domain        nc:PowerShiftKeyStrategy ;
+        rdfs:label         "powerBlockKind"@en ;
+        rdfs:range         nc:PowerBlockKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerShiftKeyStrategy.powerShiftKey
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Power shift keys strategy gives instruction on how the value (Active power) is going to be distributed inside the relevant bidding zone." ;
+        rdfs:domain        nc:PowerShiftKeyStrategy ;
+        rdfs:label         "powerShiftKey"@en ;
+        rdfs:range         nc:PowerShiftKeyKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerSystemOrganisationRole
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A role that is responsible for the functional operational of a power system resource." ;
+        rdfs:label              "PowerSystemOrganisationRole"@en ;
+        rdfs:subClassOf         cim:OrganisationRole ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:PowerTransferCorridor
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A power transfer corridor is defined as a set of circuits (transmission lines or transformers) separating two portions of the power system, or a subset of circuits exposed to a substantial portion of the transmission exchange between two parts of the system." ;
+        rdfs:label              "PowerTransferCorridor"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:PowerTransferCorridor.CircuitShare
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The circuit share for this power transfer corridor." ;
+        rdfs:domain           nc:PowerTransferCorridor ;
+        rdfs:label            "CircuitShare"@en ;
+        rdfs:range            nc:CircuitShare ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:CircuitShare.PowerTransferCorridor ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerTransferCorridor.OperationalLimitSet
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The operational limit set relevant for this power transfer corridor." ;
+        rdfs:domain           nc:PowerTransferCorridor ;
+        rdfs:label            "OperationalLimitSet"@en ;
+        rdfs:range            cim:OperationalLimitSet ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:OperationalLimitSet.PowerTransferCorridor ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerTransferCorridor.normalEnabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "It is the normal enable/disable the monitoring/assessment of a power transfer corridor. True means that the monitoring of the power transfer corridor is assessed. False means the power transfer corridor is not assessed. " ;
+        rdfs:domain        nc:PowerTransferCorridor ;
+        rdfs:label         "normalEnabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerTransformerCircuit
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A power transformer circuit is a circuit that has at least one PowerTransformer and may or may not include related switching and/or auxiliary equipment." ;
+        rdfs:label              "PowerTransformerCircuit"@en ;
+        rdfs:subClassOf         nc:Circuit ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PropertyReference  rdf:type  rdfs:Class ;
+        rdfs:comment            "The reference to a class and one of its properties." ;
+        rdfs:label              "PropertyReference"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:PropertyReference.FunctionOutputVariable
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Function output variable is the function output this property reference is used in." ;
+        rdfs:domain           nc:PropertyReference ;
+        rdfs:label            "FunctionOutputVariable"@en ;
+        rdfs:range            nc:FunctionOutputVariable ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:FunctionOutputVariable.PropertyReference ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ProportionalEnergyComponent
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Serves for grouping components within an energy group, with proportional energy allocation to all components." ;
+        rdfs:label              "ProportionalEnergyComponent"@en ;
+        rdfs:subClassOf         nc:EnergyComponent ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ProportionalEnergyComponent.normalParticipationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Normal participation factor." ;
+        rdfs:domain        nc:ProportionalEnergyComponent ;
+        rdfs:label         "normalParticipationFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ProportionalEnergyComponent.powerDuration
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Duration for the active power." ;
+        rdfs:domain        nc:ProportionalEnergyComponent ;
+        rdfs:label         "powerDuration"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RampingPrincipleKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of ramping principle." ;
+        rdfs:label              "RampingPrincipleKind"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:RampingPrincipleKind.continuous
+        rdf:type         nc:RampingPrincipleKind ;
+        rdfs:comment     "Continuous ramping principle is applied between two scheduled time point. For instance, from 10 MW to 70 MW over one hour the change is 1 MW/min." ;
+        rdfs:label       "continuous"@en ;
+        cims:stereotype  "enum" .
+
+nc:RampingPrincipleKind.fifteenMinutes
+        rdf:type         nc:RampingPrincipleKind ;
+        rdfs:comment     "Fifteen minutes ramping principle. Ramping starts 15 minutes before the schedule time point and ends 15 minutes after. For instance, if the schedule time point is 19:30h it starts at 19:15h and ends at 19:45h. " ;
+        rdfs:label       "fifteenMinutes"@en ;
+        cims:stereotype  "enum" .
+
+nc:RampingPrincipleKind.fiveMinutes
+        rdf:type         nc:RampingPrincipleKind ;
+        rdfs:comment     "Five minutes ramping principle. Ramping starts five minutes before the schedule time point and ends five minutes after. For instance, if the schedule time point is 19:30h it starts at 19:25h and ends at 19:35h. " ;
+        rdfs:label       "fiveMinutes"@en ;
+        cims:stereotype  "enum" .
+
+nc:RampingPrincipleKind.maxContinuous
+        rdf:type         nc:RampingPrincipleKind ;
+        rdfs:comment     "Maximum continuous ramping principle. The schedule is kept as long as possible and the maximum ramping rate is used to get from one point to another, symmetrically around the schedule time points. For example, there is 40 MW change in the schedule the maximum ramp rate is 20 MW/min the ramping starts 1 min before (e.g. 19:29h) and finishes 1 min after (e.g. 19:31h).  " ;
+        rdfs:label       "maxContinuous"@en ;
+        cims:stereotype  "enum" .
+
+nc:RampingPrincipleKind.tenMinutes
+        rdf:type         nc:RampingPrincipleKind ;
+        rdfs:comment     "Ten minutes ramping principle. Ramping starts 10 minutes before the schedule time point and ends 10 minutes after. For instance, if the schedule time point is 19:30h it starts at 19:20h and ends at 19:40h. " ;
+        rdfs:label       "tenMinutes"@en ;
+        cims:stereotype  "enum" .
+
+nc:ReactiveCapabilityCurve.referenceVoltage
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The reference voltage for which the capability curve is valid." ;
+        rdfs:domain        cim:ReactiveCapabilityCurve ;
+        rdfs:label         "referenceVoltage"@en ;
+        cims:dataType      cim:Voltage ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ReactivePowerControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Reactive power control function is a function block that calculate the operating point of the controlled equipment to achieve the target reactive power." ;
+        rdfs:label              "ReactivePowerControlFunction"@en ;
+        rdfs:subClassOf         nc:ControlFunctionBlock ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RecoveryOverloadLimitCurve
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The relation between the recovery time and an overload limit." ;
+        rdfs:label              "RecoveryOverloadLimitCurve"@en ;
+        rdfs:subClassOf         nc:LimitDependencyCurve ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RecoveryOverloadLimitCurve.OperationalLimitType
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The operational limit type which has recovery time characteristic." ;
+        rdfs:domain           nc:RecoveryOverloadLimitCurve ;
+        rdfs:label            "OperationalLimitType"@en ;
+        rdfs:range            cim:OperationalLimitType ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:OperationalLimitType.RecoveryOverloadLimitCurve ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Region  rdf:type             rdfs:Class ;
+        rdfs:comment            "A region where the system operator belongs to." ;
+        rdfs:label              "Region"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:Region.OverlappingZone
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The overlapping zone which is impacted by this  region." ;
+        rdfs:domain           nc:Region ;
+        rdfs:label            "OverlappingZone"@en ;
+        rdfs:range            nc:OverlappingZone ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:OverlappingZone.ImpactedRegion ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:RegulatingCondEq.EquipmentController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The equipment controller for this regulating conducting equipment." ;
+        rdfs:domain           cim:RegulatingCondEq ;
+        rdfs:label            "EquipmentController"@en ;
+        rdfs:range            nc:EquipmentController ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EquipmentController.RegulatingCondEq ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:RotatingMachineController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Rotating machine controller is controlling the equipment which may be used as a generator or motor." ;
+        rdfs:label              "RotatingMachineController"@en ;
+        rdfs:subClassOf         nc:EquipmentController ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SSSCController  rdf:type     rdfs:Class ;
+        rdfs:comment            "The controller of a Static synchronous series compensator (SSSC)." ;
+        rdfs:label              "SSSCController"@en ;
+        rdfs:subClassOf         nc:EquipmentController ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SSSCController.CurrentDroopOverride
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The current droop override for this SSSC controller. It is not used when the SSSC controller is in mode currentDroop." ;
+        rdfs:domain           nc:SSSCController ;
+        rdfs:label            "CurrentDroopOverride"@en ;
+        rdfs:range            nc:CurrentDroopOverride ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:CurrentDroopOverride.SSSCController ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:SSSCController.SSSCSimulationSettings
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The simulation setings that apply for this controller." ;
+        rdfs:domain           nc:SSSCController ;
+        rdfs:label            "SSSCSimulationSettings"@en ;
+        rdfs:range            nc:SSSCSimulationSettings ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SSSCSimulationSettings.SSSCController ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:SSSCController.maxInjectionU
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum voltage that the device can inject." ;
+        rdfs:domain        nc:SSSCController ;
+        rdfs:label         "maxInjectionU"@en ;
+        cims:dataType      cim:Voltage ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SSSCController.maxLimitI
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum operating current limit applied for the controller and used by any of the available control functions." ;
+        rdfs:domain        nc:SSSCController ;
+        rdfs:label         "maxLimitI"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SSSCController.minInjectionU
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Minimum voltage that the device can inject." ;
+        rdfs:domain        nc:SSSCController ;
+        rdfs:label         "minInjectionU"@en ;
+        cims:dataType      cim:Voltage ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SSSCController.minLimitI
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Minimum operating current limit applied for the controller and used by any of the available control functions." ;
+        rdfs:domain        nc:SSSCController ;
+        rdfs:label         "minLimitI"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SSSCSimulationSettings
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "SSSC control simulation settings used by the algorithm for power flow calculations. " ;
+        rdfs:label              "SSSCSimulationSettings"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SSSCSimulationSettings.SSSCController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The controller that uses these simulation settings." ;
+        rdfs:domain           nc:SSSCSimulationSettings ;
+        rdfs:label            "SSSCController"@en ;
+        rdfs:range            nc:SSSCController ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:SSSCController.SSSCSimulationSettings ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SSSCSimulationSettings.deltaX
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Reactance delta for the solution algorithm. The solution “outer-loop” algorithm is based on a secant method which needs two initial points. The second point is calculated from the first one by either adding or subtracting this “delta”. The “seed” is assumed to be 0 ohms." ;
+        rdfs:domain        nc:SSSCSimulationSettings ;
+        rdfs:label         "deltaX"@en ;
+        cims:dataType      cim:Reactance ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SSSCSimulationSettings.isEstimateDLDVSensitive
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Defines if the estimate is considering the dI/dV sensitivity (true) instead of the secant algorithm (false). " ;
+        rdfs:domain        nc:SSSCSimulationSettings ;
+        rdfs:label         "isEstimateDLDVSensitive"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SSSCSimulationSettings.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:SSSCSimulationSettings ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SSSCSimulationSettings.maxCorrectionX
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum value of the reactance correction applied between Iterations of the power flow calculation algorithm for the purpose of achieving control target value." ;
+        rdfs:domain        nc:SSSCSimulationSettings ;
+        rdfs:label         "maxCorrectionX"@en ;
+        cims:dataType      cim:Reactance ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SSSCSimulationSettings.maxIterations
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum number of iterations before claiming an open line condition. The algorithm uses it to assess if a line is really open by making sure low-currents are observed on various consecutive iterations. " ;
+        rdfs:domain        nc:SSSCSimulationSettings ;
+        rdfs:label         "maxIterations"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SSSCSimulationSettings.maxMismatch
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum mismatch tolerance of voltage target value. If mismatch is lower, convergence is claimed. It is only used for voltageInjection and currentDroop control modes. " ;
+        rdfs:domain        nc:SSSCSimulationSettings ;
+        rdfs:label         "maxMismatch"@en ;
+        cims:dataType      cim:Voltage ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ScheduleResource  rdf:type   rdfs:Class ;
+        rdfs:comment            "A schedule resource is a market-based method for handling participation of small units, particularly located on the lower voltage level that is controlled by a Distributed System Operator (DSO). It is a collection of units that can operate in the market by providing bids, offers and a resulting committed operational schedule for the collection." ;
+        rdfs:label              "ScheduleResource"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ScheduleResource.AreaDispatchableUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The dispatchable unit for this scheduled resource." ;
+        rdfs:domain           nc:ScheduleResource ;
+        rdfs:label            "AreaDispatchableUnit"@en ;
+        rdfs:range            nc:AreaDispatchableUnit ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AreaDispatchableUnit.ScheduleResource ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:ScheduleResource.GeneratingUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The generating unit that relates to this schedule resource." ;
+        rdfs:domain           nc:ScheduleResource ;
+        rdfs:label            "GeneratingUnit"@en ;
+        rdfs:range            cim:GeneratingUnit ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GeneratingUnit.ScheduleResource ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ScheduleResource.HydroPump
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The hydro pump that relates to this schedule resource." ;
+        rdfs:domain           nc:ScheduleResource ;
+        rdfs:label            "HydroPump"@en ;
+        rdfs:range            cim:HydroPump ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:HydroPump.ScheduleResource ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ScheduleResource.PowerElectronicsUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The power electronics unit that relates to this schedule resource." ;
+        rdfs:domain           nc:ScheduleResource ;
+        rdfs:label            "PowerElectronicsUnit"@en ;
+        rdfs:range            cim:PowerElectronicsUnit ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerElectronicsUnit.ScheduleResource ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ScheduleResource.PrimaryEnergySource
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Primary energy reference type for this schedule resource." ;
+        rdfs:domain           nc:ScheduleResource ;
+        rdfs:label            "PrimaryEnergySource"@en ;
+        rdfs:range            nc:EnergyType ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EnergyType.ScheduleResource ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ScheduleResource.ResourceOf
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The schedule resource that has this subschedule resource." ;
+        rdfs:domain           nc:ScheduleResource ;
+        rdfs:label            "ResourceOf"@en ;
+        rdfs:range            nc:ScheduleResource ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ScheduleResource.SubScheduleResource ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ScheduleResource.ScheduleResourceController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Schedule resource controller for this schedule resource." ;
+        rdfs:domain           nc:ScheduleResource ;
+        rdfs:label            "ScheduleResourceController"@en ;
+        rdfs:range            nc:ScheduleResourceController ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ScheduleResourceController.ScheduleResource ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ScheduleResource.SchedulingArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The scheduling area that has this schedule resource." ;
+        rdfs:domain           nc:ScheduleResource ;
+        rdfs:label            "SchedulingArea"@en ;
+        rdfs:range            nc:SchedulingArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SchedulingArea.ScheduleResource ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ScheduleResource.SubScheduleResource
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The subschedule resource that relates to the schedule resource." ;
+        rdfs:domain           nc:ScheduleResource ;
+        rdfs:label            "SubScheduleResource"@en ;
+        rdfs:range            nc:ScheduleResource ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ScheduleResource.ResourceOf ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ScheduleResourceController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Schedule resource controller is controlling the equipment to optimize the schedule resource. " ;
+        rdfs:label              "ScheduleResourceController"@en ;
+        rdfs:subClassOf         nc:EquipmentController ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ScheduleResourceController.ScheduleResource
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Schedule resource that has a schedule resource controller." ;
+        rdfs:domain           nc:ScheduleResourceController ;
+        rdfs:label            "ScheduleResource"@en ;
+        rdfs:range            nc:ScheduleResource ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ScheduleResource.ScheduleResourceController ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:SchedulingArea  rdf:type     rdfs:Class ;
+        rdfs:comment            "An area where production and/or consumption of energy can be forecasted, scheduled and measured. The area is operated by only one system operator, typically a Transmission System Operator (TSO). The area can consist of a sub area, which has the same definition as the main area, but it can be operated by another system operator (typically Distributed System Operator (DSO) or a Closed Distributed System Operator (CDSO)). This includes microgrid concept. A substation is the smallest grouping that can be included in the area. The area size should be considered in terms of the possibility of accumulated reading (settlement metering) and the capability of operating as an island." ;
+        rdfs:label              "SchedulingArea"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SchedulingArea.AreaDispatchableUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The area dispatchable unit related to a scheduling area." ;
+        rdfs:domain           nc:SchedulingArea ;
+        rdfs:label            "AreaDispatchableUnit"@en ;
+        rdfs:range            nc:AreaDispatchableUnit ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AreaDispatchableUnit.SchedulingArea ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SchedulingArea.BiddingZone
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The bidding zone related to this scheduling area." ;
+        rdfs:domain           nc:SchedulingArea ;
+        rdfs:label            "BiddingZone"@en ;
+        rdfs:range            nc:BiddingZone ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:BiddingZone.SchedulingArea ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:SchedulingArea.ControlArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The control area for this scheduling area." ;
+        rdfs:domain           nc:SchedulingArea ;
+        rdfs:label            "ControlArea"@en ;
+        rdfs:range            cim:ControlArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ControlArea.SchedulingArea ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:SchedulingArea.DCTieCorridor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The DC tie corridor that is part of this scheduling area." ;
+        rdfs:domain           nc:SchedulingArea ;
+        rdfs:label            "DCTieCorridor"@en ;
+        rdfs:range            nc:DCTieCorridor ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DCTieCorridor.SchedulingArea ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:SchedulingArea.EnergyCoordinationRegion
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The energy coordination region that has this scheduling area." ;
+        rdfs:domain           nc:SchedulingArea ;
+        rdfs:label            "EnergyCoordinationRegion"@en ;
+        rdfs:range            nc:EnergyCoordinationRegion ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EnergyCoordinationRegion.SchedulingArea ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:SchedulingArea.EnergyGroup
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The energy group belonging to a given energy scheduling area." ;
+        rdfs:domain           nc:SchedulingArea ;
+        rdfs:label            "EnergyGroup"@en ;
+        rdfs:range            nc:EnergyGroup ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EnergyGroup.SchedulingArea ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SchedulingArea.Line
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The line that is part of this scheduling area." ;
+        rdfs:domain           nc:SchedulingArea ;
+        rdfs:label            "Line"@en ;
+        rdfs:range            cim:Line ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:Line.SchedulingArea ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SchedulingArea.LoadFrequencyControlArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The load frequency control area which has this scheduling area." ;
+        rdfs:domain           nc:SchedulingArea ;
+        rdfs:label            "LoadFrequencyControlArea"@en ;
+        rdfs:range            nc:LoadFrequencyControlArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:LoadFrequencyControlArea.SchedulingArea ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:SchedulingArea.PowerShiftKeyStrategy
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power Shift Key Strategy which has a scheduling area." ;
+        rdfs:domain           nc:SchedulingArea ;
+        rdfs:label            "PowerShiftKeyStrategy"@en ;
+        rdfs:range            nc:PowerShiftKeyStrategy ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerShiftKeyStrategy.SchedulingArea ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SchedulingArea.ScheduleResource
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The schedule resource that belongs to this scheduled area." ;
+        rdfs:domain           nc:SchedulingArea ;
+        rdfs:label            "ScheduleResource"@en ;
+        rdfs:range            nc:ScheduleResource ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ScheduleResource.SchedulingArea ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SchedulingArea.SubSchedulingArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The subscheduling are that belongs to this scheduling area." ;
+        rdfs:domain           nc:SchedulingArea ;
+        rdfs:label            "SubSchedulingArea"@en ;
+        rdfs:range            nc:SubSchedulingArea ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:SubSchedulingArea.SchedulingArea ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SchedulingArea.Substation
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The substation that is part of this scheduling area." ;
+        rdfs:domain           nc:SchedulingArea ;
+        rdfs:label            "Substation"@en ;
+        rdfs:range            cim:Substation ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:Substation.SchedulingArea ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SchedulingArea.SynchronousArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The synchronous are that has this scheduling area." ;
+        rdfs:domain           nc:SchedulingArea ;
+        rdfs:label            "SynchronousArea"@en ;
+        rdfs:range            nc:SynchronousArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SynchronousArea.SchedulingArea ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:SchedulingArea.SystemOperator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The system operator for this scheduling area." ;
+        rdfs:domain           nc:SchedulingArea ;
+        rdfs:label            "SystemOperator"@en ;
+        rdfs:range            nc:SystemOperator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SystemOperator.SchedulingArea ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:SchedulingArea.isIslandingEnabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Identifies if the area can operate in island operation. If true, the area is enabled (capable) of operating as an electrical island. If false, the area does not have the capability or it is not enabled to operate as an electrical island." ;
+        rdfs:domain        nc:SchedulingArea ;
+        rdfs:label         "isIslandingEnabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SchedulingArea.isMeteringGridArea
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Identifies if the area is settlement metered for all import and export to the area. If true, the area is metered area. If false, it is not." ;
+        rdfs:domain        nc:SchedulingArea ;
+        rdfs:label         "isMeteringGridArea"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SchedulingArea.normalParticipationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Normal participation factor describing the entity part of the active power provided by a collection of entities (e.g. an active power forecast to a collection of entities is divided to each of the member entity according to the participation factor). Must be a positive value.\nIn the case of a sharing strategy, the distribution is following entities value (V) equals aggregated value (T) divided by sum of participation factors (PF), i.e. V=T/sum(PF). \nIn the case of priority strategy, the item with the lowest number gets allocated energy first." ;
+        rdfs:domain        nc:SchedulingArea ;
+        rdfs:label         "normalParticipationFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SecurityCoordinator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A role that coordinates the relevant remedial actions and their optimisation to ensure efficient use to achieve required operational security of the power system." ;
+        rdfs:label              "SecurityCoordinator"@en ;
+        rdfs:subClassOf         nc:SystemOperationCoordinator ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SecurityCoordinator.CapacityCalculationRegion
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The capacity calculation region operated by this security coordinator." ;
+        rdfs:domain           nc:SecurityCoordinator ;
+        rdfs:label            "CapacityCalculationRegion"@en ;
+        rdfs:range            nc:CapacityCalculationRegion ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:CapacityCalculationRegion.SecurityCoordinator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SecurityCoordinator.OutageCoordinationRegion
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The outage coordination region that has this security coordinator." ;
+        rdfs:domain           nc:SecurityCoordinator ;
+        rdfs:label            "OutageCoordinationRegion"@en ;
+        rdfs:range            nc:OutageCoordinationRegion ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:OutageCoordinationRegion.SecurityCoordinator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ShiftMethodKind  rdf:type    rdfs:Class ;
+        rdfs:comment            "Kind of shift method. Describes the way a power schedule should be distributed amongst production and consumption. e.g. Type of generating and load shift key." ;
+        rdfs:label              "ShiftMethodKind"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:ShiftMethodKind.priority
+        rdf:type         nc:ShiftMethodKind ;
+        rdfs:comment     "Power schedule shift (distribution) is done by a shared fraction prioritizing the unit e.g. A two unit with the participation factor 60 and 40 will distribute a 10 MW increased schedule by first filling the highest participation factor (priority) until max economy power or maximum power allowed by the unit before it starts filling the next on the list. e.g. The unit with 60 will be getting its maximum shared first. The same logic applies with reducing the schedule. e.g. The 60 participation factor unit will be reduced to its min economy factor or minimum power." ;
+        rdfs:label       "priority"@en ;
+        cims:stereotype  "enum" .
+
+nc:ShiftMethodKind.shared
+        rdf:type         nc:ShiftMethodKind ;
+        rdfs:comment     "Power schedule shift (distribution) is done by a shared fraction e.g. A two unit with the participation factor 60 and 40 will distribute a 10 MW schedule by 6 and 4 MW." ;
+        rdfs:label       "shared"@en ;
+        cims:stereotype  "enum" .
+
+nc:SolarRadiationDependencyCurve
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A curve or functional relationship between \n- the solar radiation independent variable (X-axis), and \n- relative dependent (Y-axis) variables." ;
+        rdfs:label              "SolarRadiationDependencyCurve"@en ;
+        rdfs:subClassOf         nc:LimitDependencyCurve ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SolarRadiationDependencyCurve.OperationalLimitType
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The operational limit type that has this permanent solar radiation curve." ;
+        rdfs:domain           nc:SolarRadiationDependencyCurve ;
+        rdfs:label            "OperationalLimitType"@en ;
+        rdfs:range            cim:OperationalLimitType ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:OperationalLimitType.PermanentSolarRadiationCurve ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:StaticSynchronousCompensator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Static synchronous compensator (STATCOM), also known as a static synchronous condenser (STATCON), is a type of flexible AC transmission system regulating equipment used on alternating current electricity transmission networks. It is based on a power electronics voltage-source converter and can act as either a source or sink of reactive AC power to an electricity network. If connected to a source of power it can also provide active AC power." ;
+        rdfs:label              "StaticSynchronousCompensator"@en ;
+        rdfs:subClassOf         nc:FACTSEquipment ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:StaticSynchronousSeriesCompensator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Static synchronous series compensator (SSSC) is a type of flexible AC transmission system which consists of a solid-state voltage source inverter coupled with a transformer that is connected in series with a transmission line. This device can inject an almost sinusoidal voltage in series with the line. This injected voltage could be considered as an inductive or capacitive reactance, which is connected in series with the transmission line. This feature can provide controllable voltage compensation. In addition, SSSC is able to reverse the power flow by injecting a sufficiently large series reactive compensating voltage. Moreover it can inject a voltage proportional to the difference between the line current and the pre-configured current threshold.<font color=\"#636671\"> </font>It shall have two Terminal-s associated with it. " ;
+        rdfs:label              "StaticSynchronousSeriesCompensator"@en ;
+        rdfs:subClassOf         nc:FACTSEquipment ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:StaticVarCompensator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A facility for providing variable and controllable shunt reactive power. The SVC typically consists of a stepdown transformer, filter, thyristor-controlled reactor, and thyristor-switched capacitor arms.\n\nThe SVC may operate in fixed MVar output mode or in voltage control mode. When in voltage control mode, the output of the SVC will be proportional to the deviation of voltage at the controlled bus from the voltage setpoint.  The SVC characteristic slope defines the proportion.  If the voltage at the controlled bus is equal to the voltage setpoint, the SVC MVar output is zero." ;
+        rdfs:label              "StaticVarCompensator"@en ;
+        rdfs:subClassOf         nc:FACTSEquipment ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SubSchedulingArea  rdf:type  rdfs:Class ;
+        rdfs:comment            "An area that is a part of another scheduling area. Typically part of a Transmission System Operator (TSO) scheduling area operated by a Distributed System Operator (DSO) or a Close Distributed System Operator (CDSO). This includes microgrid concept. A sub scheduling area can contain other sub areas. A sub scheduling area leaf will form the smallest entity of any given energy area." ;
+        rdfs:label              "SubSchedulingArea"@en ;
+        rdfs:subClassOf         nc:SchedulingArea ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SubSchedulingArea.Feeder
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The feeder that is part of this subscheduling area." ;
+        rdfs:domain           nc:SubSchedulingArea ;
+        rdfs:label            "Feeder"@en ;
+        rdfs:range            cim:Feeder ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:Feeder.SubSchedulingArea ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SubSchedulingArea.SchedulingArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The scheduling area that has this subscheduling area." ;
+        rdfs:domain           nc:SubSchedulingArea ;
+        rdfs:label            "SchedulingArea"@en ;
+        rdfs:range            nc:SchedulingArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SchedulingArea.SubSchedulingArea ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:Substation.DCSubstation
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC substation that is part of AC and DC substation." ;
+        rdfs:domain           cim:Substation ;
+        rdfs:label            "DCSubstation"@en ;
+        rdfs:range            nc:DCSubstation ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:DCSubstation.Substation ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Substation.SchedulingArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The scheduling area that has this substation." ;
+        rdfs:domain           cim:Substation ;
+        rdfs:label            "SchedulingArea"@en ;
+        rdfs:range            nc:SchedulingArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SchedulingArea.Substation ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:SubstationController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Substation controller is controlling the equipment to optimize the use of the controlling equipment within a substation. " ;
+        rdfs:label              "SubstationController"@en ;
+        rdfs:subClassOf         nc:EquipmentController ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SynchronousArea  rdf:type    rdfs:Class ;
+        rdfs:comment            "A synchronous area is an electrical area covered by interconnect with a common system frequency in a steady-state. " ;
+        rdfs:label              "SynchronousArea"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SynchronousArea.LoadFrequencyControlBlock
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The load frequency control block that is part of this synchronous area." ;
+        rdfs:domain           nc:SynchronousArea ;
+        rdfs:label            "LoadFrequencyControlBlock"@en ;
+        rdfs:range            nc:LoadFrequencyControlBlock ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:LoadFrequencyControlBlock.SynchronousArea ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SynchronousArea.SchedulingArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The scheduling area that is part of this synchronous area." ;
+        rdfs:domain           nc:SynchronousArea ;
+        rdfs:label            "SchedulingArea"@en ;
+        rdfs:range            nc:SchedulingArea ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:SchedulingArea.SynchronousArea ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SynchronousArea.nominalFrequency
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The nominal frequency for the Synchronous Area, e.g. 50 Hz for Europe." ;
+        rdfs:domain        nc:SynchronousArea ;
+        rdfs:label         "nominalFrequency"@en ;
+        cims:dataType      cim:Frequency ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SystemControl  rdf:type      rdfs:Class ;
+        rdfs:comment            "System control is the management and regulation of various parameters within the electrical grid to ensure its stable and reliable operation. The primary goal of system control is to maintain the balance between electricity generation and consumption, while also managing factors such as voltage, frequency, and power quality. This involves the use of control devices, automation, and monitoring systems to respond to changes in the grid and maintain its overall stability.\nThis serves as Integrated AC and DC control system (IEC 60633) which governs the integrated operation of AC and DC systems of a power system." ;
+        rdfs:label              "SystemControl"@en ;
+        rdfs:subClassOf         nc:AutomationFunction ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:SystemControl.EquipmentController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Equipment controller controlles by this system control" ;
+        rdfs:domain           nc:SystemControl ;
+        rdfs:label            "EquipmentController"@en ;
+        rdfs:range            nc:EquipmentController ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EquipmentController.SystemControl ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:SystemOperationCoordinator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A role that coordinates relevant information and impact in regards to operating the power system." ;
+        rdfs:label              "SystemOperationCoordinator"@en ;
+        rdfs:subClassOf         nc:PowerSystemOrganisationRole ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:SystemOperator  rdf:type     rdfs:Class ;
+        rdfs:comment            "System operator." ;
+        rdfs:label              "SystemOperator"@en ;
+        rdfs:subClassOf         nc:PowerSystemOrganisationRole ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" .
+
+nc:SystemOperator.ControlArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The control area that is related to this system operator." ;
+        rdfs:domain           nc:SystemOperator ;
+        rdfs:label            "ControlArea"@en ;
+        rdfs:range            cim:ControlArea ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ControlArea.SystemOperator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SystemOperator.SchedulingArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The scheduling area that is operated by this system operator." ;
+        rdfs:domain           nc:SystemOperator ;
+        rdfs:label            "SchedulingArea"@en ;
+        rdfs:range            nc:SchedulingArea ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:SchedulingArea.SystemOperator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:TCSCCompensationPoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Compensation point of a TCSC compensator." ;
+        rdfs:label              "TCSCCompensationPoint"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:TCSCCompensationPoint.ThyristorControlledSeriesCompensator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "TCSC that has different compensation points." ;
+        rdfs:domain           nc:TCSCCompensationPoint ;
+        rdfs:label            "ThyristorControlledSeriesCompensator"@en ;
+        rdfs:range            nc:ThyristorControlledSeriesCompensator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ThyristorControlledSeriesCompensator.TCSCCompensationPoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:TCSCCompensationPoint.compensationZ
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The compensation impedance for this compensation point." ;
+        rdfs:domain        nc:TCSCCompensationPoint ;
+        rdfs:label         "compensationZ"@en ;
+        cims:dataType      cim:Impedance ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:TCSCCompensationPoint.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:TCSCCompensationPoint ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:TCSCCompensationPoint.section
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The number of the section." ;
+        rdfs:domain        nc:TCSCCompensationPoint ;
+        rdfs:label         "section"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:TCSCController  rdf:type     rdfs:Class ;
+        rdfs:comment            "TCSC controller is controlling the equipment to optimize the performance of the TCSC. " ;
+        rdfs:label              "TCSCController"@en ;
+        rdfs:subClassOf         nc:EquipmentController ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:TapChanger.TapChangeController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The tap changer controller that controls this TapChanger." ;
+        rdfs:domain           cim:TapChanger ;
+        rdfs:label            "TapChangeController"@en ;
+        rdfs:range            nc:TapChangerController ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:TapChangerController.TapChanger ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:TapChangerController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Tap changer controller is an equipment controller that controls a tap changer, e.g. how the voltage at the end of a line varies with the load level and compensation of the voltage drop by tap adjustment." ;
+        rdfs:label              "TapChangerController"@en ;
+        rdfs:subClassOf         nc:EquipmentController ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:TapChangerController.TapChanger
+        rdf:type              rdf:Property ;
+        rdfs:comment          "All tap changers controlled by this controller." ;
+        rdfs:domain           nc:TapChangerController ;
+        rdfs:label            "TapChanger"@en ;
+        rdfs:range            cim:TapChanger ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:TapChanger.TapChangeController ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Terminal.FrequencyMonitoringTerminal
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Frequency monitoring terminal that has a terminal." ;
+        rdfs:domain           cim:Terminal ;
+        rdfs:label            "FrequencyMonitoringTerminal"@en ;
+        rdfs:range            nc:FrequencyMonitoringTerminal ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:FrequencyMonitoringTerminal.Terminal ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Terminal.PinTerminal
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The pin that uses this input." ;
+        rdfs:domain           cim:Terminal ;
+        rdfs:label            "PinTerminal"@en ;
+        rdfs:range            nc:PinTerminal ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PinTerminal.Terminal ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Terminal.VoltageAngleLimit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The voltage angle limit which has this reference angle terminal." ;
+        rdfs:domain           cim:Terminal ;
+        rdfs:label            "VoltageAngleLimit"@en ;
+        rdfs:range            nc:VoltageAngleLimit ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:VoltageAngleLimit.AngleReferenceTerminal ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ThyristorControlledSeriesCompensator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Thyristor-controlled series capacitors (TCSC) is a type of flexible AC transmission system regulating equipment that is configured with controlled reactors in parallel with sections of a capacitor bank. This combination allows smooth control of the fundamental frequency capacitive reactance over a wide range. The thyristor valve contains a string of series connected high power thyristors. TCSC can control power flows in order to achieve eliminating of line overloads, reducing loop flows and minimising system losses." ;
+        rdfs:label              "ThyristorControlledSeriesCompensator"@en ;
+        rdfs:subClassOf         nc:FACTSEquipment ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ThyristorControlledSeriesCompensator.TCSCCompensationPoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Compensation point for this TCSC." ;
+        rdfs:domain           nc:ThyristorControlledSeriesCompensator ;
+        rdfs:label            "TCSCCompensationPoint"@en ;
+        rdfs:range            nc:TCSCCompensationPoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:TCSCCompensationPoint.ThyristorControlledSeriesCompensator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ThyristorControlledSeriesCompensator.flexibleCapacitiveZ
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Flexible impedance that can be controlled by the compensator when operating in the capacitive range.  Shall always be positive." ;
+        rdfs:domain        nc:ThyristorControlledSeriesCompensator ;
+        rdfs:label         "flexibleCapacitiveZ"@en ;
+        cims:dataType      cim:Impedance ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ThyristorControlledSeriesCompensator.flexibleInductiveZ
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Flexible impedance that can be controlled by the compensator when operating in the inductive range.  Shall always be negative." ;
+        rdfs:domain        nc:ThyristorControlledSeriesCompensator ;
+        rdfs:label         "flexibleInductiveZ"@en ;
+        cims:dataType      cim:Impedance ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ThyristorControlledSeriesCompensator.minI
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Minimum current below which the device bypassed." ;
+        rdfs:domain        nc:ThyristorControlledSeriesCompensator ;
+        rdfs:label         "minI"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ThyristorControlledSeriesCompensator.reconnectionCurrent
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The current for which the TCSC returns back to operation after bypass." ;
+        rdfs:domain        nc:ThyristorControlledSeriesCompensator ;
+        rdfs:label         "reconnectionCurrent"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:TieCorridor  rdf:type        rdfs:Class ;
+        rdfs:comment            "A collection of one or more tie-lines or direct current poles that connect two different control areas." ;
+        rdfs:label              "TieCorridor"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:TieCorridor.AreaDispatchableUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "AreaDispatchableUnit for the Tie Corridor." ;
+        rdfs:domain           nc:TieCorridor ;
+        rdfs:label            "AreaDispatchableUnit"@en ;
+        rdfs:range            nc:AreaDispatchableUnit ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AreaDispatchableUnit.TieCorridor ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:TieCorridor.BiddingZoneBorder
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Bidding zone border in which the tie corridor is located." ;
+        rdfs:domain           nc:TieCorridor ;
+        rdfs:label            "BiddingZoneBorder"@en ;
+        rdfs:range            nc:BiddingZoneBorder ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:BiddingZoneBorder.TieCorridor ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:TieCorridor.LoadFrequencyControlArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "LoadFrequencyControlArea controlling the TieCorridor." ;
+        rdfs:domain           nc:TieCorridor ;
+        rdfs:label            "LoadFrequencyControlArea"@en ;
+        rdfs:range            nc:LoadFrequencyControlArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:LoadFrequencyControlArea.TieCorridor ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:TieCorridor.TieFlow
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Tie flow which belongs to the tie corridor." ;
+        rdfs:domain           nc:TieCorridor ;
+        rdfs:label            "TieFlow"@en ;
+        rdfs:range            cim:TieFlow ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:TieFlow.TieCorridor ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:TieCorridor.delayRegulatingReserve
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A positive number that is a multiple of Automatic Generation Control (AGC) run cycles that describes the delay in adapting imbalance of the tie corridor." ;
+        rdfs:domain        nc:TieCorridor ;
+        rdfs:label         "delayRegulatingReserve"@en ;
+        cims:dataType      cim:Seconds ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:TieCorridor.maxRegulatingReserveRamp
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum authorized ramp for regulating reserve." ;
+        rdfs:domain        nc:TieCorridor ;
+        rdfs:label         "maxRegulatingReserveRamp"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:TieCorridor.thresholdRegulatingReserve
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Regulating reserve threshold." ;
+        rdfs:domain        nc:TieCorridor ;
+        rdfs:label         "thresholdRegulatingReserve"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:TieFlow.TieCorridor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Tie corridor which has the tie flow." ;
+        rdfs:domain           cim:TieFlow ;
+        rdfs:label            "TieCorridor"@en ;
+        rdfs:range            nc:TieCorridor ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:TieCorridor.TieFlow ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:TransmissionSystemOperator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A system operator role that is responsible for operating of an energy transmission network." ;
+        rdfs:label              "TransmissionSystemOperator"@en ;
+        rdfs:subClassOf         nc:SystemOperator ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:UnifiedPowerFlowController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Unified power flow controller (UPFC) is providing fast-acting reactive power compensation on high-voltage electricity transmission networks. " ;
+        rdfs:label              "UnifiedPowerFlowController"@en ;
+        rdfs:subClassOf         nc:EquipmentController ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:VoltageAngleLimit  rdf:type  rdfs:Class ;
+        rdfs:comment            "Voltage angle limit between two terminals. The association end OperationalLimitSet.Terminal defines one end and the host of the limit. The association end VoltageAngleLimit.AngleReferenceTerminal defines the reference terminal." ;
+        rdfs:label              "VoltageAngleLimit"@en ;
+        rdfs:subClassOf         cim:OperationalLimit ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:VoltageAngleLimit.AngleReferenceTerminal
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The angle reference terminal for the voltage angle limit." ;
+        rdfs:domain           nc:VoltageAngleLimit ;
+        rdfs:label            "AngleReferenceTerminal"@en ;
+        rdfs:range            cim:Terminal ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Terminal.VoltageAngleLimit ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:VoltageAngleLimit.isFlowToRefTerminal
+        rdf:type           rdf:Property ;
+        rdfs:comment       "True if the flow is from the operating limit terminal to the angle reference terminal. False means that the flow is the other direction. When it is not given, the limit is the same for both directions." ;
+        rdfs:domain        nc:VoltageAngleLimit ;
+        rdfs:label         "isFlowToRefTerminal"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VoltageAngleLimit.normalValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The difference in angle degrees between referenced by the association end OperationalLimitSet.Terminal and the Terminal referenced by the association end VoltageAngleLimit.AngleReferenceTerminal. The value shall be positive (greater than zero)." ;
+        rdfs:domain        nc:VoltageAngleLimit ;
+        rdfs:label         "normalValue"@en ;
+        cims:dataType      cim:AngleDegrees ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VoltageControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Voltage control function is a function block that calculate the operating point of the controlled equipment to achieve the target voltage." ;
+        rdfs:label              "VoltageControlFunction"@en ;
+        rdfs:subClassOf         nc:ControlFunctionBlock ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:VoltageInjectionControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Voltage injection control function is a function block that calculates the operating point of the controlled equipment to achieve the target voltage injection. The controlled point is the Terminal with sequenceNumber =1." ;
+        rdfs:label              "VoltageInjectionControlFunction"@en ;
+        rdfs:subClassOf         nc:ControlFunctionBlock ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:VsCapabilityCurve.referenceVoltage
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The reference voltage for which the capability curve is valid." ;
+        rdfs:domain        cim:VsCapabilityCurve ;
+        rdfs:label         "referenceVoltage"@en ;
+        cims:dataType      cim:Voltage ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+profcim:IRI  rdf:type           rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as rdf:resource in RDFXML.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "IRI"@en ;
+        cims:belongsToCategory  er:Package_EquipmentReliabilityProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringFixedLanguage
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited.\nThe primitive is serialized as literal without language support." ;
+        rdfs:label              "StringFixedLanguage"@en ;
+        cims:belongsToCategory  er:Package_DocEquipmentReliabilityProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringIRI  rdf:type     rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as literal without language support.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "StringIRI"@en ;
+        cims:belongsToCategory  er:Package_DocEquipmentReliabilityProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:URL  rdf:type           rdfs:Class ;
+        rdfs:comment            "A Uniform Resource Locator (URL), colloquially termed a web address, is a reference to a web resource that specifies its location on a computer network and a mechanism for retrieving it. A URL is a specific type of Uniform Resource Identifier (URI), although many people use the two terms interchangeably.URLs occur most commonly to reference web pages (http), but are also used for file transfer (ftp), email (mailto), database access (JDBC), and many other applications." ;
+        rdfs:label              "URL"@en ;
+        cims:belongsToCategory  er:Package_DocEquipmentReliabilityProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+

--- a/r2.3/ap-voc/ttl/GridDisturbance-AP-Voc-RDFS2020.ttl
+++ b/r2.3/ap-voc/ttl/GridDisturbance-AP-Voc-RDFS2020.ttl
@@ -1,0 +1,1355 @@
+@prefix cim:     <https://cim.ucaiug.io/ns#> .
+@prefix cims:    <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/#> .
+@prefix gd:      <https://ap.cim4.eu/GridDisturbance#> .
+@prefix nc:      <https://cim4.eu/ns/nc#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix profcim: <https://cim.ucaiug.io/ns/prof-cim#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+
+cim:ActivePower  rdf:type       rdfs:Class ;
+        rdfs:comment            "Product of RMS value of the voltage and the RMS value of the in-phase component of the current." ;
+        rdfs:label              "ActivePower"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:ActivePower.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePower.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "W" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePower.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:BaseVoltage  rdf:type       rdfs:Class ;
+        rdfs:comment            "Defines a system base voltage which is referenced. " ;
+        rdfs:label              "BaseVoltage"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile .
+
+cim:BaseVoltage.Fault
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The fault which belongs to the base voltage." ;
+        rdfs:domain           cim:BaseVoltage ;
+        rdfs:label            "Fault"@en ;
+        rdfs:range            cim:Fault ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:Fault.BaseVoltage ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+cim:Boolean  rdf:type           rdfs:Class ;
+        rdfs:comment            "A type with the value space \"true\" and \"false\"." ;
+        rdfs:label              "Boolean"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:CoordinateSystem  rdf:type  rdfs:Class ;
+        rdfs:comment            "Coordinate reference system." ;
+        rdfs:label              "CoordinateSystem"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:CoordinateSystem.Locations
+        rdf:type              rdf:Property ;
+        rdfs:comment          "All locations described with position points in this coordinate system." ;
+        rdfs:domain           cim:CoordinateSystem ;
+        rdfs:label            "Locations"@en ;
+        rdfs:range            cim:Location ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:Location.CoordinateSystem ;
+        cims:multiplicity     cims:M:0..n .
+
+cim:CoordinateSystem.crsUrn
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A Uniform Resource Name (URN) for the coordinate reference system (crs) used to define 'Location.PositionPoints'.\nAn example would be the European Petroleum Survey Group (EPSG) code for a coordinate reference system, defined in URN under the Open Geospatial Consortium (OGC) namespace as: urn:ogc:def:crs:EPSG::XXXX, where XXXX is an EPSG code (a full list of codes can be found at the EPSG Registry web site http://www.epsg-registry.org/). To define the coordinate system as being WGS84 (latitude, longitude) using an EPSG OGC, this attribute would be urn:ogc:def:crs:EPSG::4236.\nA profile should limit this code to a set of allowed URNs agreed to by all sending and receiving parties." ;
+        rdfs:domain        cim:CoordinateSystem ;
+        rdfs:label         "crsUrn"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Date  rdf:type              rdfs:Class ;
+        rdfs:comment            "Date as \"yyyy-mm-dd\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddZ\". A local timezone relative UTC is specified as \"yyyy-mm-dd(+/-)hh:mm\"." ;
+        rdfs:label              "Date"@en ;
+        cims:belongsToCategory  gd:Package_DocGridDisturbanceProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:DateTime  rdf:type          rdfs:Class ;
+        rdfs:comment            "Date and time as \"yyyy-mm-ddThh:mm:ss.sss\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddThh:mm:ss.sssZ\". A local timezone relative UTC is specified as \"yyyy-mm-ddThh:mm:ss.sss-hh:mm\". The second component (shown here as \"ss.sss\") could have any number of digits in its fractional part to allow any kind of precision beyond seconds." ;
+        rdfs:label              "DateTime"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Document  rdf:type          rdfs:Class ;
+        rdfs:comment            "Parent class for different groupings of information collected and managed as a part of a business process. It will frequently contain references to other objects, such as assets, people and power system resources." ;
+        rdfs:label              "Document"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile .
+
+cim:Duration  rdf:type          rdfs:Class ;
+        rdfs:comment            "Duration as \"PnYnMnDTnHnMnS\" which conforms to ISO 8601, where nY expresses a number of years, nM a number of months, nD a number of days. The letter T separates the date expression from the time expression and, after it, nH identifies a number of hours, nM a number of minutes and nS a number of seconds. The number of seconds could be expressed as a decimal number, but all other numbers are integers." ;
+        rdfs:label              "Duration"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Equipment  rdf:type         rdfs:Class ;
+        rdfs:comment            "The parts of a power system that are physical devices, electronic or mechanical." ;
+        rdfs:label              "Equipment"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         "Description" .
+
+cim:Equipment.Faults  rdf:type  rdf:Property ;
+        rdfs:comment          "All faults on this equipment." ;
+        rdfs:domain           cim:Equipment ;
+        rdfs:label            "Faults"@en ;
+        rdfs:range            cim:Fault ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:Fault.FaultyEquipment ;
+        cims:multiplicity     cims:M:0..1 .
+
+cim:Equipment.Outages
+        rdf:type              rdf:Property ;
+        rdfs:comment          "All outages in which this equipment is involved." ;
+        rdfs:domain           cim:Equipment ;
+        rdfs:label            "Outages"@en ;
+        rdfs:range            cim:Outage ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:Outage.Equipments ;
+        cims:multiplicity     cims:M:0..1 .
+
+cim:Equipment.UnplannedOutage
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The outage this tripped breaker is involved with." ;
+        rdfs:domain           cim:Equipment ;
+        rdfs:label            "UnplannedOutage"@en ;
+        rdfs:range            cim:UnplannedOutage ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:UnplannedOutage.TrippedEquipment ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+cim:Fault  rdf:type             rdfs:Class ;
+        rdfs:comment            "Abnormal condition causing current flow through conducting equipment, such as caused by equipment failure or short circuits from objects not typically modelled (for example, a tree falling on a line)." ;
+        rdfs:label              "Fault"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:Fault.BaseVoltage
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The base voltage of this fault." ;
+        rdfs:domain           cim:Fault ;
+        rdfs:label            "BaseVoltage"@en ;
+        rdfs:range            cim:BaseVoltage ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:BaseVoltage.Fault ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+cim:Fault.FaultyEquipment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Equipment carrying this fault." ;
+        rdfs:domain           cim:Fault ;
+        rdfs:label            "FaultyEquipment"@en ;
+        rdfs:range            cim:Equipment ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:Equipment.Faults ;
+        cims:multiplicity     cims:M:1 .
+
+cim:Fault.Location  rdf:type  rdf:Property ;
+        rdfs:comment          "Location of this fault." ;
+        rdfs:domain           cim:Fault ;
+        rdfs:label            "Location"@en ;
+        rdfs:range            cim:Location ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:Location.Fault ;
+        cims:multiplicity     cims:M:1 .
+
+cim:Fault.kind  rdf:type   rdf:Property ;
+        rdfs:comment       "The kind of phase fault." ;
+        rdfs:domain        cim:Fault ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         cim:PhaseConnectedFaultKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Fault.occurredDateTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The date and time at which the fault occurred." ;
+        rdfs:domain        cim:Fault ;
+        rdfs:label         "occurredDateTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Fault.phases  rdf:type  rdf:Property ;
+        rdfs:comment       "The phases participating in the fault. The fault connections into these phases are further specified by the type of fault." ;
+        rdfs:domain        cim:Fault ;
+        rdfs:label         "phases"@en ;
+        rdfs:range         cim:PhaseCode ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:FaultCauseType  rdf:type    rdfs:Class ;
+        rdfs:comment            "Type of cause of the fault." ;
+        rdfs:label              "FaultCauseType"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:Float  rdf:type             rdfs:Class ;
+        rdfs:comment            "A floating point number. The range is unspecified and not limited." ;
+        rdfs:label              "Float"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:IdentifiedObject  rdf:type  rdfs:Class ;
+        rdfs:comment            "This is a root class to provide common identification for all classes needing identification and naming attributes." ;
+        rdfs:label              "IdentifiedObject"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile .
+
+cim:IdentifiedObject.description
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The description is a free human readable text describing or naming the object. It may be non unique and may not correlate to a naming hierarchy." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "description"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.name
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The name is any free human readable and possibly non unique text naming the object." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "name"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Integer  rdf:type           rdfs:Class ;
+        rdfs:comment            "An integer number. The range is unspecified and not limited." ;
+        rdfs:label              "Integer"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Location  rdf:type          rdfs:Class ;
+        rdfs:comment            "The place, scene, or point of something where someone or something has been, is, and/or will be at a given moment in time. It can be defined with one or more position points (coordinates) in a given coordinate system." ;
+        rdfs:label              "Location"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:Location.CoordinateSystem
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Coordinate system used to describe position points of this location." ;
+        rdfs:domain           cim:Location ;
+        rdfs:label            "CoordinateSystem"@en ;
+        rdfs:range            cim:CoordinateSystem ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:CoordinateSystem.Locations ;
+        cims:multiplicity     cims:M:1 .
+
+cim:Location.Fault  rdf:type  rdf:Property ;
+        rdfs:comment          "All faults at this location." ;
+        rdfs:domain           cim:Location ;
+        rdfs:label            "Fault"@en ;
+        rdfs:range            cim:Fault ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:Fault.Location ;
+        cims:multiplicity     cims:M:0..n .
+
+cim:Location.PositionPoints
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Sequence of position points describing this location, expressed in coordinate system 'Location.CoordinateSystem'." ;
+        rdfs:domain           cim:Location ;
+        rdfs:label            "PositionPoints"@en ;
+        rdfs:range            cim:PositionPoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:PositionPoint.Location ;
+        cims:multiplicity     cims:M:1..n .
+
+cim:Outage  rdf:type            rdfs:Class ;
+        rdfs:comment            "Document describing details of an active or planned outage in a part of the electrical network.\nA non-planned outage may be created upon:\n- a breaker trip,\n- a fault indicator status change,\n- a meter event indicating customer outage,\n- a reception of one or more customer trouble calls, or\n- an operator command, reflecting information obtained from the field crew.\nOutage restoration may be performed using a switching plan which complements the outage information with detailed switching activities, including the relationship to the crew and work.\nA planned outage may be created upon:\n- a request for service, maintenance or construction work in the field, or\n- an operator-defined outage for what-if/contingency network analysis." ;
+        rdfs:label              "Outage"@en ;
+        rdfs:subClassOf         cim:Document ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile .
+
+cim:Outage.Equipments
+        rdf:type              rdf:Property ;
+        rdfs:comment          "All equipments associated with this outage." ;
+        rdfs:domain           cim:Outage ;
+        rdfs:label            "Equipments"@en ;
+        rdfs:range            cim:Equipment ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:Equipment.Outages ;
+        cims:multiplicity     cims:M:1 .
+
+cim:PhaseCode  rdf:type         rdfs:Class ;
+        rdfs:comment            "An unordered enumeration of phase identifiers.  Allows designation of phases for both transmission and distribution equipment, circuits and loads.   The enumeration, by itself, does not describe how the phases are connected together or connected to ground.  Ground is not explicitly denoted as a phase.\nResidential and small commercial loads are often served from single-phase, or split-phase, secondary circuits. For the example of s12N, phases 1 and 2 refer to hot wires that are 180 degrees out of phase, while N refers to the neutral wire. Through single-phase transformer connections, these secondary circuits may be served from one or two of the primary phases A, B, and C. For three-phase loads, use the A, B, C phase codes instead of s12N.\nThe integer values are from IEC 61968-9 to support revenue metering applications." ;
+        rdfs:label              "PhaseCode"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:PhaseCode.A  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Phase A." ;
+        rdfs:label       "A"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.AB  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Phases A and B." ;
+        rdfs:label       "AB"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.ABC  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Phases A, B, and C." ;
+        rdfs:label       "ABC"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.ABCN  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Phases A, B, C, and N." ;
+        rdfs:label       "ABCN"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.ABN  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Phases A, B, and neutral." ;
+        rdfs:label       "ABN"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.AC  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Phases A and C." ;
+        rdfs:label       "AC"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.ACN  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Phases A, C and neutral." ;
+        rdfs:label       "ACN"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.AN  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Phases A and neutral." ;
+        rdfs:label       "AN"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.B  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Phase B." ;
+        rdfs:label       "B"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.BC  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Phases B and C." ;
+        rdfs:label       "BC"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.BCN  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Phases B, C, and neutral." ;
+        rdfs:label       "BCN"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.BN  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Phases B and neutral." ;
+        rdfs:label       "BN"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.C  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Phase C." ;
+        rdfs:label       "C"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.CN  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Phases C and neutral." ;
+        rdfs:label       "CN"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.N  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Neutral phase." ;
+        rdfs:label       "N"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.X  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Unknown non-neutral phase." ;
+        rdfs:label       "X"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.XN  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Unknown non-neutral phase plus neutral." ;
+        rdfs:label       "XN"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.XY  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Two unknown non-neutral phases." ;
+        rdfs:label       "XY"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.XYN  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Two unknown non-neutral phases plus neutral." ;
+        rdfs:label       "XYN"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.none  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "No phases specified." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.s1  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Secondary phase 1." ;
+        rdfs:label       "s1"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.s12  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Secondary phase 1 and 2." ;
+        rdfs:label       "s12"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.s12N  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Secondary phases 1, 2, and neutral." ;
+        rdfs:label       "s12N"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.s1N  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Secondary phase 1 and neutral." ;
+        rdfs:label       "s1N"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.s2  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Secondary phase 2." ;
+        rdfs:label       "s2"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseCode.s2N  rdf:type  cim:PhaseCode ;
+        rdfs:comment     "Secondary phase 2 and neutral." ;
+        rdfs:label       "s2N"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseConnectedFaultKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The type of fault connection among phases." ;
+        rdfs:label              "PhaseConnectedFaultKind"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:PhaseConnectedFaultKind.lineOpen
+        rdf:type         cim:PhaseConnectedFaultKind ;
+        rdfs:comment     "The fault is when the conductor path is broken between two terminals. Additional coexisting faults may be required if the broken conductor also causes connections to grounds or other lines or phases." ;
+        rdfs:label       "lineOpen"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseConnectedFaultKind.lineToGround
+        rdf:type         cim:PhaseConnectedFaultKind ;
+        rdfs:comment     "The fault connects the indicated phases to ground. The line to line fault impedance is not used and assumed infinite. The full ground impedance is connected between each phase specified in the fault and ground, but not between the phases." ;
+        rdfs:label       "lineToGround"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseConnectedFaultKind.lineToLine
+        rdf:type         cim:PhaseConnectedFaultKind ;
+        rdfs:comment     "The fault connects the specified phases together without a connection to ground. The ground impedance of this fault is ignored. The line to line impedance is connected between each of the phases specified in the fault. For example three times for a three phase fault, one time for a two phase fault.  A single phase fault should not be specified." ;
+        rdfs:label       "lineToLine"@en ;
+        cims:stereotype  "enum" .
+
+cim:PhaseConnectedFaultKind.lineToLineToGround
+        rdf:type         cim:PhaseConnectedFaultKind ;
+        rdfs:comment     "The fault connects the indicated phases to ground and to each other. The line to line impedance is connected between each of the phases specified in the fault in a full mesh. For example three times for a three phase fault, one time for a two phase fault. A single phase fault should not be specified. The full ground impedance is connected between each phase specified in the fault and ground." ;
+        rdfs:label       "lineToLineToGround"@en ;
+        cims:stereotype  "enum" .
+
+cim:PositionPoint  rdf:type     rdfs:Class ;
+        rdfs:comment            "Set of spatial coordinates that determine a point, defined in the coordinate system specified in 'Location.CoordinateSystem'. Use a single position point instance to describe a point-oriented location. Use a sequence of position points to describe a line-oriented object (physical location of non-point oriented objects like cables or lines), or area of an object (like a substation or a geographical zone - in this case, have first and last position point with the same values)." ;
+        rdfs:label              "PositionPoint"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+cim:PositionPoint.Location
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Location described by this position point." ;
+        rdfs:domain           cim:PositionPoint ;
+        rdfs:label            "Location"@en ;
+        rdfs:range            cim:Location ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  cim:Location.PositionPoints ;
+        cims:multiplicity     cims:M:1 .
+
+cim:PositionPoint.xPosition
+        rdf:type           rdf:Property ;
+        rdfs:comment       "X axis position." ;
+        rdfs:domain        cim:PositionPoint ;
+        rdfs:label         "xPosition"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PositionPoint.yPosition
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Y axis position." ;
+        rdfs:domain        cim:PositionPoint ;
+        rdfs:label         "yPosition"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PositionPoint.zPosition
+        rdf:type           rdf:Property ;
+        rdfs:comment       "(if applicable) Z axis position." ;
+        rdfs:domain        cim:PositionPoint ;
+        rdfs:label         "zPosition"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:RealEnergy  rdf:type        rdfs:Class ;
+        rdfs:comment            "Real electrical energy." ;
+        rdfs:label              "RealEnergy"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:RealEnergy.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:RealEnergy ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:RealEnergy.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:RealEnergy ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "Wh" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:RealEnergy.value  rdf:type  rdf:Property ;
+        rdfs:domain        cim:RealEnergy ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:String  rdf:type            rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited." ;
+        rdfs:label              "String"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:UnitMultiplier  rdf:type    rdfs:Class ;
+        rdfs:comment            "The unit multipliers defined for the CIM.  When applied to unit symbols, the unit symbol is treated as a derived unit. Regardless of the contents of the unit symbol text, the unit symbol shall be treated as if it were a single-character unit symbol. Unit symbols should not contain multipliers, and it should be left to the multiplier to define the multiple for an entire data type. \n\nFor example, if a unit symbol is \"m2Pers\" and the multiplier is \"k\", then the value is k(m**2/s), and the multiplier applies to the entire final value, not to any individual part of the value. This can be conceptualized by substituting a derived unit symbol for the unit type. If one imagines that the symbol \"Þ\" represents the derived unit \"m2Pers\", then applying the multiplier \"k\" can be conceptualized simply as \"kÞ\".\n\nFor example, the SI unit for mass is \"kg\" and not \"g\".  If the unit symbol is defined as \"kg\", then the multiplier is applied to \"kg\" as a whole and does not replace the \"k\" in front of the \"g\". In this case, the multiplier of \"m\" would be used with the unit symbol of \"kg\" to represent one gram.  As a text string, this violates the instructions in IEC 80000-1. However, because the unit symbol in CIM is treated as a derived unit instead of as an SI unit, it makes more sense to conceptualize the \"kg\" as if it were replaced by one of the proposed replacements for the SI mass symbol. If one imagines that the \"kg\" were replaced by a symbol \"Þ\", then it is easier to conceptualize the multiplier \"m\" as creating the proper unit \"mÞ\", and not the forbidden unit \"mkg\"." ;
+        rdfs:label              "UnitMultiplier"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitMultiplier.M  rdf:type  cim:UnitMultiplier ;
+        rdfs:comment     "Mega 10**6." ;
+        rdfs:label       "M"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitMultiplier.k  rdf:type  cim:UnitMultiplier ;
+        rdfs:comment     "Kilo 10**3." ;
+        rdfs:label       "k"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol  rdf:type        rdfs:Class ;
+        rdfs:comment            "The derived units defined for usage in the CIM. In some cases, the derived unit is equal to an SI unit. Whenever possible, the standard derived symbol is used instead of the formula for the derived unit. For example, the unit symbol Farad is defined as \"F\" instead of \"CPerV\". In cases where a standard symbol does not exist for a derived unit, the formula for the unit is used as the unit symbol. For example, density does not have a standard symbol and so it is represented as \"kgPerm3\". With the exception of the \"kg\", which is an SI unit, the unit symbols do not contain multipliers and therefore represent the base derived unit to which a multiplier can be applied as a whole. \nEvery unit symbol is treated as an unparseable text as if it were a single-letter symbol. The meaning of each unit symbol is defined by the accompanying descriptive text and not by the text contents of the unit symbol.\nTo allow the widest possible range of serializations without requiring special character handling, several substitutions are made which deviate from the format described in IEC 80000-1. The division symbol \"/\" is replaced by the letters \"Per\". Exponents are written in plain text after the unit as \"m3\" instead of being formatted as \"m\" with a superscript of 3  or introducing a symbol as in \"m^3\". The degree symbol \"°\" is replaced with the letters \"deg\". Any clarification of the meaning for a substitution is included in the description for the unit symbol.\nNon-SI units are included in list of unit symbols to allow sources of data to be correctly labelled with their non-SI units (for example, a GPS sensor that is reporting numbers that represent feet instead of meters). This allows software to use the unit symbol information correctly convert and scale the raw data of those sources into SI-based units. \nThe integer values are used for harmonization with IEC 61850." ;
+        rdfs:label              "UnitSymbol"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitSymbol.W  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Real power in watts (J/s). Electrical power may have real and reactive components. The real portion of electrical power (I&#178;R or VIcos(phi)), is expressed in Watts. See also apparent power and reactive power." ;
+        rdfs:label       "W"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.Wh  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Real energy in watt hours." ;
+        rdfs:label       "Wh"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnplannedOutage  rdf:type   rdfs:Class ;
+        rdfs:comment            "Document describing the consequence of an unplanned outage in a part of the electrical network. For the purposes of this model, an unplanned outage refers to a state where energy is not delivered; such as, customers out of service, a street light is not served, etc.\nA unplanned outage may be created upon:\n- impacts the SAIDI calculation\n- a breaker trip,\n- a fault indicator status change,\n- a meter event indicating customer outage,\n- a reception of one or more customer trouble calls, or\n- an operator command, reflecting information obtained from the field crew.\nOutage restoration may be performed using a switching plan which complements the outage information with detailed switching activities, including the relationship to the crew and work." ;
+        rdfs:label              "UnplannedOutage"@en ;
+        rdfs:subClassOf         cim:Outage ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:UnplannedOutage.TrippedEquipment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The equipment that tripped during the outage." ;
+        rdfs:domain           cim:UnplannedOutage ;
+        rdfs:label            "TrippedEquipment"@en ;
+        rdfs:range            cim:Equipment ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  cim:Equipment.UnplannedOutage ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+cim:UnplannedOutage.reportedStartTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The earliest start time of the Outage - as reported by some system or individual" ;
+        rdfs:domain        cim:UnplannedOutage ;
+        rdfs:label         "reportedStartTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+gd:Ontology  rdf:type         owl:Ontology ;
+        dcterms:conformsTo    "urn:iso:std:iec:61970-501:draft:ed-2" , "urn:iso:std:iec:61970-301:ed-7:amd1" , "file://CIM100_CGMES31v01_501-20v02_NC23v62_MM10v01.eap" , "file://iec61970cim17v40_iec61968cim13v13a_iec62325cim03v17a.eap" , "urn:iso:std:iec:61970-600-2:ed-1" , "urn:iso:std:iec:61970-401:draft:ed-1" ;
+        dcterms:creator       "ENTSO-E CIM WG PRA project "@en ;
+        dcterms:description   "This vocabulary is describing the grid disturbance profile."@en ;
+        dcterms:identifier    "urn:uuid:81c488d7-a09f-49ef-a3cd-3bb19a1d6f16" ;
+        dcterms:language      "en-GB" ;
+        dcterms:license       "https://www.apache.org/licenses/LICENSE-2.0"@en ;
+        dcterms:modified      "2024-04-08"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        dcterms:publisher     "ENTSO-E"@en ;
+        dcterms:rightsHolder  "ENTSO-E"@en ;
+        dcterms:title         "Grid Disturbance vocabulary"@en ;
+        owl:versionIRI        <https://ap.cim4.eu/GridDisturbance/1.1> ;
+        owl:versionInfo       "1.1.0"@en ;
+        dcat:keyword          "GD" ;
+        dcat:theme            "vocabulary"@en .
+
+gd:Package_DocGridDisturbanceProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains datatypes used only in the RDFS header." ;
+        rdfs:label    "DocGridDisturbanceProfile"@en .
+
+gd:Package_GridDisturbanceProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains the grid disturbance profile." ;
+        rdfs:label    "GridDisturbanceProfile"@en .
+
+nc:AutoReclosingKind  rdf:type  rdfs:Class ;
+        rdfs:comment            "The type of autoreclosing that occurred with the trip.\n\nIf high-speed automatic reclosing is successful at one end of a line, but the line needs to be reclosed manually at the other end, choose manual reclosing.\n\nIn this document, high-speed automatic reclosing refers to automatic reclosing after less than 2 seconds." ;
+        rdfs:label              "AutoReclosingKind"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:AutoReclosingKind.automaticallyAfter2SecondsOrMore
+        rdf:type         nc:AutoReclosingKind ;
+        rdfs:comment     "If the automatic reclosing was successful in 2 seconds or more.\n\nAlso known as \"successful high-speed reclosing\"." ;
+        rdfs:label       "automaticallyAfter2SecondsOrMore"@en ;
+        cims:stereotype  "enum" .
+
+nc:AutoReclosingKind.automaticallyAfterLessThan2Seconds
+        rdf:type         nc:AutoReclosingKind ;
+        rdfs:comment     "If the automatic reclosing was successful in 2 seconds or less.\n\nAlso known as \"successful high-speed reclosing\"." ;
+        rdfs:label       "automaticallyAfterLessThan2Seconds"@en ;
+        cims:stereotype  "enum" .
+
+nc:AutoReclosingKind.manuallyAfterInspection
+        rdf:type         nc:AutoReclosingKind ;
+        rdfs:comment     "If the reclosing was done manually after inspection of the component." ;
+        rdfs:label       "manuallyAfterInspection"@en ;
+        cims:stereotype  "enum" .
+
+nc:AutoReclosingKind.manuallyAfterRepair
+        rdf:type         nc:AutoReclosingKind ;
+        rdfs:comment     "If the reclosing was done manually after repair." ;
+        rdfs:label       "manuallyAfterRepair"@en ;
+        cims:stereotype  "enum" .
+
+nc:AutoReclosingKind.manuallyAfterRestructuringOfOperations
+        rdf:type         nc:AutoReclosingKind ;
+        rdfs:comment     "If the reclosing was done manually after restructuring of operations." ;
+        rdfs:label       "manuallyAfterRestructuringOfOperations"@en ;
+        cims:stereotype  "enum" .
+
+nc:AutoReclosingKind.manuallyWithoutEitherInspectionRepairOrRestructuringOfOperations
+        rdf:type         nc:AutoReclosingKind ;
+        rdfs:comment     "If the reclosing was done manually without any inspections, repairs or restructurings of operations." ;
+        rdfs:label       "manuallyWithoutEitherInspectionRepairOrRestructuringOfOperations"@en ;
+        cims:stereotype  "enum" .
+
+nc:AutoReclosingKind.other
+        rdf:type         nc:AutoReclosingKind ;
+        rdfs:comment     "If the type of auto-reclosing is not unknown but does not fit the other categories, report it as other." ;
+        rdfs:label       "other"@en ;
+        cims:stereotype  "enum" .
+
+nc:AutoReclosingKind.unknown
+        rdf:type         nc:AutoReclosingKind ;
+        rdfs:comment     "If the type of auto-reclosing is unknown." ;
+        rdfs:label       "unknown"@en ;
+        cims:stereotype  "enum" .
+
+nc:CertaintyLevelKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "High certainty level is used when the cause of a fault is 100 % certain or when the cause is the most probable cause and potentially determined by an expert. " ;
+        rdfs:label              "CertaintyLevelKind"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:CertaintyLevelKind.high
+        rdf:type         nc:CertaintyLevelKind ;
+        rdfs:comment     "The certainty level is high." ;
+        rdfs:label       "high"@en ;
+        cims:stereotype  "enum" .
+
+nc:CertaintyLevelKind.low
+        rdf:type         nc:CertaintyLevelKind ;
+        rdfs:comment     "The certainty level is low." ;
+        rdfs:label       "low"@en ;
+        cims:stereotype  "enum" .
+
+nc:CertaintyLevelKind.medium
+        rdf:type         nc:CertaintyLevelKind ;
+        rdfs:comment     "The certainty level is medium." ;
+        rdfs:label       "medium"@en ;
+        cims:stereotype  "enum" .
+
+nc:CertaintyLevelKind.none
+        rdf:type         nc:CertaintyLevelKind ;
+        rdfs:comment     "The certainty level is none." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+nc:Equipment.Interruption
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The interruption that belongs to the interrupted delivery equipment." ;
+        rdfs:domain           cim:Equipment ;
+        rdfs:label            "Interruption"@en ;
+        rdfs:range            nc:Interruption ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:Interruption.InterruptedDeliveryEquipment ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:Fault.FaultCause  rdf:type  rdf:Property ;
+        rdfs:comment          "The fault and cause combination to be simulated for this fault." ;
+        rdfs:domain           cim:Fault ;
+        rdfs:label            "FaultCause"@en ;
+        rdfs:range            nc:FaultCause ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:FaultCause.Fault ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:Fault.FaultOutage  rdf:type  rdf:Property ;
+        rdfs:comment          "The combination of a fault and an outage to be simulated for this fault." ;
+        rdfs:domain           cim:Fault ;
+        rdfs:label            "FaultOutage"@en ;
+        rdfs:range            nc:FaultOutage ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:FaultOutage.Fault ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Fault.GridDisturbance
+        rdf:type              rdf:Property ;
+        rdfs:comment          "A grid disturbance to contain all faults." ;
+        rdfs:domain           cim:Fault ;
+        rdfs:label            "GridDisturbance"@en ;
+        rdfs:range            nc:GridDisturbance ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GridDisturbance.Fault ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:Fault.SystemOperator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The system operator in whose control area this fault occurred." ;
+        rdfs:domain           cim:Fault ;
+        rdfs:label            "SystemOperator"@en ;
+        rdfs:range            nc:SystemOperator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SystemOperator.Fault ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:Fault.category  rdf:type  rdf:Property ;
+        rdfs:comment       "The fault category." ;
+        rdfs:domain        cim:Fault ;
+        rdfs:label         "category"@en ;
+        rdfs:range         nc:FaultCategoryKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Fault.duration  rdf:type  rdf:Property ;
+        rdfs:comment       "The duration of the fault." ;
+        rdfs:domain        cim:Fault ;
+        rdfs:label         "duration"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Fault.faultKind  rdf:type  rdf:Property ;
+        rdfs:comment       "One fault can consist of several fault types. If a fault consists of several fault types, the most significant fault type is used.\n\nIn case of developing faults, that is in faults changing from one type to another, the final type is given." ;
+        rdfs:domain        cim:Fault ;
+        rdfs:label         "faultKind"@en ;
+        rdfs:range         nc:FaultKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Fault.isDirectlyEarthed
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Whether the power system is directly earthed (true) or compensated (false). \nUsually optional for faults on units with reactive compensation with voltages lower than 100 kV." ;
+        rdfs:domain        cim:Fault ;
+        rdfs:label         "isDirectlyEarthed"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Fault.isIntermittent
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The kind of occurrence of the fault. It is either intermittent (true) or non-intermittent (false).\nAn intermittent fault is a recurring fault in the same unit and in the same place and for the same reason which repeats itself before it becomes necessary to carry out any repairs or eliminate the cause [8].\nA non-intermittent fault occurs only once.\n\nNote 1: a fault which repeats itself after an inspection, which did not result in the fault being pinpointed or repaired, is not considered an intermittent fault. A fault like this is considered as the beginning of a grid disturbance every time the fault occurs.\nNote 2: one example of an intermittent fault is galloping lines.\nNote 3: when deciding whether a fault is intermittent or not, one should consider more of the cause, location and consequence of the fault and not on the time between the faults. An intermittent fault is counted as one fault. However, all individual caused outages are connected to this fault.\nNote 4: there is no standard for the required timespan between intermittent faults. Some system operators use 2 hours." ;
+        rdfs:domain        cim:Fault ;
+        rdfs:label         "isIntermittent"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Fault.isPermanent  rdf:type  rdf:Property ;
+        rdfs:comment       "Whether the fault is a permanent (true) or a temporary (false) fault.\nA permanent fault is a fault that will remain unless it is removed by some intervention.\nNote 1 to entry: The “intervention” may be modification or maintenance.\nNote 2: a permanent fault requires repair or adjustment before the unit is ready for operation. For example, the resetting of computers is considered as repair work and a switch in the wrong position is considered as a permanent fault. Signal acknowledgement is not considered as repair work. \nNote 3: the duration of the disconnection is irrelevant when determining if a fault is permanent or not.\n\nA temporary fault is a fault where the unit or component is undamaged and is restored to service by switching operations without repair but possibly with on-site inspection.  \nNote 1: a temporary fault does not require measures other than the reconnection of circuit breakers, replacement of fuses or signal acknowledgement.\nNote 2: the duration of the disconnection is irrelevant when determining if a fault is temporary or not. If, for example, a fault results in long-term disconnection and (on-site) inspection cannot pinpoint its source, the fault is considered to be temporary as no repairs are carried out." ;
+        rdfs:domain        cim:Fault ;
+        rdfs:label         "isPermanent"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Fault.repairTime  rdf:type  rdf:Property ;
+        rdfs:comment       "Time from when repair commences, including necessary troubleshooting, until the unit’s function(s) has (have) been resumed and the unit is ready for operation.\n\nNote 1: repair time is registered only for permanent faults and does not include administrative delays (voluntary waiting time). However, any preparations necessary to carry out repairs, for example the collection or ordering of spare parts, waiting for spare parts or transport, are included in the repair time. \n\nNote 2: the repair time is zero if a fault is left unrepaired deliberately.\n\nNote 3: this definition differs from the IEC 192-07-19 definition by also including the preparation time necessary to carry out the repairs mentioned in note 1." ;
+        rdfs:domain        cim:Fault ;
+        rdfs:label         "repairTime"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Fault.sequenceNumber
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A chronological serial number indicating the order of the faults related to the grid disturbance. \n\nPrimary faults have fault ID “1”, and secondary/latent faults have fault ID “2” or more." ;
+        rdfs:domain        cim:Fault ;
+        rdfs:label         "sequenceNumber"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:FaultCategoryKind  rdf:type  rdfs:Class ;
+        rdfs:comment            "Available kinds of fault categories." ;
+        rdfs:label              "FaultCategoryKind"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:FaultCategoryKind.operational
+        rdf:type         nc:FaultCategoryKind ;
+        rdfs:comment     "A fault due to a temporary human error.\n\nNote 1: incorrect operation is considered a fault in a component, or in other words, the incorrect operation is attributed to the unit which has been operated incorrectly." ;
+        rdfs:label       "operational"@en ;
+        cims:stereotype  "enum" .
+
+nc:FaultCategoryKind.system
+        rdf:type         nc:FaultCategoryKind ;
+        rdfs:comment     "A fault due to off-nominal parameters, exceeding of regulated norms and standards, or exceeding protection limits.\n\nNote 1: Typical examples of system fault causes are high/low frequency, power oscillations, overload, overvoltage, undervoltage or high harmonic content in voltage or current. Common causes for system faults are significant changes in load or generation and switching of lines or transformers with following change of load flow." ;
+        rdfs:label       "system"@en ;
+        cims:stereotype  "enum" .
+
+nc:FaultCategoryKind.technical
+        rdf:type         nc:FaultCategoryKind ;
+        rdfs:comment     "A fault due to a technical error." ;
+        rdfs:label       "technical"@en ;
+        cims:stereotype  "enum" .
+
+nc:FaultCause  rdf:type         rdfs:Class ;
+        rdfs:comment            "Fault cause." ;
+        rdfs:label              "FaultCause"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:FaultCause.Fault  rdf:type  rdf:Property ;
+        rdfs:comment          "The fault defined for this fault and cause combination." ;
+        rdfs:domain           nc:FaultCause ;
+        rdfs:label            "Fault"@en ;
+        rdfs:range            cim:Fault ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Fault.FaultCause ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:FaultCause.FaultCauseType
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The fault and cause combination to be simulated for this cause." ;
+        rdfs:domain           nc:FaultCause ;
+        rdfs:label            "FaultCauseType"@en ;
+        rdfs:range            cim:FaultCauseType ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:FaultCauseType.FaultCause ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:FaultCause.certaintyLevel
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The degree of certainty of which the cause of a fault is determined by a user. \nNote 1: the used certainty levels are low, medium and high. High certainty level is used when the cause of a fault is 100 % certain or when the cause is the most probable cause and potentially determined by an expert. Medium certainty level is used when the cause of the fault is very probable but there is not enough evidence to fully support the claim. Low certainty level is used when there is some idea of what the cause could be with the help of, for example, the fault details or expert knowledge. \nNote 2: the fault cause ‘unknown’ is used if no other fault cause can be chosen by any degree of certainty. " ;
+        rdfs:domain        nc:FaultCause ;
+        rdfs:label         "certaintyLevel"@en ;
+        rdfs:range         nc:CertaintyLevelKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:FaultCause.mRID  rdf:type  rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:FaultCause ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:FaultCauseType.FaultCause
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The fault cause defined for this fault and cause combination." ;
+        rdfs:domain           cim:FaultCauseType ;
+        rdfs:label            "FaultCause"@en ;
+        rdfs:range            nc:FaultCause ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:FaultCause.FaultCauseType ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:FaultKind  rdf:type          rdfs:Class ;
+        rdfs:comment            "One fault can consist of several fault types. If a fault consists of several fault types, the most significant fault type is used.\n\nIn case of developing faults, that is in faults changing from one type to another, the final type is given." ;
+        rdfs:label              "FaultKind"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:FaultKind.functional
+        rdf:type         nc:FaultKind ;
+        rdfs:comment     "The components main function failed to occur." ;
+        rdfs:label       "functional"@en ;
+        cims:stereotype  "enum" .
+
+nc:FaultKind.lineOpen
+        rdf:type         nc:FaultKind ;
+        rdfs:comment     "The fault is when the conductor path is broken between two terminals. Additional coexisting faults may be required if the broken conductor also causes connections to grounds or other lines or phases." ;
+        rdfs:label       "lineOpen"@en ;
+        cims:stereotype  "enum" .
+
+nc:FaultKind.lineToGround
+        rdf:type         nc:FaultKind ;
+        rdfs:comment     "The fault connects the indicated phases to ground. The line to line fault impedance is not used and assumed infinite. The full ground impedance is connected between each phase specified in the fault and ground, but not between the phases." ;
+        rdfs:label       "lineToGround"@en ;
+        cims:stereotype  "enum" .
+
+nc:FaultKind.lineToLine
+        rdf:type         nc:FaultKind ;
+        rdfs:comment     "The fault connects the specified phases together without a connection to ground. The ground impedance of this fault is ignored. The line to line impedance is connected between each of the phases specified in the fault. For example three times for a three phase fault, one time for a two phase fault.  A single phase fault should not be specified." ;
+        rdfs:label       "lineToLine"@en ;
+        cims:stereotype  "enum" .
+
+nc:FaultKind.lineToLineToGround
+        rdf:type         nc:FaultKind ;
+        rdfs:comment     "The fault connects the indicated phases to ground and to each other. The line to line impedance is connected between each of the phases specified in the fault in a full mesh. For example three times for a three phase fault, one time for a two phase fault. A single phase fault should not be specified. The full ground impedance is connected between each phase specified in the fault and ground." ;
+        rdfs:label       "lineToLineToGround"@en ;
+        cims:stereotype  "enum" .
+
+nc:FaultKind.other  rdf:type  nc:FaultKind ;
+        rdfs:comment     "For example, geomagnetic currents, SSR, capacitor bank imbalances, bad contact, overheating." ;
+        rdfs:label       "other"@en ;
+        cims:stereotype  "enum" .
+
+nc:FaultKind.undesiredFunction
+        rdf:type         nc:FaultKind ;
+        rdfs:comment     "If the component's main function occurred correctly but had an undesired result, that is, the fault.\nIs only stated if the component is a circuit breaker, disconnector or control system." ;
+        rdfs:label       "undesiredFunction"@en ;
+        cims:stereotype  "enum" .
+
+nc:FaultOutage  rdf:type        rdfs:Class ;
+        rdfs:comment            "Association class for relating one fault and one outage." ;
+        rdfs:label              "FaultOutage"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:FaultOutage.Fault  rdf:type  rdf:Property ;
+        rdfs:comment          "The fault defined for this combination of a fault and an outage. " ;
+        rdfs:domain           nc:FaultOutage ;
+        rdfs:label            "Fault"@en ;
+        rdfs:range            cim:Fault ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Fault.FaultOutage ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:FaultOutage.Outage
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The outage defined for this combination of a fault and an outage." ;
+        rdfs:domain           nc:FaultOutage ;
+        rdfs:label            "Outage"@en ;
+        rdfs:range            cim:Outage ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Outage.FaultOutage ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:FaultOutage.isMainFault
+        rdf:type           rdf:Property ;
+        rdfs:comment       "If true the fault outage is the main fault." ;
+        rdfs:domain        nc:FaultOutage ;
+        rdfs:label         "isMainFault"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:FaultOutage.mRID  rdf:type  rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:FaultOutage ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GridDisturbance  rdf:type    rdfs:Class ;
+        rdfs:comment            "Automatic, unintended, or manual undeferrable switching of breakers as a result of faults in the power grid." ;
+        rdfs:label              "GridDisturbance"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:GridDisturbance.Fault
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Faults that are related to one grid disturbance." ;
+        rdfs:domain           nc:GridDisturbance ;
+        rdfs:label            "Fault"@en ;
+        rdfs:range            cim:Fault ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:Fault.GridDisturbance ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:Interruption  rdf:type       rdfs:Class ;
+        rdfs:comment            "Disappearance of the supply voltage at a delivery point." ;
+        rdfs:label              "Interruption"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:Interruption.InterruptedDeliveryEquipment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The delivery point (equipment) that is affected by the interruption. It is an equipment, power transformer or busbar in the grid where electricity is exchanged." ;
+        rdfs:domain           nc:Interruption ;
+        rdfs:label            "InterruptedDeliveryEquipment"@en ;
+        rdfs:range            cim:Equipment ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Equipment.Interruption ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:Interruption.Outage
+        rdf:type              rdf:Property ;
+        rdfs:comment          "One outage may have multiple interruptions." ;
+        rdfs:domain           nc:Interruption ;
+        rdfs:label            "Outage"@en ;
+        rdfs:range            cim:Outage ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Outage.Interruption ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:Interruption.duration
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The duration of the interruption." ;
+        rdfs:domain        nc:Interruption ;
+        rdfs:label         "duration"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Interruption.energyNotDelivered
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The estimated energy which would have been delivered through the delivery point if no interruption and no transmission restrictions had occurred." ;
+        rdfs:domain        nc:Interruption ;
+        rdfs:label         "energyNotDelivered"@en ;
+        cims:dataType      cim:RealEnergy ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Interruption.energyNotSupplied
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The estimated energy which would have been supplied to end-users if no interruption and no transmission restrictions had occurred." ;
+        rdfs:domain        nc:Interruption ;
+        rdfs:label         "energyNotSupplied"@en ;
+        cims:dataType      cim:RealEnergy ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Interruption.interruptedPower
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The estimated power that was delivered through the delivery point when the interruption occurred." ;
+        rdfs:domain        nc:Interruption ;
+        rdfs:label         "interruptedPower"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Interruption.startDateTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The date and time at which the interruption occurred." ;
+        rdfs:domain        nc:Interruption ;
+        rdfs:label         "startDateTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Outage.FaultOutage
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The combination of a fault and an outage to be simulated for this outage." ;
+        rdfs:domain           cim:Outage ;
+        rdfs:label            "FaultOutage"@en ;
+        rdfs:range            nc:FaultOutage ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:FaultOutage.Outage ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Outage.Interruption
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Multiple interruptions may be connected with an outage." ;
+        rdfs:domain           cim:Outage ;
+        rdfs:label            "Interruption"@en ;
+        rdfs:range            nc:Interruption ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:Interruption.Outage ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SystemOperator  rdf:type     rdfs:Class ;
+        rdfs:comment            "System operator." ;
+        rdfs:label              "SystemOperator"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         "NC" .
+
+nc:SystemOperator.Fault
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The faults that have occurred in this System Operator's control area." ;
+        rdfs:domain           nc:SystemOperator ;
+        rdfs:label            "Fault"@en ;
+        rdfs:range            cim:Fault ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:Fault.SystemOperator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SystemUnitKind  rdf:type     rdfs:Class ;
+        rdfs:comment            "A system unit is defined as:\n\nA group of components which are delimited by one or more circuit breakers.\n\nNote 1: the system unit concept has been defined to simplify the calculation of availability. While a system unit is always delimited by circuit breakers, an individual component may not always be. A system unit may therefore contain more than one component. \n\nNote 2: the circuit breakers are not included in the system unit.\n \nNote 3: a tripped element is synonymous to a tripped system unit.\n\nNote 4: the type of a system unit is determined by its dominant component. The available system unit types are power transformer, overhead line, cable, reactor, busbar, series capacitor, shunt capacitor and SVC.\n\nNote 5: when a system unit is no longer transporting or supplying electrical energy, the system unit is affected by an outage. The system unit is unavailable after the outage has occurred." ;
+        rdfs:label              "SystemUnitKind"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:SystemUnitKind.busbar
+        rdf:type         nc:SystemUnitKind ;
+        rdfs:comment     "If the main function of the system unit is busbar." ;
+        rdfs:label       "busbar"@en ;
+        cims:stereotype  "enum" .
+
+nc:SystemUnitKind.cable
+        rdf:type         nc:SystemUnitKind ;
+        rdfs:comment     "If the main function of the system unit is cable." ;
+        rdfs:label       "cable"@en ;
+        cims:stereotype  "enum" .
+
+nc:SystemUnitKind.dcCable
+        rdf:type         nc:SystemUnitKind ;
+        rdfs:comment     "If the main function of the system unit is DCCable." ;
+        rdfs:label       "dcCable"@en ;
+        cims:stereotype  "enum" .
+
+nc:SystemUnitKind.dcConverter
+        rdf:type         nc:SystemUnitKind ;
+        rdfs:comment     "If the main function of the system unit is DCConverter." ;
+        rdfs:label       "dcConverter"@en ;
+        cims:stereotype  "enum" .
+
+nc:SystemUnitKind.facts
+        rdf:type         nc:SystemUnitKind ;
+        rdfs:comment     "If the main function of the system unit is FACTS." ;
+        rdfs:label       "facts"@en ;
+        cims:stereotype  "enum" .
+
+nc:SystemUnitKind.other
+        rdf:type         nc:SystemUnitKind ;
+        rdfs:comment     "If it is of other kind." ;
+        rdfs:label       "other"@en ;
+        cims:stereotype  "enum" .
+
+nc:SystemUnitKind.overheadLine
+        rdf:type         nc:SystemUnitKind ;
+        rdfs:comment     "If the main function of the system unit is overhead line." ;
+        rdfs:label       "overheadLine"@en ;
+        cims:stereotype  "enum" .
+
+nc:SystemUnitKind.powerTransformer
+        rdf:type         nc:SystemUnitKind ;
+        rdfs:comment     "If the main function of the system unit is power transformer." ;
+        rdfs:label       "powerTransformer"@en ;
+        cims:stereotype  "enum" .
+
+nc:SystemUnitKind.reactor
+        rdf:type         nc:SystemUnitKind ;
+        rdfs:comment     "If the main function of the system unit is reactor." ;
+        rdfs:label       "reactor"@en ;
+        cims:stereotype  "enum" .
+
+nc:SystemUnitKind.seriesCapacitor
+        rdf:type         nc:SystemUnitKind ;
+        rdfs:comment     "If the main function of the system unit is series capacitor." ;
+        rdfs:label       "seriesCapacitor"@en ;
+        cims:stereotype  "enum" .
+
+nc:SystemUnitKind.shuntCapacitor
+        rdf:type         nc:SystemUnitKind ;
+        rdfs:comment     "If the main function of the system unit is shunt capacitor." ;
+        rdfs:label       "shuntCapacitor"@en ;
+        cims:stereotype  "enum" .
+
+nc:SystemUnitKind.svc
+        rdf:type         nc:SystemUnitKind ;
+        rdfs:comment     "If the main function of the system unit is static var compensator (SVC)." ;
+        rdfs:label       "svc"@en ;
+        cims:stereotype  "enum" .
+
+nc:TripKind  rdf:type           rdfs:Class ;
+        rdfs:comment            "Whether the type of the trip due to the outage was automatic, automatic with successful automatic reclosing or manual.\n\nIn case of a fault in the reclosing automatics resulting in lack of reclosing, automatic should be chosen as an alternative." ;
+        rdfs:label              "TripKind"@en ;
+        cims:belongsToCategory  gd:Package_GridDisturbanceProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:TripKind.automatic
+        rdf:type         nc:TripKind ;
+        rdfs:comment     "The trip that resulted in the outage was automatic.\n\nIn case of a fault in the reclosing automatics resulting in lack of reclosing, automatic should be chosen as an alternative." ;
+        rdfs:label       "automatic"@en ;
+        cims:stereotype  "enum" .
+
+nc:TripKind.automaticWithUnsuccessfulAutomaticReclosing
+        rdf:type         nc:TripKind ;
+        rdfs:comment     "The trip that resulted in an outage was correctly initiated but the automatic reclosing was unsuccessful.\n\nIn case of a fault in the reclosing automatics resulting in lack of reclosing, automatic should be chosen as an alternative." ;
+        rdfs:label       "automaticWithUnsuccessfulAutomaticReclosing"@en ;
+        cims:stereotype  "enum" .
+
+nc:TripKind.manual  rdf:type  nc:TripKind ;
+        rdfs:comment     "The trip that resulted in the outage was manually cleared." ;
+        rdfs:label       "manual"@en ;
+        cims:stereotype  "enum" .
+
+nc:UnplannedOutage.autoReclosingKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The type of autoreclosing that occurred with the trip.\n\nIf high-speed automatic reclosing is successful at one end of a line, but the line needs to be reclosed manually at the other end, choose manual reclosing.\n\nIn this document, high-speed automatic reclosing refers to automatic reclosing after less than 2 seconds." ;
+        rdfs:domain        cim:UnplannedOutage ;
+        rdfs:label         "autoReclosingKind"@en ;
+        rdfs:range         nc:AutoReclosingKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:UnplannedOutage.duration
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The duration of the unplanned outage." ;
+        rdfs:domain        cim:UnplannedOutage ;
+        rdfs:label         "duration"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:UnplannedOutage.startDateTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The date and time at which the unplanned outage occurred." ;
+        rdfs:domain        cim:UnplannedOutage ;
+        rdfs:label         "startDateTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:UnplannedOutage.systemUnitKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The type of system unit of the component affected by the outage.\n\nA system unit is defined as:\n\nA group of components which are delimited by one or more circuit breakers.\n\nNote 1: the system unit concept has been defined to simplify the calculation of availability. While a system unit is always delimited by circuit breakers, an individual component may not always be. A system unit may therefore contain more than one component. \n\nNote 2: the circuit breakers are not included in the system unit.\n\nNote 3: a tripped element is synonymous to a tripped system unit.\n\nNote 4: the type of a system unit is determined by its dominant component. The available system unit types are power transformer, overhead line, cable, reactor, busbar, series capacitor, shunt capacitor and SVC.\n\nNote 5: when a system unit is no longer transporting or supplying electrical energy, the system unit is affected by an outage. The system unit is unavailable after the outage has occurred." ;
+        rdfs:domain        cim:UnplannedOutage ;
+        rdfs:label         "systemUnitKind"@en ;
+        rdfs:range         nc:SystemUnitKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:UnplannedOutage.tripKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Whether the type of the trip due to the outage was automatic, automatic with successful automatic reclosing or manual.\n\nIn case of a fault in the reclosing automatics resulting in lack of reclosing, automatic should be chosen as an alternative." ;
+        rdfs:domain        cim:UnplannedOutage ;
+        rdfs:label         "tripKind"@en ;
+        rdfs:range         nc:TripKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+profcim:IRI  rdf:type           rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as rdf:resource in RDFXML.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "IRI"@en ;
+        cims:belongsToCategory  gd:Package_DocGridDisturbanceProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringFixedLanguage
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited.\nThe primitive is serialized as literal without language support." ;
+        rdfs:label              "StringFixedLanguage"@en ;
+        cims:belongsToCategory  gd:Package_DocGridDisturbanceProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringIRI  rdf:type     rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as literal without language support.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "StringIRI"@en ;
+        cims:belongsToCategory  gd:Package_DocGridDisturbanceProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:URL  rdf:type           rdfs:Class ;
+        rdfs:comment            "A Uniform Resource Locator (URL), colloquially termed a web address, is a reference to a web resource that specifies its location on a computer network and a mechanism for retrieving it. A URL is a specific type of Uniform Resource Identifier (URI), although many people use the two terms interchangeably.URLs occur most commonly to reference web pages (http), but are also used for file transfer (ftp), email (mailto), database access (JDBC), and many other applications." ;
+        rdfs:label              "URL"@en ;
+        cims:belongsToCategory  gd:Package_DocGridDisturbanceProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+

--- a/r2.3/ap-voc/ttl/Header-AP-Voc-RDFS2020.ttl
+++ b/r2.3/ap-voc/ttl/Header-AP-Voc-RDFS2020.ttl
@@ -1,0 +1,880 @@
+@prefix adms:     <http://www.w3.org/ns/adms#> .
+@prefix cim:      <https://cim.ucaiug.io/ns#> .
+@prefix cims:     <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#> .
+@prefix dcat:     <http://www.w3.org/ns/dcat#> .
+@prefix dcat-cim: <https://cim4.eu/ns/dcat-cim#> .
+@prefix dcterms:  <http://purl.org/dc/terms/#> .
+@prefix dh:       <https://ap.cim4.eu/DocumentHeader#> .
+@prefix dm:       <http://iec.ch/TC57/61970-552/DifferenceModel/1#> .
+@prefix eu:       <https://cim.ucaiug.io/ns/eu#> .
+@prefix eumd:     <https://cim4.eu/ns/Metadata-European#> .
+@prefix euvoc:    <http://publications.europa.eu/ontology/euvoc#> .
+@prefix md:       <http://iec.ch/TC57/61970-552/ModelDescription/1#> .
+@prefix owl:      <http://www.w3.org/2002/07/owl#> .
+@prefix profcim:  <https://cim.ucaiug.io/ns/prof-cim#> .
+@prefix prov:     <http://www.w3.org/ns/prov#> .
+@prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:     <http://www.w3.org/2000/01/rdf-schema#> .
+
+adms:versionNotes  rdf:type  rdf:Property ;
+        rdfs:comment       "A description of changes between this version and the previous version of the resource." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "versionNotes"@en ;
+        cims:dataType      rdf:LangString ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "adms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Date  rdf:type              rdfs:Class ;
+        rdfs:comment            "Date as \"yyyy-mm-dd\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddZ\". A local timezone relative UTC is specified as \"yyyy-mm-dd(+/-)hh:mm\"." ;
+        rdfs:label              "Date"@en ;
+        cims:belongsToCategory  dh:Package_DocDocumentHeaderProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:DateTime  rdf:type          rdfs:Class ;
+        rdfs:comment            "Date and time as \"yyyy-mm-ddThh:mm:ss.sss\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddThh:mm:ss.sssZ\". A local timezone relative UTC is specified as \"yyyy-mm-ddThh:mm:ss.sss-hh:mm\". The second component (shown here as \"ss.sss\") could have any number of digits in its fractional part to allow any kind of precision beyond seconds." ;
+        rdfs:label              "DateTime"@en ;
+        cims:belongsToCategory  dh:Package_DocumentHeaderProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Duration  rdf:type          rdfs:Class ;
+        rdfs:comment            "Duration as \"PnYnMnDTnHnMnS\" which conforms to ISO 8601, where nY expresses a number of years, nM a number of months, nD a number of days. The letter T separates the date expression from the time expression and, after it, nH identifies a number of hours, nM a number of minutes and nS a number of seconds. The number of seconds could be expressed as a decimal number, but all other numbers are integers." ;
+        rdfs:label              "Duration"@en ;
+        cims:belongsToCategory  dh:Package_Domain ;
+        cims:stereotype         "Primitive" .
+
+cim:String  rdf:type            rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited." ;
+        rdfs:label              "String"@en ;
+        cims:belongsToCategory  dh:Package_DocumentHeaderProfile ;
+        cims:stereotype         "Primitive" .
+
+dcat-cim:alternativeVersionOf
+        rdf:type              rdf:Property ;
+        rdfs:comment          "This resource is an alternative version of a non-versioned or abstract resource.\nThis property is intended for relating a versioned resource to a non-versioned or abstract resource at the same time express that multiple versions exist.\ndcat-cim:alternativeVersionOf is a specialisation of dcat:isVersionOf with the restriction that the resource shall have a preferred version (dcat-cim:preferredVersion) so that the preferred dataset can be used when there is no need to access all alternative versions." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "alternativeVersionOf"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  dcat-cim:hasAlternativeVersion ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "dcat-cim" .
+
+dcat-cim:hasAlternativeVersion
+        rdf:type              rdf:Property ;
+        rdfs:comment          "This resource has a more specific, versioned alternative resource.\nThis property is intended for relating a non-versioned or abstract resource to several versioned alternative resources, e.g. snapshots.\n\ndcat-cim:hasAlternativeVersion is a specialisation of dcat:hasVersion with the restriction that the resource shall have a preferred version (dcat-cim:preferredVersion) so that the preferred dataset can be used when there is no need to access all alternative versions." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "hasAlternativeVersion"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  dcat-cim:alternativeVersionOf ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "dcat-cim" .
+
+dcat-cim:hasPreferredVersion
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The resource that has a preferred version." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "hasPreferredVersion"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  dcat-cim:preferredVersion ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "dcat-cim" .
+
+dcat-cim:preferredVersion
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The preferred version of a resource in a lineage of alternative versions.\nThis property is used to specify a specific version to be the preference in a chain of alternatives, consisting of snapshots of a resource." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "preferredVersion"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  dcat-cim:hasPreferredVersion ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "dcat-cim" .
+
+dcat:Resource7  rdf:type      rdf:Property ;
+        rdfs:comment          "The resoource of a previous version that has this next version." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "Resource7"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  dcat:previousVersion ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "dcat" .
+
+dcat:Resource8  rdf:type      rdf:Property ;
+        rdfs:comment          "The resource that has this next version." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "Resource8"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  dcat:nextVersion ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "dcat" .
+
+dcat:endDate  rdf:type     rdf:Property ;
+        rdfs:comment       "This property contains the end of the period.\n[CIM context:\nThe end date and time of the validity period of the model that it is serialized in the document where the header is located. It is only used in relation to the startDate property which indicates the beginning of the validity period of the model.]." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "endDate"@en ;
+        cims:dataType      eumd:DateTimeStamp ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcat" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcat:hasVersion  rdf:type     rdf:Property ;
+        rdfs:comment          "This resource has a more specific, versioned resource.\nThis property is intended for relating a non-versioned or abstract resource to several versioned resources, e.g. snapshots [PAV].\n\nThe notion of version used by this property is limited to versions resulting from revisions occurring to a resource as part of its life-cycle. Therefore, its semantics is more specific than its super-property dcterms:hasVersion, which makes use of a broader notion of version, including editions and adaptations.\n\nThis property is deprecated." , "This resource is a version of a non-versioned or abstract resource.\nThis property is intended for relating a versioned resource to a non-versioned or abstract resource.\n\nThe notion of version used by this property is limited to versions resulting from revisions occurring to a resource as part of its life-cycle. Therefore, its semantics is more specific than its super-property dcterms:isVersionOf, which makes use of a broader notion of version, including editions and adaptations." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "hasVersion"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "No" ;
+        cims:dataType         cim:String ;
+        cims:inverseRoleName  dcat:isVersionOf ;
+        cims:multiplicity     cims:M:0..1 , cims:M:0..n ;
+        cims:stereotype       "dcat" , "deprecated" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcat:inSeries  rdf:type       rdf:Property ;
+        rdfs:comment          "A dataset series of which the dataset is part." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "inSeries"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  dcat:seriesMember ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "dcat" .
+
+dcat:isVersionOf  rdf:type    rdf:Property ;
+        rdfs:comment          "This resource has a more specific, versioned resource. This property is intended for relating a non-versioned or abstract resource to several versioned resources, e.g., snapshots.\n\nThe notion of version used by this property is limited to versions resulting from revisions occurring to a resource as part of its life-cycle. Therefore, its semantics is more specific than its super-property dcterms:hasVersion, which makes use of a broader notion of version, including editions and adaptations." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "isVersionOf"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  dcat:hasVersion ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "dcat" .
+
+dcat:keyword  rdf:type     rdf:Property ;
+        rdfs:comment       "A keyword or tag describing a resource.\n[CIM context:\nThe intended content type of the model, usually the profile keyword. Used to identify what profiles and content is expected in the document, e.g., Equipment, Boundary, SSH, AE, etc. The same keyword is used for different versions of same profile. It can be also used to identify different content based on the same profile.\nFor instance, as the equipment profile can be used for both boundary data and equipment not related to boundary, the keyword is different to indicate that boundary data is exchanged. In order to avoid ambiguity the property is not exchanged in cases where the document contains multiple profiles referenced by dct:conformsTo.]." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "keyword"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..n ;
+        cims:stereotype    "dcat" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcat:nextVersion  rdf:type    rdf:Property ;
+        rdfs:comment          "The next version for the resource." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "nextVersion"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  dcat:Resource8 ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "dcat" .
+
+dcat:previousVersion  rdf:type  rdf:Property ;
+        rdfs:comment          "The previous version of a resource in a lineage.\nThis property is meant to be used to specify a version chain, consisting of snapshots of a resource.\n\nThe notion of version used by this property is limited to versions resulting from revisions occurring to a resource as part of its life-cycle. One of the typical cases here is representing the history of the versions of a dataset that have been released over time." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "previousVersion"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  dcat:Resource7 ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "dcat" .
+
+dcat:seriesMember  rdf:type   rdf:Property ;
+        rdfs:comment          "A dataset that is member of this series. " ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "seriesMember"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  dcat:inSeries ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "dcat" .
+
+dcat:startDate  rdf:type   rdf:Property ;
+        rdfs:comment       "This property contains the start of the \nperiod.\n[CIM context:\nThe date and time that this model represents, i.e. for which the model is (or was) valid. It indicates the beginning of the validity period. It is indicating either an instant (in cases where the model is only valid for a point in time) or the start time of a period. If not provided the model is considered valid for any time stamp. The format is an extended format according to the ISO 8601-2005. European exchanges shall refer to UTC.]." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "startDate"@en ;
+        cims:dataType      eumd:DateTimeStamp ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcat" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcat:temporalResolution
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Minimum time period resolvable in the dataset.\n[CIM context: \n\nDescribes the Market Time Unit (MTU), e.g. hourly, 15 min., etc.]" ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "temporalResolution"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcat" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcat:version  rdf:type     rdf:Property ;
+        rdfs:comment       "The version number of a resource." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "version"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcat" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:Resource1  rdf:type   rdf:Property ;
+        rdfs:comment          "The resource that has these access rights." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "Resource1"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  dcterms:accessRights ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "dcterms" .
+
+dcterms:Resource10  rdf:type  rdf:Property ;
+        rdfs:comment          "The resource that has this spatial location." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "Resource10"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  dcterms:spatial ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "dcterms" .
+
+dcterms:Resource11  rdf:type  rdf:Property ;
+        rdfs:comment          "The resource that is made available." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "Resource11"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  dcterms:publisher ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "dcterms" .
+
+dcterms:Resource12  rdf:type  rdf:Property ;
+        rdfs:comment          "The resource that replaces the referenced resource." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "Resource12"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  dcterms:replaces ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "dcterms" .
+
+dcterms:Resource13  rdf:type  rdf:Property ;
+        rdfs:comment          "The resource that has these recerences." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "Resource13"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  dcterms:references ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "dcterms" .
+
+dcterms:Resource2  rdf:type   rdf:Property ;
+        rdfs:comment          "The resource that conforms to." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "Resource2"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  dcterms:conformsTo ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "dcterms" .
+
+dcterms:Resource3  rdf:type   rdf:Property ;
+        rdfs:comment          "The resource that has this license." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "Resource3"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  dcterms:license ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "dcterms" .
+
+dcterms:Resource4  rdf:type   rdf:Property ;
+        rdfs:comment          "The resource that has this type." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "Resource4"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  dcterms:type ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "dcterms" .
+
+dcterms:Resource5  rdf:type   rdf:Property ;
+        rdfs:comment          "The resource that has this periodicity." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "Resource5"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  dcterms:accrualPeriodicity ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "dcterms" .
+
+dcterms:Resource6  rdf:type   rdf:Property ;
+        rdfs:comment          "The resource that has this source." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "Resource6"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  dcterms:source ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "dcterms" .
+
+dcterms:accessRights  rdf:type  rdf:Property ;
+        rdfs:comment          "Information about who access the resource or an indication of its security status. Access Rights may include information regarding access or restrictions based on privacy, security, or other policies.\n[CIM context:\nReference to the confidentiality level that shall be applied when handling this model.]." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "accessRights"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  dcterms:Resource1 ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "dcterms" .
+
+dcterms:accrualPeriodicity
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The frequency with which items are added to a collection.\n[CIM context:\nReference to the time frame.]." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "accrualPeriodicity"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  dcterms:Resource5 ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "dcterms" .
+
+dcterms:conformsTo  rdf:type  rdf:Property ;
+        rdfs:comment          "An established standard to which the described resource conforms.\n[CIM context:\nAn IRI describing the profile that governs this model. It uniquely identifies the profile and its version. Multiple instances of the property describe all standards or specifications to which the model and the document representing this model conform to.\nA document would normally conform to profile definitions, the constraints that relate to the profile and/or the set of business specific constrains. A reference to a machine- readable constraints or specification indicates that the document was tested against these constraints and it conforms to them.]." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "conformsTo"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  dcterms:Resource2 ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "dcterms" .
+
+dcterms:creator  rdf:type  rdf:Property ;
+        rdfs:comment       "An entity responsible for making the resource.\nRecommended practice is to identify the creator with a URI. If this is not possible or feasible, a literal value that identifies the creator may be provided.\n[CIM context:\nThe name of the agent (Modeling Authority) from which the model originates. This property is deprecated. Use dcterms:publisher.]." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "creator"@en ;
+        cims:dataType      profcim:StringIRI ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "deprecated" , "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:description  rdf:type  rdf:Property ;
+        rdfs:comment       "A free-text account of the item." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "description"@en ;
+        cims:dataType      rdf:LangString ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:identifier  rdf:type  rdf:Property ;
+        rdfs:comment       "An unambiguous reference to the resource within a given context. Recommended practice is to identify the resource by means of a string conforming to an identification system. Examples include International Standard Book Number (ISBN), Digital Object Identifier (DOI), and Uniform Resource Name (URN). Persistent identifiers should be provided as HTTP URIs.\n[CIM context:\nA unique identifier of the model which is serialised in the document where the header is located. The identifier is persistent for a given version of the model and shall change when the model changes.\nIf a model is serialized as complete (full) model or as difference model exchange the identifier shall be the same. The identifier shall not be used as an identifier of the document which can be different for a given version of a model.]." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "identifier"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:issued  rdf:type   rdf:Property ;
+        rdfs:comment       "The date of listing (i.e., formal recording) of the corresponding dataset or service in the catalog.\n[CIM context:\nReference to the date that the complete data set was made valid/available.]." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "issued"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:license  rdf:type     rdf:Property ;
+        rdfs:comment          "A legal document giving official permission to do something with the resource. Recommended practice is to identify the license document with a URI. If this is not possible or feasible, a literal value that identifies the license may be provided.\n[CIM context:\nReference to the license under which the data is made available. If no license holder is defined, then the original data provider holds the license.]." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "license"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  dcterms:Resource3 ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "dcterms" .
+
+dcterms:publisher  rdf:type   rdf:Property ;
+        rdfs:comment          "An entity responsible for making the resource available.\n[CIM context: \nThe agent that is publishing the dataset on the given platform.]" ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "publisher"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  dcterms:Resource11 ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "dcterms" .
+
+dcterms:references  rdf:type  rdf:Property ;
+        rdfs:comment          "A related resource that is referenced, cited, or otherwise pointed to by the described resource[.\n[CIM context: \nThe referenced resource that is being complemented in this dataset, e.g. SSH is referencing EQ.]" ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "references"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  dcterms:Resource13 ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "dcterms" .
+
+dcterms:replaces  rdf:type    rdf:Property ;
+        rdfs:comment          "A related resource that is supplanted, displaced, or superseded by the described resource\n[CIM context: \nThe referenced dataset is being replaced by this dataset.]" ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "replaces"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  dcterms:Resource12 ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "dcterms" .
+
+dcterms:rights  rdf:type   rdf:Property ;
+        rdfs:comment       "A statement that concerns all rights not addressed with dct:license or dct:accessRights, such as copyright statements." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "rights"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:rightsHolder  rdf:type  rdf:Property ;
+        rdfs:comment       "Information about rights held in and over the resource. Typically, rights information includes a statement about various property rights associated with the resource, including intellectual property rights. Recommended practice is to refer to a rights statement with a URI. If this is not possible or feasible, a literal value (name, label, or short text) may be provided." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "rightsHolder"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:source  rdf:type      rdf:Property ;
+        rdfs:comment          "A related resource from which the described resource is derived.\nThis property is intended to be used with non-literal values. The described resource may be derived from the related resource in whole or in part. Best practice is to identify the related resource by means of a URI or a string conforming to a formal identification system." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "source"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  dcterms:Resource6 ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "dcterms" .
+
+dcterms:spatial  rdf:type     rdf:Property ;
+        rdfs:comment          "The geographical area covered by the dataset.\n[CIM context: \nThe responsibility area that multiple model can describe, also referred to frame.]" ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "spatial"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  dcterms:Resource10 ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "dcterms" .
+
+dcterms:title  rdf:type    rdf:Property ;
+        rdfs:comment       "A name given to the resource\n[CIM context: \n\nThe human readable name of the dataset that can form the instance file name.]" ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "title"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:type  rdf:type        rdf:Property ;
+        rdfs:comment          "The nature or genre of the resource. Recommended practice is to use a controlled vocabulary such as the DCMI Type Vocabulary [DCMI-TYPE]. To describe the file format, physical medium, or dimensions of the resource, use the property Format." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "type"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  dcterms:Resource4 ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "dcterms" .
+
+dh:Ontology  rdf:type               owl:Ontology ;
+        dcterms:conformsTo          "urn:iso:std:iec:61970-501:draft:ed-2" , "urn:iso:std:iec:61970-401:draft:ed-1" ;
+        dcterms:creator             "ENTSO-E"@en ;
+        dcterms:description         "This vocabulary is describing the document header profile."@en ;
+        dcterms:identifier          "urn:uuid:0693858e-f49d-46c2-805d-1dbb9fd9d90f" ;
+        dcterms:language            "en-GB" ;
+        dcterms:license             "https://www.apache.org/licenses/LICENSE-2.0"@en ;
+        dcterms:modified            "2023-09-28"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        dcterms:publisher           "ENTSO-E"@en ;
+        dcterms:rightsHolder        "ENTSO-E"@en ;
+        dcterms:title               "Document header vocabulary"@en ;
+        owl:backwardCompatibleWith  <http://iec.ch/TC57/61970-552/ModelDescription/1> ;
+        owl:priorVersion            <https://ap.cim4.eu/DocumentHeader/2.2> ;
+        owl:versionIRI              <https://ap.cim4.eu/DocumentHeader/2.3> ;
+        owl:versionInfo             "2.3.1"@en ;
+        dcat:keyword                "DH" ;
+        dcat:theme                  "vocabulary"@en .
+
+dh:Package_DocDocumentHeaderProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains datatypes used only in the RDFS header." ;
+        rdfs:label    "DocDocumentHeaderProfile"@en .
+
+dh:Package_DocumentHeaderProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "The package describes the profile for the extended header." ;
+        rdfs:label    "DocumentHeaderProfile"@en .
+
+dm:DifferenceModel  rdf:type    rdfs:Class ;
+        rdfs:comment            "It represents the difference model header. The content is described by the Model class, the association role forwardDifferences and association role reverseDifferences. Both association roles may have one set of Statements." ;
+        rdfs:label              "DifferenceModel"@en ;
+        rdfs:subClassOf         md:Model ;
+        cims:belongsToCategory  dh:Package_DocumentHeaderProfile ;
+        cims:stereotype         "dm" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+dm:DifferenceModel.forwardDifferences
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A property of the difference model whose value is a collection of statements (i.e., resources of type rdf:Statement) representing the forward difference statements. " ;
+        rdfs:domain        dm:DifferenceModel ;
+        rdfs:label         "forwardDifferences"@en ;
+        cims:dataType      md:Statement ;
+        cims:multiplicity  cims:M:1..n ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dm:DifferenceModel.preconditions
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A property of the difference model whose value is the collection of precondition statements." ;
+        rdfs:domain        dm:DifferenceModel ;
+        rdfs:label         "preconditions"@en ;
+        cims:dataType      md:Statement ;
+        cims:multiplicity  cims:M:1..n ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dm:DifferenceModel.reverseDifferences
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A property of the difference model whose value is the collection of reverse difference statements." ;
+        rdfs:domain        dm:DifferenceModel ;
+        rdfs:label         "reverseDifferences"@en ;
+        cims:dataType      md:Statement ;
+        cims:multiplicity  cims:M:1..n ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+eu:URI  rdf:type                rdfs:Class ;
+        rdfs:comment            "URI is a string following the rules defined by the W3C/IETF URI Planning Interest Group in a set of RFCs of which one is RFC 3305." ;
+        rdfs:label              "URI"@en ;
+        cims:belongsToCategory  dh:Package_DocumentHeaderProfile ;
+        cims:stereotype         "European" , "Primitive" .
+
+eumd:DateTimeStamp  rdf:type    rdfs:Class ;
+        rdfs:comment            "Position of an instant, expressed using xsd:dateTimeStamp, in which the time-zone field is mandatory." ;
+        rdfs:label              "DateTimeStamp"@en ;
+        cims:belongsToCategory  dh:Package_DocumentHeaderProfile ;
+        cims:stereotype         "eumd" , "Primitive" .
+
+eumd:Model.applicationSoftware
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Identifies the application software which generated this instance file. The application software term is defined in ISO/IEC/IEEE 24765:2017. The application software can be identified either:\n- as a string which contains information on the software name and version, e.g. &lt;tool_name&gt;-&lt;major_version&gt;.&lt;minor_version&gt;.&lt;patch&gt;, or\n- as a reference to a software identification tag as defined by ISO/IEC 19770-2:2015 and ISO/IEC/IEEE 24765:2017." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "applicationSoftware"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "eumd" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+eumd:Model.serviceLocation
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Reference to a service location (region or a domain)." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "serviceLocation"@en ;
+        cims:dataType      profcim:IRI ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "deprecated" , "eumd" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+eumd:Model1  rdf:type         rdf:Property ;
+        rdfs:comment          "The model taht uses these settings." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "Model1"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  eumd:usedSettings ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "eumd" .
+
+eumd:Model2  rdf:type         rdf:Property ;
+        rdfs:comment          "The model for this process type." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "Model2"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  eumd:processType ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "eumd" .
+
+eumd:processType  rdf:type    rdf:Property ;
+        rdfs:comment          "The exact business nature. Reference to Business Process configurations." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "processType"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  eumd:Model2 ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "eumd" .
+
+eumd:usedSettings  rdf:type   rdf:Property ;
+        rdfs:comment          "Reference to a set of parameters describing used settings (e.g. power flow settings, process settings, etc.) applied to the model prior its serialisation." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "usedSettings"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  eumd:Model1 ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "eumd" .
+
+euvoc:status  rdf:type     rdf:Property ;
+        rdfs:comment       "Indicates the status of a skos:Concept or a skosxl:Label, or any resource related to controlled vocabulary management.\n[CIM context:\nThe condition or position of an object with regard to its standing. (Validated, Primary, Backup etc.)]." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "status"@en ;
+        cims:dataType      profcim:IRI ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "euvoc" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+md:FullModel  rdf:type          rdfs:Class ;
+        rdfs:comment            "It represents the full model header and its contents is described by the Model class." ;
+        rdfs:label              "FullModel"@en ;
+        rdfs:subClassOf         md:Model ;
+        cims:belongsToCategory  dh:Package_DocumentHeaderProfile ;
+        cims:stereotype         "md" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+md:Model  rdf:type              rdfs:Class ;
+        rdfs:comment            "A Model is a collection of data describing instances, objects or entities, real or computed. In the context of CIM the semantics of the data is defined by profiles. Hence a model can contain equipment data, power flow initial values, power flow results etc.\nThe Model class describes the header content that is the same for the FullModel and the DifferenceModel. A Model is identified by an rdf:about attribute. The rdf:about attribute uniquely describes the model data and not the CIMXML document. A new rdf:about identification is generated for created documents only when the model data has changed. A repeated creation of documents from unchanged model data shall have the same rdf:about identification as previous document generated from the same model data." ;
+        rdfs:label              "Model"@en ;
+        cims:belongsToCategory  dh:Package_DocumentHeaderProfile .
+
+md:Model.DependentOn  rdf:type  rdf:Property ;
+        rdfs:comment          "A reference to the model documents that the model described by this document depends on. In general there can be 0 or many Model.DependentOn depending on the profile and the content of the instance file.\nFor instance:\n– A load flow solution depends on the topology model it was computed from\n– A topology model computed by a topology processor depends on the network model it was computed from.\nThe referenced models are identified by the FullModel rdf:about attribute for full model documents and by DifferenceModel rdf:about attribute for difference model documents.\nThe references are maintained by the producer of the CIMXML document and the references are valid for the model with version and identifier for which the document was created." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "DependentOn"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  md:Model.Depending ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "md" .
+
+md:Model.Depending  rdf:type  rdf:Property ;
+        rdfs:comment          "All documents depending on the model described by this document. This role is not intended to be included in any document exchanging instance data." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "Depending"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  md:Model.DependentOn ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "md" .
+
+md:Model.SupersededBy
+        rdf:type              rdf:Property ;
+        rdfs:comment          "All models superseding this model. This role is not intended to be included in any document exchanging instance data." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "SupersededBy"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  md:Model.Supersedes ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "md" .
+
+md:Model.Supersedes  rdf:type  rdf:Property ;
+        rdfs:comment          "When a model is updated the resulting model supersedes the models that were used as basis for the update. Hence this is a reference to the CIMXML documents which are superseded by this model. A model (or instance file) can supersede 1 or more models, e.g. a difference model or a full model supersede multiple models (difference or full). In this case more than one Model.Supersedes are included in the header. The referenced document(s) is (are) identified by the URN/MRID/UUID in the FullModel rdf:about attribute when full model(s) is (are) referenced and by the URN/MRID/UUID in the DifferenceModel rdf:about attribute when difference model(s) is (are) referenced." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "Supersedes"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  md:Model.SupersededBy ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "md" .
+
+md:Model.created  rdf:type  rdf:Property ;
+        rdfs:comment       "The date and time when the model was created. It is the time of the serialization. The format is an extended format according to the ISO 8601-2005. European exchanges shall refer to UTC, e.g. &lt;md:Model.created&gt;2014-05-15T17:48:31.474Z&lt;/md:Model.created&gt;." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "created"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "md" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+md:Model.description  rdf:type  rdf:Property ;
+        rdfs:comment       "A description of the model, e.g. the name of person that created the model and for what purpose. The number of UTF 8 characters is limited to 2000." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "description"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "md" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+md:Model.modelingAuthoritySet
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A URN/URI referring to the organisation role / model authority set reference. The organization role is the source of the model. It is the same for all profiles part of a model exchange. " ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "modelingAuthoritySet"@en ;
+        cims:dataType      eu:URI ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "md" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+md:Model.profile  rdf:type  rdf:Property ;
+        rdfs:comment       "URN/URI describing the profiles that governs this model. It uniquely identifies the profiles and its version, e.g. http://iec.ch/TC57/61970-456/SteadyStateHypothesis/2/0. " ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "profile"@en ;
+        cims:dataType      eu:URI ;
+        cims:multiplicity  cims:M:0..n ;
+        cims:stereotype    "md" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+md:Model.scenarioTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The date and time that this model represents, i.e. for which the model is valid. The format is an extended format according to the ISO 8601-2005. European exchanges shall refer to UTC, e.g. &lt;md:Model.scenarioTime&gt;2030-01-15T17:00:00.000Z&lt;/md:Model.scenarioTime&gt;." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "scenarioTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "md" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+md:Model.version  rdf:type  rdf:Property ;
+        rdfs:comment       "The version of the model. If the instance file is imported and exported with no change, the version number is kept the same. The version changes only if the content of the file changes. It is the same logic as for the header id. The version is the human readable id. [CIM context: It relates to the version of the document and not the version of the model which is serialized.]." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "version"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "md" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+md:Statement  rdf:type          rdfs:Class ;
+        rdfs:comment            "It represent a set of Definition and/or Description elements." ;
+        rdfs:label              "Statement"@en ;
+        cims:belongsToCategory  dh:Package_DocumentHeaderProfile ;
+        cims:stereotype         "rdf" , "Compound" .
+
+md:Statement.object  rdf:type  rdf:Property ;
+        rdfs:comment       "Statement object." ;
+        rdfs:domain        md:Statement ;
+        rdfs:label         "object"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+md:Statement.predicate
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Statement predicate." ;
+        rdfs:domain        md:Statement ;
+        rdfs:label         "predicate"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+md:Statement.subject  rdf:type  rdf:Property ;
+        rdfs:comment       "Statement subject." ;
+        rdfs:domain        md:Statement ;
+        rdfs:label         "subject"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+profcim:IRI  rdf:type           rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as rdf:resource in RDFXML.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "IRI"@en ;
+        cims:belongsToCategory  dh:Package_DocumentHeaderProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringIRI  rdf:type     rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as literal without language support.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "StringIRI"@en ;
+        cims:belongsToCategory  dh:Package_DocumentHeaderProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:URL  rdf:type           rdfs:Class ;
+        rdfs:comment            "A Uniform Resource Locator (URL), colloquially termed a web address, is a reference to a web resource that specifies its location on a computer network and a mechanism for retrieving it. A URL is a specific type of Uniform Resource Identifier (URI), although many people use the two terms interchangeably.URLs occur most commonly to reference web pages (http), but are also used for file transfer (ftp), email (mailto), database access (JDBC), and many other applications." ;
+        rdfs:label              "URL"@en ;
+        cims:belongsToCategory  dh:Package_DocumentHeaderProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+prov:Entity  rdf:type         rdf:Property ;
+        rdfs:comment          "The entity that generated by this activity." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "Entity"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  prov:wasGeneratedBy ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "prov" .
+
+prov:atLocation  rdf:type  rdf:Property ;
+        rdfs:comment       "A location can be an identifiable geographic place (ISO 19112), but it can also be a non-geographic place such as a directory, row, or column. As such, there are numerous ways in which location can be expressed, such as by a coordinate, address, landmark, and so forth.\n[CIM context:\nReference to a region or a domain for which this model is provided. This property is deprecated. Use dcterms:spatial.]." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "atLocation"@en ;
+        cims:dataType      profcim:IRI ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "deprecated" , "prov" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+prov:generatedAtTime  rdf:type  rdf:Property ;
+        rdfs:comment       "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation.\n[CIM context:\nThe date and time when the model was serialized in the document where the header is located. The format is an extended format according to the ISO 8601-2005. European exchanges shall refer to UTC.]." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "generatedAtTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "prov" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+prov:hadPrimarySource
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A primary source for a topic refers to something produced by some agent with direct experience and knowledge about the topic, at the time of the topic's study, without benefit from hindsight. Because of the directness of primary sources, they 'speak for themselves' in ways that cannot be captured through the filter of secondary sources. As such, it is important for secondary sources to reference those primary sources from which they were derived, so that their reliability can be investigated. A primary source relation is a particular case of derivation of secondary materials from their primary sources. It is recognized that the determination of primary sources can be up to interpretation, and should be done according to conventions accepted within the application's domain.\n[CIM context:\nReference to a modelling authority set version sourcing the model. It is only used in cases where a model is modified by an agent which has different version of modelling authority set. The agent that makes a revision of a model indicates the primary source using this property and also refers to its own version of modelling authority set using prov:specializationOf. This property is deprecated. Use dcat:isVersionOf and dcterms:publisher.]." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "hadPrimarySource"@en ;
+        cims:dataType      profcim:IRI ;
+        cims:multiplicity  cims:M:0..n ;
+        cims:stereotype    "deprecated" , "prov" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+prov:specializationOf
+        rdf:type           rdf:Property ;
+        rdfs:comment       "An entity that is a specialization of another shares all aspects of the latter, and additionally presents more specific aspects of the same thing as the latter. In particular, the lifetime of the entity being specialized contains that of any specialization. Examples of aspects include a time period, an abstraction, and a context associated with the entity.\n[CIM context:\nReference to modelling authority set version sourcing the model. The agent that makes a revision of a model indicates the primary source using prov:hadPrimarySource and refers to its own version of modelling authority set using this property. This property is deprecated. Use dcterms:publisher.]." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "specializationOf"@en ;
+        cims:dataType      profcim:IRI ;
+        cims:multiplicity  cims:M:0..n ;
+        cims:stereotype    "deprecated" , "prov" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+prov:wasAttributedTo  rdf:type  rdf:Property ;
+        rdfs:comment       "Attribution is the ascribing of an entity to an agent.\n[CIM context:\nReference to the agent (or service provider) from which the model originates. This property is deprecated. Use dcterms:publisher.]." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "wasAttributedTo"@en ;
+        cims:dataType      profcim:IRI ;
+        cims:multiplicity  cims:M:0..n ;
+        cims:stereotype    "deprecated" , "prov" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+prov:wasGeneratedBy  rdf:type  rdf:Property ;
+        rdfs:comment          "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation.\n[CIM context:\nReference to an activity or the exact business nature (process, configuration) which produced or uses the model.]." ;
+        rdfs:domain           md:Model ;
+        rdfs:label            "wasGeneratedBy"@en ;
+        rdfs:range            md:Model ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  prov:Entity ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "prov" .
+
+prov:wasInfluencedBy  rdf:type  rdf:Property ;
+        rdfs:comment       "Influence is the capacity of an entity, activity, or agent to have an effect on the character, development, or behavior of another by means of usage, start, end, generation, invalidation, communication, derivation, attribution, association, or delegation.\n[CIM context:\nA reference to the model on which the model serialised in this document depends on. The references are maintained by the producer of the model. Minimum requirements for the dependency are specified and can be restricted within a business process as long as they do not contradict requirements by standards. For instance, IEC 61970-600-1 defines minimum requirements for the profiles defined in that standard. This property is deprecated. Use dcterms:references.]." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "wasInfluencedBy"@en ;
+        cims:dataType      profcim:IRI ;
+        cims:multiplicity  cims:M:0..n ;
+        cims:stereotype    "deprecated" , "prov" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+prov:wasRevisionOf  rdf:type  rdf:Property ;
+        rdfs:comment       "A revision is a derivation for which the resulting entity is a revised version of some original. The implication here is that the resulting entity contains substantial content from the original. Revision is a particular case of derivation. \n[CIM context:\nWhen a model is updated the resulting model supersedes the models that were used as basis for the update. Hence this is a reference to the model which are superseded by this model. A model can supersede 1 or more models, e.g. a difference model or a full model supersede multiple models (difference or full). In this case, multiple properties are included in the header. The referenced document(s) is (are) identified by the URN/MRID/UUID in the FullModel rdf:about attribute when full model(s) is (are) referenced and by the URN/MRID/UUID in the DifferenceModel rdf:about attribute when difference model(s) is (are) referenced. This property is deprecated. Use dcterms:replaces.]." ;
+        rdfs:domain        md:Model ;
+        rdfs:label         "wasRevisionOf"@en ;
+        cims:dataType      profcim:IRI ;
+        cims:multiplicity  cims:M:0..n ;
+        cims:stereotype    "deprecated" , "prov" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+rdf:LangString  rdf:type        rdfs:Class ;
+        rdfs:comment            "According to RDF 1.1 and RDF 1.2 the rdf:langString returns the given value and language tag. The rdf:langString type extends xs:string, and represents a language tagged string in RDF." ;
+        rdfs:label              "LangString"@en ;
+        cims:belongsToCategory  dh:Package_DocumentHeaderProfile ;
+        cims:stereotype         "rdf" , "Primitive" .
+

--- a/r2.3/ap-voc/ttl/Header-AP-Voc-RDFS2020.ttl
+++ b/r2.3/ap-voc/ttl/Header-AP-Voc-RDFS2020.ttl
@@ -16,6 +16,34 @@
 @prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:     <http://www.w3.org/2000/01/rdf-schema#> .
 
+dh:Ontology  rdf:type               owl:Ontology ;
+        dcterms:conformsTo          "urn:iso:std:iec:61970-501:draft:ed-2" , "urn:iso:std:iec:61970-401:draft:ed-1" ;
+        dcterms:creator             "ENTSO-E"@en ;
+        dcterms:description         "This vocabulary is describing the document header profile."@en ;
+        dcterms:identifier          "urn:uuid:0693858e-f49d-46c2-805d-1dbb9fd9d90f" ;
+        dcterms:language            "en-GB" ;
+        dcterms:license             "https://www.apache.org/licenses/LICENSE-2.0"@en ;
+        dcterms:modified            "2023-09-28"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        dcterms:publisher           "ENTSO-E"@en ;
+        dcterms:rightsHolder        "ENTSO-E"@en ;
+        dcterms:title               "Document header vocabulary"@en ;
+        owl:backwardCompatibleWith  <http://iec.ch/TC57/61970-552/ModelDescription/1> ;
+        owl:priorVersion            <https://ap.cim4.eu/DocumentHeader/2.2> ;
+        owl:versionIRI              <https://ap.cim4.eu/DocumentHeader/2.3> ;
+        owl:versionInfo             "2.3.1"@en ;
+        dcat:keyword                "DH" ;
+        dcat:theme                  "vocabulary"@en .
+
+dh:Package_DocDocumentHeaderProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains datatypes used only in the RDFS header." ;
+        rdfs:label    "DocDocumentHeaderProfile"@en .
+
+dh:Package_DocumentHeaderProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "The package describes the profile for the extended header." ;
+        rdfs:label    "DocumentHeaderProfile"@en .
+
 adms:versionNotes  rdf:type  rdf:Property ;
         rdfs:comment       "A description of changes between this version and the previous version of the resource." ;
         rdfs:domain        md:Model ;
@@ -484,34 +512,6 @@ dcterms:type  rdf:type        rdf:Property ;
         cims:inverseRoleName  dcterms:Resource4 ;
         cims:multiplicity     cims:M:0..1 ;
         cims:stereotype       "dcterms" .
-
-dh:Ontology  rdf:type               owl:Ontology ;
-        dcterms:conformsTo          "urn:iso:std:iec:61970-501:draft:ed-2" , "urn:iso:std:iec:61970-401:draft:ed-1" ;
-        dcterms:creator             "ENTSO-E"@en ;
-        dcterms:description         "This vocabulary is describing the document header profile."@en ;
-        dcterms:identifier          "urn:uuid:0693858e-f49d-46c2-805d-1dbb9fd9d90f" ;
-        dcterms:language            "en-GB" ;
-        dcterms:license             "https://www.apache.org/licenses/LICENSE-2.0"@en ;
-        dcterms:modified            "2023-09-28"^^<http://www.w3.org/2001/XMLSchema#date> ;
-        dcterms:publisher           "ENTSO-E"@en ;
-        dcterms:rightsHolder        "ENTSO-E"@en ;
-        dcterms:title               "Document header vocabulary"@en ;
-        owl:backwardCompatibleWith  <http://iec.ch/TC57/61970-552/ModelDescription/1> ;
-        owl:priorVersion            <https://ap.cim4.eu/DocumentHeader/2.2> ;
-        owl:versionIRI              <https://ap.cim4.eu/DocumentHeader/2.3> ;
-        owl:versionInfo             "2.3.1"@en ;
-        dcat:keyword                "DH" ;
-        dcat:theme                  "vocabulary"@en .
-
-dh:Package_DocDocumentHeaderProfile
-        rdf:type      cims:ClassCategory ;
-        rdfs:comment  "This package contains datatypes used only in the RDFS header." ;
-        rdfs:label    "DocDocumentHeaderProfile"@en .
-
-dh:Package_DocumentHeaderProfile
-        rdf:type      cims:ClassCategory ;
-        rdfs:comment  "The package describes the profile for the extended header." ;
-        rdfs:label    "DocumentHeaderProfile"@en .
 
 dm:DifferenceModel  rdf:type    rdfs:Class ;
         rdfs:comment            "It represents the difference model header. The content is described by the Model class, the association role forwardDifferences and association role reverseDifferences. Both association roles may have one set of Statements." ;

--- a/r2.3/ap-voc/ttl/ImpactAssessmentMatrix-AP-Voc-RDFS2020.ttl
+++ b/r2.3/ap-voc/ttl/ImpactAssessmentMatrix-AP-Voc-RDFS2020.ttl
@@ -1,0 +1,554 @@
+@prefix cim:     <https://cim.ucaiug.io/ns#> .
+@prefix cims:    <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/#> .
+@prefix iam:     <https://ap.cim4.eu/ImpactAssessmentMatrix#> .
+@prefix nc:      <https://cim4.eu/ns/nc#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix profcim: <https://cim.ucaiug.io/ns/prof-cim#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+
+cim:Date  rdf:type              rdfs:Class ;
+        rdfs:comment            "Date as \"yyyy-mm-dd\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddZ\". A local timezone relative UTC is specified as \"yyyy-mm-dd(+/-)hh:mm\"." ;
+        rdfs:label              "Date"@en ;
+        cims:belongsToCategory  iam:Package_DocImpactAssessmentMatrixProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:DateTime  rdf:type          rdfs:Class ;
+        rdfs:comment            "Date and time as \"yyyy-mm-ddThh:mm:ss.sss\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddThh:mm:ss.sssZ\". A local timezone relative UTC is specified as \"yyyy-mm-ddThh:mm:ss.sss-hh:mm\". The second component (shown here as \"ss.sss\") could have any number of digits in its fractional part to allow any kind of precision beyond seconds." ;
+        rdfs:label              "DateTime"@en ;
+        cims:belongsToCategory  iam:Package_DocImpactAssessmentMatrixProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Float  rdf:type             rdfs:Class ;
+        rdfs:comment            "A floating point number. The range is unspecified and not limited." ;
+        rdfs:label              "Float"@en ;
+        cims:belongsToCategory  iam:Package_ImpactAssessmentMatrixProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:IdentifiedObject  rdf:type  rdfs:Class ;
+        rdfs:comment            "This is a root class to provide common identification for all classes needing identification and naming attributes." ;
+        rdfs:label              "IdentifiedObject"@en ;
+        cims:belongsToCategory  iam:Package_ImpactAssessmentMatrixProfile .
+
+cim:IdentifiedObject.description
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The description is a free human readable text describing or naming the object. It may be non unique and may not correlate to a naming hierarchy." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "description"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.name
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The name is any free human readable and possibly non unique text naming the object." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "name"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:String  rdf:type            rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited." ;
+        rdfs:label              "String"@en ;
+        cims:belongsToCategory  iam:Package_ImpactAssessmentMatrixProfile ;
+        cims:stereotype         "Primitive" .
+
+iam:Ontology  rdf:type        owl:Ontology ;
+        dcterms:conformsTo    "file://CIM100_CGMES31v01_501-20v02_NC23v62_MM10v01.eap" , "file://iec61970cim17v40_iec61968cim13v13a_iec62325cim03v17a.eap" , "urn:iso:std:iec:61970-401:draft:ed-1" , "urn:iso:std:iec:61970-501:draft:ed-2" , "urn:iso:std:iec:61970-301:ed-7:amd1" , "urn:iso:std:iec:61970-600-2:ed-1" ;
+        dcterms:creator       "ENTSO-E CIM WG NC project "@en ;
+        dcterms:description   "This vocabulary is describing the impact assessment matrix profile."@en ;
+        dcterms:identifier    "urn:uuid:1eb41c0b-3c58-4762-a79b-33220d051d32" ;
+        dcterms:language      "en-GB" ;
+        dcterms:license       "https://www.apache.org/licenses/LICENSE-2.0"@en ;
+        dcterms:modified      "2024-03-20"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        dcterms:publisher     "ENTSO-E"@en ;
+        dcterms:rightsHolder  "ENTSO-E"@en ;
+        dcterms:title         "Impact Assessment Matrix Vocabulary"@en ;
+        owl:priorVersion      <http://entsoe.eu/ns/CIM/ImpactAssessmentMatrix-EU/2.2> ;
+        owl:versionIRI        <https://ap.cim4.eu/ImpactAssessmentMatrix/2.3> ;
+        owl:versionInfo       "2.3.0"@en ;
+        dcat:keyword          "IAM" ;
+        dcat:theme            "vocabulary"@en .
+
+iam:Package_DocImpactAssessmentMatrixProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains datatypes used only in the RDFS header." ;
+        rdfs:label    "DocImpactAssessmentMatrixProfile"@en .
+
+iam:Package_ImpactAssessmentMatrixProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains impact assessment matrix profile." ;
+        rdfs:label    "ImpactAssessmentMatrixProfile"@en .
+
+nc:CalculationBasedImpactAssessmentMatrix
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Calculation based impact assessment matrix. It relates to the remedial action schedule. Calculation-Based is the impact matrix determined by calculating the impact factors (eventually scaled by the intensity of the remedial action) and matching them against a threshold in a determined way described by the methodologies." ;
+        rdfs:label              "CalculationBasedImpactAssessmentMatrix"@en ;
+        rdfs:subClassOf         nc:ImpactAssessmentMatrix ;
+        cims:belongsToCategory  iam:Package_ImpactAssessmentMatrixProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ConnectingImpactAssessmentMatrix
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Connecting system operator matrix is the impact matrix indicating which system operators are connecting for that specific remedial action. The concept of connecting system operator for a remedial action is defined by CSAm Article 2.1(14)." ;
+        rdfs:label              "ConnectingImpactAssessmentMatrix"@en ;
+        rdfs:subClassOf         nc:ImpactAssessmentMatrix ;
+        cims:belongsToCategory  iam:Package_ImpactAssessmentMatrixProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ImpactAgreementKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The impact agreement for the remedial action." ;
+        rdfs:label              "ImpactAgreementKind"@en ;
+        cims:belongsToCategory  iam:Package_ImpactAssessmentMatrixProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:ImpactAgreementKind.always
+        rdf:type         nc:ImpactAgreementKind ;
+        rdfs:comment     "An agreement is reached that the remedial action is always impacting whichever the intensity." ;
+        rdfs:label       "always"@en ;
+        cims:stereotype  "enum" .
+
+nc:ImpactAgreementKind.never
+        rdf:type         nc:ImpactAgreementKind ;
+        rdfs:comment     "An agreement is reached that a remedial action is never impacting." ;
+        rdfs:label       "never"@en ;
+        cims:stereotype  "enum" .
+
+nc:ImpactAgreementKind.noAgreement
+        rdf:type         nc:ImpactAgreementKind ;
+        rdfs:comment     "No agreement is reached on the qualitative impact of a remedial action." ;
+        rdfs:label       "noAgreement"@en ;
+        cims:stereotype  "enum" .
+
+nc:ImpactAssessmentMatrix
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The result of an impact assessment analysis for each remedial action or remedial action schedule onto the grid and operation of each system operator." ;
+        rdfs:label              "ImpactAssessmentMatrix"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  iam:Package_ImpactAssessmentMatrixProfile ;
+        cims:stereotype         "NC" .
+
+nc:ImpactAssessmentMatrix.OutcomeValue
+        rdf:type              rdf:Property ;
+        rdfs:comment          "One of the values of the impact assessment matrix." ;
+        rdfs:domain           nc:ImpactAssessmentMatrix ;
+        rdfs:label            "OutcomeValue"@en ;
+        rdfs:range            nc:OutcomeValue ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:OutcomeValue.ImpactAssessmentMatrix ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:ListBasedImpactAssessmentMatrix
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "List-Based is the impact matrix determined by agreement of the system operators involved. System operators jointly decide which Remedial Action (eventually scaled by the intensity of the remedial action) is impacting." ;
+        rdfs:label              "ListBasedImpactAssessmentMatrix"@en ;
+        rdfs:subClassOf         nc:ImpactAssessmentMatrix ;
+        cims:belongsToCategory  iam:Package_ImpactAssessmentMatrixProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:OutcomeImpactAssessmentKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Outcome impact assessments kinds." ;
+        rdfs:label              "OutcomeImpactAssessmentKind"@en ;
+        cims:belongsToCategory  iam:Package_ImpactAssessmentMatrixProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:OutcomeImpactAssessmentKind.false
+        rdf:type         nc:OutcomeImpactAssessmentKind ;
+        rdfs:comment     "False." ;
+        rdfs:label       "false"@en ;
+        cims:stereotype  "enum" .
+
+nc:OutcomeImpactAssessmentKind.true
+        rdf:type         nc:OutcomeImpactAssessmentKind ;
+        rdfs:comment     "True." ;
+        rdfs:label       "true"@en ;
+        cims:stereotype  "enum" .
+
+nc:OutcomeImpactAssessmentKind.undecided
+        rdf:type         nc:OutcomeImpactAssessmentKind ;
+        rdfs:comment     "Undecided. Used only for list-based impact assessment matrix." ;
+        rdfs:label       "undecided"@en ;
+        cims:stereotype  "enum" .
+
+nc:OutcomeValue  rdf:type       rdfs:Class ;
+        rdfs:comment            "Outcome of an impact assessment matrix." ;
+        rdfs:label              "OutcomeValue"@en ;
+        cims:belongsToCategory  iam:Package_ImpactAssessmentMatrixProfile ;
+        cims:stereotype         "NC" .
+
+nc:OutcomeValue.ImpactAssessmentMatrix
+        rdf:type              rdf:Property ;
+        rdfs:comment          "the impact assessment matrix which has this value." ;
+        rdfs:domain           nc:OutcomeValue ;
+        rdfs:label            "ImpactAssessmentMatrix"@en ;
+        rdfs:range            nc:ImpactAssessmentMatrix ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ImpactAssessmentMatrix.OutcomeValue ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:OutcomeValue.ImpactedSystemOperator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The impacted system operator that has an outcome value." ;
+        rdfs:domain           nc:OutcomeValue ;
+        rdfs:label            "ImpactedSystemOperator"@en ;
+        rdfs:range            nc:SystemOperator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SystemOperator.OutcomeValue ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:OutcomeValue.mRID  rdf:type  rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:OutcomeValue ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:OutcomeValue.outcome
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Outcome value." ;
+        rdfs:domain        nc:OutcomeValue ;
+        rdfs:label         "outcome"@en ;
+        rdfs:range         nc:OutcomeImpactAssessmentKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:OwnerRemedialActionAssessment
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Owner remedial action assessment of the impact of their remedial action on neighboring system operators." ;
+        rdfs:label              "OwnerRemedialActionAssessment"@en ;
+        cims:belongsToCategory  iam:Package_ImpactAssessmentMatrixProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:OwnerRemedialActionAssessment.ImpactedSystemOperator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "System operator that is evaluated to be impacted by the remedial action done by the remedial action owner." ;
+        rdfs:domain           nc:OwnerRemedialActionAssessment ;
+        rdfs:label            "ImpactedSystemOperator"@en ;
+        rdfs:range            nc:SystemOperator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SystemOperator.OwnerRemedialActionAssessment ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:OwnerRemedialActionAssessment.RemedialActionImpact
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action impact which is evaluated by the owner of the remedial action." ;
+        rdfs:domain           nc:OwnerRemedialActionAssessment ;
+        rdfs:label            "RemedialActionImpact"@en ;
+        rdfs:range            nc:RemedialActionImpact ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialActionImpact.OwnerRemedialActionAssessment ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:OwnerRemedialActionAssessment.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:OwnerRemedialActionAssessment ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:QualitativeRemedialActionImpact
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Defines the qualitative impact for a remedial action. Relevant remedial action is assumed to have impact when the impact quantity is applied." ;
+        rdfs:label              "QualitativeRemedialActionImpact"@en ;
+        rdfs:subClassOf         nc:RemedialActionImpact ;
+        cims:belongsToCategory  iam:Package_ImpactAssessmentMatrixProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:QuantitativeRemedialActionImpact
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Defines the quantitative impact for a remedial action. The value if the impact quantity is derived through offline calculation that has coursed an impact of an element that is monitored by the assessed system operator higher than the relevant threshold for the conducting equipment. " ;
+        rdfs:label              "QuantitativeRemedialActionImpact"@en ;
+        rdfs:subClassOf         nc:RemedialActionImpact ;
+        cims:belongsToCategory  iam:Package_ImpactAssessmentMatrixProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:QuantitativeRemedialActionImpact.SensitivityArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Sensitivity area which should be monitored to evaluate the threshold given by the remedial action impact on relevant equipment." ;
+        rdfs:domain           nc:QuantitativeRemedialActionImpact ;
+        rdfs:label            "SensitivityArea"@en ;
+        rdfs:range            nc:SensitivityArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SensitivityArea.QuantitativeRemedialActionImpact ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialAction  rdf:type     rdfs:Class ;
+        rdfs:comment            "Remedial action describes one or more actions that can be performed on a given power system model situation to eliminate one or more identified breaches of constraints. The remedial action can be costly, and have a cost characteristic, or non costly. " ;
+        rdfs:label              "RemedialAction"@en ;
+        cims:belongsToCategory  iam:Package_ImpactAssessmentMatrixProfile ;
+        cims:stereotype         "NC" .
+
+nc:RemedialAction.RemedialActionImpact
+        rdf:type              rdf:Property ;
+        rdfs:comment          "This is the impact for a given remedial action." ;
+        rdfs:domain           nc:RemedialAction ;
+        rdfs:label            "RemedialActionImpact"@en ;
+        rdfs:range            nc:RemedialActionImpact ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialActionImpact.RemedialAction ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialAction.RemedialActionOutcomeValue
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The remedial action outcome value associated with a remedial action." ;
+        rdfs:domain           nc:RemedialAction ;
+        rdfs:label            "RemedialActionOutcomeValue"@en ;
+        rdfs:range            nc:RemedialActionOutcomeValue ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialActionOutcomeValue.RemedialAction ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionImpact
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Remedial action impact assessment based on a given agreement with a specific system operator. " ;
+        rdfs:label              "RemedialActionImpact"@en ;
+        cims:belongsToCategory  iam:Package_ImpactAssessmentMatrixProfile ;
+        cims:stereotype         "NC" .
+
+nc:RemedialActionImpact.AssessingSystemOperator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The impacted System Operator that assigns a remedial action impact." ;
+        rdfs:domain           nc:RemedialActionImpact ;
+        rdfs:label            "AssessingSystemOperator"@en ;
+        rdfs:range            nc:SystemOperator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SystemOperator.RemedialActionImpact ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionImpact.OwnerRemedialActionAssessment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The owner's assessment to the impacted system operator." ;
+        rdfs:domain           nc:RemedialActionImpact ;
+        rdfs:label            "OwnerRemedialActionAssessment"@en ;
+        rdfs:range            nc:OwnerRemedialActionAssessment ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:OwnerRemedialActionAssessment.RemedialActionImpact ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionImpact.RemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The remedial action that has an impact." ;
+        rdfs:domain           nc:RemedialActionImpact ;
+        rdfs:label            "RemedialAction"@en ;
+        rdfs:range            nc:RemedialAction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialAction.RemedialActionImpact ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionImpact.impactQuantity
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Delta, positive or negative, quantity that when it is applied to the remedial action,  it will cause impact on a conducting equipment monitored by the assessed system operator.\nExample of relevant remedial action changes are redispatching, countertrading, change of set point on HVDC systems or change of taps on phase-shifting transformers." ;
+        rdfs:domain        nc:RemedialActionImpact ;
+        rdfs:label         "impactQuantity"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionImpact.kind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The impact agreement kind." ;
+        rdfs:domain        nc:RemedialActionImpact ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         nc:ImpactAgreementKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionImpact.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:RemedialActionImpact ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionOutcomeValue
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Outcome of an impact assessment matrix for a remedial action." ;
+        rdfs:label              "RemedialActionOutcomeValue"@en ;
+        rdfs:subClassOf         nc:OutcomeValue ;
+        cims:belongsToCategory  iam:Package_ImpactAssessmentMatrixProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RemedialActionOutcomeValue.RemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The remedial action that has a remedial action outcome value." ;
+        rdfs:domain           nc:RemedialActionOutcomeValue ;
+        rdfs:label            "RemedialAction"@en ;
+        rdfs:range            nc:RemedialAction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialAction.RemedialActionOutcomeValue ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionOutcomeValue.impactQuantity
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Delta, positive or negative, quantity that when it is applied to the remedial action,  it will cause impact on a conducting equipment monitored by the assessed system operator.\nExample of relevant remedial action changes are redispatching, countertrading, change of set point on HVDC systems or change of taps on phase-shifting transformers." ;
+        rdfs:domain        nc:RemedialActionOutcomeValue ;
+        rdfs:label         "impactQuantity"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A schedule for a determined remedial action." ;
+        rdfs:label              "RemedialActionSchedule"@en ;
+        cims:belongsToCategory  iam:Package_ImpactAssessmentMatrixProfile ;
+        cims:stereotype         "NC" .
+
+nc:RemedialActionSchedule.RemedialActionScheduleOutcomeValue
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The remedial action schedule outcome value associated with a remedial action schedule." ;
+        rdfs:domain           nc:RemedialActionSchedule ;
+        rdfs:label            "RemedialActionScheduleOutcomeValue"@en ;
+        rdfs:range            nc:RemedialActionScheduleOutcomeValue ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialActionScheduleOutcomeValue.RemedialActionSchedule ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionScheduleOutcomeValue
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Outcome of an impact assessment matrix for a remedial action schedule." ;
+        rdfs:label              "RemedialActionScheduleOutcomeValue"@en ;
+        rdfs:subClassOf         nc:OutcomeValue ;
+        cims:belongsToCategory  iam:Package_ImpactAssessmentMatrixProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RemedialActionScheduleOutcomeValue.RemedialActionSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The remedial action schedule that has a remedial action schedule outcome value." ;
+        rdfs:domain           nc:RemedialActionScheduleOutcomeValue ;
+        rdfs:label            "RemedialActionSchedule"@en ;
+        rdfs:range            nc:RemedialActionSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialActionSchedule.RemedialActionScheduleOutcomeValue ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:SensitivityArea  rdf:type    rdfs:Class ;
+        rdfs:comment            "A monitoring area that defines the required observability area given by the sensitivity factors." ;
+        rdfs:label              "SensitivityArea"@en ;
+        cims:belongsToCategory  iam:Package_ImpactAssessmentMatrixProfile ;
+        cims:stereotype         "NC" .
+
+nc:SensitivityArea.QuantitativeRemedialActionImpact
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Quantitative remedial action impact when the remedial action is influencing equipment included in the sensitivity area." ;
+        rdfs:domain           nc:SensitivityArea ;
+        rdfs:label            "QuantitativeRemedialActionImpact"@en ;
+        rdfs:range            nc:QuantitativeRemedialActionImpact ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:QuantitativeRemedialActionImpact.SensitivityArea ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SystemOperator  rdf:type     rdfs:Class ;
+        rdfs:comment            "System operator." ;
+        rdfs:label              "SystemOperator"@en ;
+        cims:belongsToCategory  iam:Package_ImpactAssessmentMatrixProfile ;
+        cims:stereotype         "NC" .
+
+nc:SystemOperator.OutcomeValue
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Impact assessment outcome value for this impacted system operator." ;
+        rdfs:domain           nc:SystemOperator ;
+        rdfs:label            "OutcomeValue"@en ;
+        rdfs:range            nc:OutcomeValue ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:OutcomeValue.ImpactedSystemOperator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SystemOperator.OwnerRemedialActionAssessment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Owner's assessment of the remedial action." ;
+        rdfs:domain           nc:SystemOperator ;
+        rdfs:label            "OwnerRemedialActionAssessment"@en ;
+        rdfs:range            nc:OwnerRemedialActionAssessment ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:OwnerRemedialActionAssessment.ImpactedSystemOperator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SystemOperator.RemedialActionImpact
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The remedial action impact for a given assessing System Operator." ;
+        rdfs:domain           nc:SystemOperator ;
+        rdfs:label            "RemedialActionImpact"@en ;
+        rdfs:range            nc:RemedialActionImpact ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialActionImpact.AssessingSystemOperator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+profcim:IRI  rdf:type           rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as rdf:resource in RDFXML.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "IRI"@en ;
+        cims:belongsToCategory  iam:Package_DocImpactAssessmentMatrixProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringFixedLanguage
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited.\nThe primitive is serialized as literal without language support." ;
+        rdfs:label              "StringFixedLanguage"@en ;
+        cims:belongsToCategory  iam:Package_DocImpactAssessmentMatrixProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringIRI  rdf:type     rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as literal without language support.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "StringIRI"@en ;
+        cims:belongsToCategory  iam:Package_DocImpactAssessmentMatrixProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:URL  rdf:type           rdfs:Class ;
+        rdfs:comment            "A Uniform Resource Locator (URL), colloquially termed a web address, is a reference to a web resource that specifies its location on a computer network and a mechanism for retrieving it. A URL is a specific type of Uniform Resource Identifier (URI), although many people use the two terms interchangeably.URLs occur most commonly to reference web pages (http), but are also used for file transfer (ftp), email (mailto), database access (JDBC), and many other applications." ;
+        rdfs:label              "URL"@en ;
+        cims:belongsToCategory  iam:Package_DocImpactAssessmentMatrixProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+

--- a/r2.3/ap-voc/ttl/MonitoringArea-AP-Voc-RDFS2020.ttl
+++ b/r2.3/ap-voc/ttl/MonitoringArea-AP-Voc-RDFS2020.ttl
@@ -1,0 +1,397 @@
+@prefix cim:     <https://cim.ucaiug.io/ns#> .
+@prefix cims:    <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/#> .
+@prefix ma:      <https://ap.cim4.eu/MonitoringArea#> .
+@prefix nc:      <https://cim4.eu/ns/nc#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix profcim: <https://cim.ucaiug.io/ns/prof-cim#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+
+cim:Date  rdf:type              rdfs:Class ;
+        rdfs:comment            "Date as \"yyyy-mm-dd\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddZ\". A local timezone relative UTC is specified as \"yyyy-mm-dd(+/-)hh:mm\"." ;
+        rdfs:label              "Date"@en ;
+        cims:belongsToCategory  ma:Package_DocMonitoringAreaProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:DateTime  rdf:type          rdfs:Class ;
+        rdfs:comment            "Date and time as \"yyyy-mm-ddThh:mm:ss.sss\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddThh:mm:ss.sssZ\". A local timezone relative UTC is specified as \"yyyy-mm-ddThh:mm:ss.sss-hh:mm\". The second component (shown here as \"ss.sss\") could have any number of digits in its fractional part to allow any kind of precision beyond seconds." ;
+        rdfs:label              "DateTime"@en ;
+        cims:belongsToCategory  ma:Package_DocMonitoringAreaProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Float  rdf:type             rdfs:Class ;
+        rdfs:comment            "A floating point number. The range is unspecified and not limited." ;
+        rdfs:label              "Float"@en ;
+        cims:belongsToCategory  ma:Package_MonitoringAreaProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:IdentifiedObject  rdf:type  rdfs:Class ;
+        rdfs:comment            "This is a root class to provide common identification for all classes needing identification and naming attributes." ;
+        rdfs:label              "IdentifiedObject"@en ;
+        cims:belongsToCategory  ma:Package_MonitoringAreaProfile .
+
+cim:IdentifiedObject.description
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The description is a free human readable text describing or naming the object. It may be non unique and may not correlate to a naming hierarchy." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "description"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.name
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The name is any free human readable and possibly non unique text naming the object." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "name"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent  rdf:type           rdfs:Class ;
+        rdfs:comment            "Percentage on a defined base.   For example, specify as 100 to indicate at the defined base." ;
+        rdfs:label              "PerCent"@en ;
+        cims:belongsToCategory  ma:Package_MonitoringAreaProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:PerCent.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent.value  rdf:type  rdf:Property ;
+        rdfs:comment       "Normally 0 to 100 on a defined base." ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PowerSystemResource
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A power system resource (PSR) can be an item of equipment such as a switch, an equipment container containing many individual items of equipment such as a substation, or an organisational entity such as sub-control area. Power system resources can have measurements associated." ;
+        rdfs:label              "PowerSystemResource"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ma:Package_MonitoringAreaProfile .
+
+cim:String  rdf:type            rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited." ;
+        rdfs:label              "String"@en ;
+        cims:belongsToCategory  ma:Package_MonitoringAreaProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Terminal  rdf:type          rdfs:Class ;
+        rdfs:comment            "An AC electrical connection point to a piece of conducting equipment. Terminals are connected at physical connection points called connectivity nodes." ;
+        rdfs:label              "Terminal"@en ;
+        cims:belongsToCategory  ma:Package_MonitoringAreaProfile .
+
+cim:UnitMultiplier  rdf:type    rdfs:Class ;
+        rdfs:comment            "The unit multipliers defined for the CIM.  When applied to unit symbols, the unit symbol is treated as a derived unit. Regardless of the contents of the unit symbol text, the unit symbol shall be treated as if it were a single-character unit symbol. Unit symbols should not contain multipliers, and it should be left to the multiplier to define the multiple for an entire data type. \n\nFor example, if a unit symbol is \"m2Pers\" and the multiplier is \"k\", then the value is k(m**2/s), and the multiplier applies to the entire final value, not to any individual part of the value. This can be conceptualized by substituting a derived unit symbol for the unit type. If one imagines that the symbol \"Þ\" represents the derived unit \"m2Pers\", then applying the multiplier \"k\" can be conceptualized simply as \"kÞ\".\n\nFor example, the SI unit for mass is \"kg\" and not \"g\".  If the unit symbol is defined as \"kg\", then the multiplier is applied to \"kg\" as a whole and does not replace the \"k\" in front of the \"g\". In this case, the multiplier of \"m\" would be used with the unit symbol of \"kg\" to represent one gram.  As a text string, this violates the instructions in IEC 80000-1. However, because the unit symbol in CIM is treated as a derived unit instead of as an SI unit, it makes more sense to conceptualize the \"kg\" as if it were replaced by one of the proposed replacements for the SI mass symbol. If one imagines that the \"kg\" were replaced by a symbol \"Þ\", then it is easier to conceptualize the multiplier \"m\" as creating the proper unit \"mÞ\", and not the forbidden unit \"mkg\"." ;
+        rdfs:label              "UnitMultiplier"@en ;
+        cims:belongsToCategory  ma:Package_MonitoringAreaProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitMultiplier.none
+        rdf:type         cim:UnitMultiplier ;
+        rdfs:comment     "No multiplier or equivalently multiply by 1." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol  rdf:type        rdfs:Class ;
+        rdfs:comment            "The derived units defined for usage in the CIM. In some cases, the derived unit is equal to an SI unit. Whenever possible, the standard derived symbol is used instead of the formula for the derived unit. For example, the unit symbol Farad is defined as \"F\" instead of \"CPerV\". In cases where a standard symbol does not exist for a derived unit, the formula for the unit is used as the unit symbol. For example, density does not have a standard symbol and so it is represented as \"kgPerm3\". With the exception of the \"kg\", which is an SI unit, the unit symbols do not contain multipliers and therefore represent the base derived unit to which a multiplier can be applied as a whole. \nEvery unit symbol is treated as an unparseable text as if it were a single-letter symbol. The meaning of each unit symbol is defined by the accompanying descriptive text and not by the text contents of the unit symbol.\nTo allow the widest possible range of serializations without requiring special character handling, several substitutions are made which deviate from the format described in IEC 80000-1. The division symbol \"/\" is replaced by the letters \"Per\". Exponents are written in plain text after the unit as \"m3\" instead of being formatted as \"m\" with a superscript of 3  or introducing a symbol as in \"m^3\". The degree symbol \"°\" is replaced with the letters \"deg\". Any clarification of the meaning for a substitution is included in the description for the unit symbol.\nNon-SI units are included in list of unit symbols to allow sources of data to be correctly labelled with their non-SI units (for example, a GPS sensor that is reporting numbers that represent feet instead of meters). This allows software to use the unit symbol information correctly convert and scale the raw data of those sources into SI-based units. \nThe integer values are used for harmonization with IEC 61850." ;
+        rdfs:label              "UnitSymbol"@en ;
+        cims:belongsToCategory  ma:Package_MonitoringAreaProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitSymbol.none  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Dimension less quantity, e.g. count, per unit, etc." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+ma:Ontology  rdf:type         owl:Ontology ;
+        dcterms:conformsTo    "urn:iso:std:iec:61970-501:draft:ed-2" , "urn:iso:std:iec:61970-301:ed-7:amd1" , "file://iec61970cim17v40_iec61968cim13v13a_iec62325cim03v17a.eap" , "urn:iso:std:iec:61970-401:draft:ed-1" , "file://CIM100_CGMES31v01_501-20v02_NC23v62_MM10v01.eap" , "urn:iso:std:iec:61970-600-2:ed-1" ;
+        dcterms:creator       "ENTSO-E CIM WG NC project"@en ;
+        dcterms:description   "This vocabulary is describing the monitoring area profile."@en ;
+        dcterms:identifier    "urn:uuid:41075091-91f0-4b14-a5b8-93945aa528ed" ;
+        dcterms:language      "en-GB" ;
+        dcterms:license       "https://www.apache.org/licenses/LICENSE-2.0"@en ;
+        dcterms:modified      "2024-03-20"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        dcterms:publisher     "ENTSO-E"@en ;
+        dcterms:rightsHolder  "ENTSO-E"@en ;
+        dcterms:title         "Monitoring area Vocabulary"@en ;
+        owl:versionIRI        <https://ap.cim4.eu/MonitoringArea/2.3> ;
+        owl:versionInfo       "2.3.0"@en ;
+        dcat:keyword          "MA" ;
+        dcat:theme            "vocabulary"@en .
+
+ma:Package_DocMonitoringAreaProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains datatypes used only in the RDFS header." ;
+        rdfs:label    "DocMonitoringAreaProfile"@en .
+
+ma:Package_MonitoringAreaProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains monitoring area profile." ;
+        rdfs:label    "MonitoringAreaProfile"@en .
+
+nc:AreaBorderTerminal
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Area border terminal defines the terminals that are defining a monitoring area." ;
+        rdfs:label              "AreaBorderTerminal"@en ;
+        cims:belongsToCategory  ma:Package_MonitoringAreaProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AreaBorderTerminal.MonitoringArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The MonitoringArea defined by this AreaBorderTerminal." ;
+        rdfs:domain           nc:AreaBorderTerminal ;
+        rdfs:label            "MonitoringArea"@en ;
+        rdfs:range            nc:MonitoringArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:MonitoringArea.AreaBorderTerminal ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:AreaBorderTerminal.Terminal
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The Terminal that is part of an AreaBorderTerminal." ;
+        rdfs:domain           nc:AreaBorderTerminal ;
+        rdfs:label            "Terminal"@en ;
+        rdfs:range            cim:Terminal ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Terminal.AreaBorderTerminal ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:AreaBorderTerminal.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:AreaBorderTerminal ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ContingencyArea  rdf:type    rdfs:Class ;
+        rdfs:comment            "A monitoring area that defines the required contingency elements. This includes elements that are part of the external contingency list." ;
+        rdfs:label              "ContingencyArea"@en ;
+        rdfs:subClassOf         nc:InfluenceArea ;
+        cims:belongsToCategory  ma:Package_MonitoringAreaProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:InfluenceArea  rdf:type      rdfs:Class ;
+        rdfs:comment            "Influence area is a monitoring area that is defined by calculating the equipment that is affected by the influence factors." ;
+        rdfs:label              "InfluenceArea"@en ;
+        rdfs:subClassOf         nc:MonitoringArea ;
+        cims:belongsToCategory  ma:Package_MonitoringAreaProfile ;
+        cims:stereotype         "NC" .
+
+nc:InfluenceArea.filteringInfluenceFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Power flow filtering influence factor of a network element not normalised.  This is referred as power flow influence threshold in CSA methodology.\n\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:InfluenceArea ;
+        rdfs:label         "filteringInfluenceFactor"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:InfluenceArea.identificationInfluenceFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Power flow identification influence factor of a network element that is normalised in order to take into account potential impacts induced by differences in Permanently Admissible Transmission Loading (PATL) values. This is referred as identification influence threshold in CSA methodology.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:InfluenceArea ;
+        rdfs:label         "identificationInfluenceFactor"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:InfluenceArea.voltageInfluenceFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Voltage influence factor of a network element as defined in the CSA methodology.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:InfluenceArea ;
+        rdfs:label         "voltageInfluenceFactor"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+nc:MonitoringArea  rdf:type     rdfs:Class ;
+        rdfs:comment            "A coherent part of the interconnected electrical power system, that includes the system operators' responsibility area and the surrounding parts of other system operators' responsibility area, that need to be monitored for security assessment." ;
+        rdfs:label              "MonitoringArea"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  ma:Package_MonitoringAreaProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:MonitoringArea.AreaBorderTerminal
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The AreaBorderTerminal which defines the MonitoringArea." ;
+        rdfs:domain           nc:MonitoringArea ;
+        rdfs:label            "AreaBorderTerminal"@en ;
+        rdfs:range            nc:AreaBorderTerminal ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AreaBorderTerminal.MonitoringArea ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:MonitoringArea.Region
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Region that has monitoring areas." ;
+        rdfs:domain           nc:MonitoringArea ;
+        rdfs:label            "Region"@en ;
+        rdfs:range            nc:Region ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Region.MonitoringArea ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:MonitoringArea.SynchronousArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The synchronous area that has this monitoring area." ;
+        rdfs:domain           nc:MonitoringArea ;
+        rdfs:label            "SynchronousArea"@en ;
+        rdfs:range            nc:SynchronousArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SynchronousArea.MonitoringArea ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:MonitoringArea.SystemOperator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The system operator that operates this monitoring area." ;
+        rdfs:domain           nc:MonitoringArea ;
+        rdfs:label            "SystemOperator"@en ;
+        rdfs:range            nc:SystemOperator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SystemOperator.MonitoringArea ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ObservabilityArea  rdf:type  rdfs:Class ;
+        rdfs:comment            "A monitoring area that is given by a real time measurement." ;
+        rdfs:label              "ObservabilityArea"@en ;
+        rdfs:subClassOf         nc:MonitoringArea ;
+        cims:belongsToCategory  ma:Package_MonitoringAreaProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:Region  rdf:type             rdfs:Class ;
+        rdfs:comment            "A region where the system operator belongs to." ;
+        rdfs:label              "Region"@en ;
+        cims:belongsToCategory  ma:Package_MonitoringAreaProfile ;
+        cims:stereotype         "NC" .
+
+nc:Region.MonitoringArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Monitoring area which belongs to a region." ;
+        rdfs:domain           nc:Region ;
+        rdfs:label            "MonitoringArea"@en ;
+        rdfs:range            nc:MonitoringArea ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:MonitoringArea.Region ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SensitivityArea  rdf:type    rdfs:Class ;
+        rdfs:comment            "A monitoring area that defines the required observability area given by the sensitivity factors." ;
+        rdfs:label              "SensitivityArea"@en ;
+        rdfs:subClassOf         nc:InfluenceArea ;
+        cims:belongsToCategory  ma:Package_MonitoringAreaProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SynchronousArea  rdf:type    rdfs:Class ;
+        rdfs:comment            "A synchronous area is an electrical area covered by interconnect with a common system frequency in a steady-state. " ;
+        rdfs:label              "SynchronousArea"@en ;
+        cims:belongsToCategory  ma:Package_MonitoringAreaProfile ;
+        cims:stereotype         "NC" .
+
+nc:SynchronousArea.MonitoringArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The monitoring area that is part of this synchronous area." ;
+        rdfs:domain           nc:SynchronousArea ;
+        rdfs:label            "MonitoringArea"@en ;
+        rdfs:range            nc:MonitoringArea ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:MonitoringArea.SynchronousArea ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SystemOperator  rdf:type     rdfs:Class ;
+        rdfs:comment            "System operator." ;
+        rdfs:label              "SystemOperator"@en ;
+        cims:belongsToCategory  ma:Package_MonitoringAreaProfile ;
+        cims:stereotype         "NC" .
+
+nc:SystemOperator.MonitoringArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The monitoring area that is operated by this system operator." ;
+        rdfs:domain           nc:SystemOperator ;
+        rdfs:label            "MonitoringArea"@en ;
+        rdfs:range            nc:MonitoringArea ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:MonitoringArea.SystemOperator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Terminal.AreaBorderTerminal
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The AreaBorderTerminal that has this Terminal." ;
+        rdfs:domain           cim:Terminal ;
+        rdfs:label            "AreaBorderTerminal"@en ;
+        rdfs:range            nc:AreaBorderTerminal ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AreaBorderTerminal.Terminal ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+profcim:IRI  rdf:type           rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as rdf:resource in RDFXML.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "IRI"@en ;
+        cims:belongsToCategory  ma:Package_DocMonitoringAreaProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringFixedLanguage
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited.\nThe primitive is serialized as literal without language support." ;
+        rdfs:label              "StringFixedLanguage"@en ;
+        cims:belongsToCategory  ma:Package_DocMonitoringAreaProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringIRI  rdf:type     rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as literal without language support.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "StringIRI"@en ;
+        cims:belongsToCategory  ma:Package_DocMonitoringAreaProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:URL  rdf:type           rdfs:Class ;
+        rdfs:comment            "A Uniform Resource Locator (URL), colloquially termed a web address, is a reference to a web resource that specifies its location on a computer network and a mechanism for retrieving it. A URL is a specific type of Uniform Resource Identifier (URI), although many people use the two terms interchangeably.URLs occur most commonly to reference web pages (http), but are also used for file transfer (ftp), email (mailto), database access (JDBC), and many other applications." ;
+        rdfs:label              "URL"@en ;
+        cims:belongsToCategory  ma:Package_DocMonitoringAreaProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+

--- a/r2.3/ap-voc/ttl/ObjectRegistry-AP-Voc-RDFS2020.ttl
+++ b/r2.3/ap-voc/ttl/ObjectRegistry-AP-Voc-RDFS2020.ttl
@@ -1,0 +1,392 @@
+@prefix cim:     <https://cim.ucaiug.io/ns#> .
+@prefix cims:    <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/#> .
+@prefix eu:      <https://cim.ucaiug.io/ns/eu#> .
+@prefix nc:      <https://cim4.eu/ns/nc#> .
+@prefix or:      <https://ap.cim4.eu/ObjectRegistry#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://iec.ch/TC57/ns/CIM/prof-cim#IRI>
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as rdf:resource in RDFXML.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "IRI"@en ;
+        cims:belongsToCategory  or:Package_DocObjectRegistryProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+<http://iec.ch/TC57/ns/CIM/prof-cim#StringFixedLanguage>
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited.\nThe primitive is serialized as literal without language support." ;
+        rdfs:label              "StringFixedLanguage"@en ;
+        cims:belongsToCategory  or:Package_DocObjectRegistryProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+<http://iec.ch/TC57/ns/CIM/prof-cim#StringIRI>
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as literal without language support.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "StringIRI"@en ;
+        cims:belongsToCategory  or:Package_DocObjectRegistryProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+<http://iec.ch/TC57/ns/CIM/prof-cim#URL>
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A Uniform Resource Locator (URL), colloquially termed a web address, is a reference to a web resource that specifies its location on a computer network and a mechanism for retrieving it. A URL is a specific type of Uniform Resource Identifier (URI), although many people use the two terms interchangeably.URLs occur most commonly to reference web pages (http), but are also used for file transfer (ftp), email (mailto), database access (JDBC), and many other applications." ;
+        rdfs:label              "URL"@en ;
+        cims:belongsToCategory  or:Package_DocObjectRegistryProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+cim:Date  rdf:type              rdfs:Class ;
+        rdfs:comment            "Date as \"yyyy-mm-dd\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddZ\". A local timezone relative UTC is specified as \"yyyy-mm-dd(+/-)hh:mm\"." ;
+        rdfs:label              "Date"@en ;
+        cims:belongsToCategory  or:Package_DocObjectRegistryProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:DateTime  rdf:type          rdfs:Class ;
+        rdfs:comment            "Date and time as \"yyyy-mm-ddThh:mm:ss.sss\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddThh:mm:ss.sssZ\". A local timezone relative UTC is specified as \"yyyy-mm-ddThh:mm:ss.sss-hh:mm\". The second component (shown here as \"ss.sss\") could have any number of digits in its fractional part to allow any kind of precision beyond seconds." ;
+        rdfs:label              "DateTime"@en ;
+        cims:belongsToCategory  or:Package_DocObjectRegistryProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:IdentifiedObject  rdf:type  rdfs:Class ;
+        rdfs:comment            "This is a root class to provide common identification for all classes needing identification and naming attributes." ;
+        rdfs:label              "IdentifiedObject"@en ;
+        cims:belongsToCategory  or:Package_ObjectRegistryProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:IdentifiedObject.aliasName
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The aliasName is free text human readable name of the object alternative to IdentifiedObject.name. It may be non unique and may not correlate to a naming hierarchy.\nThe attribute aliasName is retained because of backwards compatibility between CIM relases. It is however recommended to replace aliasName with the Name class as aliasName is planned for retirement at a future time." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "aliasName"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.description
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The description is a free human readable text describing or naming the object. It may be non unique and may not correlate to a naming hierarchy." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "description"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.name
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The name is any free human readable and possibly non unique text naming the object." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "name"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Name  rdf:type              rdfs:Class ;
+        rdfs:comment            "The Name class provides the means to define any number of human readable  names for an object. A name is <b>not</b> to be used for defining inter-object relationships. For inter-object relationships instead use the object identification 'mRID'." ;
+        rdfs:label              "Name"@en ;
+        cims:belongsToCategory  or:Package_ObjectRegistryProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:Name.name  rdf:type    rdf:Property ;
+        rdfs:comment       "Any free text that used as a name or alternative identifier of the object." ;
+        rdfs:domain        cim:Name ;
+        rdfs:label         "name"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:NameType  rdf:type          rdfs:Class ;
+        rdfs:comment            "Type of name. Possible values for attribute 'name' are implementation dependent but standard profiles may specify types. An enterprise may have multiple IT systems each having its own local name for the same object, e.g. a planning system may have different names from an EMS. An object may also have different names within the same IT system, e.g. localName as defined in CIM version 14. The definition from CIM14 is:\nThe localName is a human readable name of the object. It is a free text name local to a node in a naming hierarchy similar to a file directory structure. A power system related naming hierarchy may be: Substation, VoltageLevel, Equipment etc. Children of the same parent in such a hierarchy have names that typically are unique among them." ;
+        rdfs:label              "NameType"@en ;
+        cims:belongsToCategory  or:Package_ObjectRegistryProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:NameType.description
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Description of the name type." ;
+        rdfs:domain        cim:NameType ;
+        rdfs:label         "description"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:NameType.name  rdf:type  rdf:Property ;
+        rdfs:comment       "Name of the name type." ;
+        rdfs:domain        cim:NameType ;
+        rdfs:label         "name"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:String  rdf:type            rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited." ;
+        rdfs:label              "String"@en ;
+        cims:belongsToCategory  or:Package_ObjectRegistryProfile ;
+        cims:stereotype         "Primitive" .
+
+eu:IdentifiedObject.energyIdentCodeEic
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The attribute is used for an exchange of the EIC code (Energy identification Code). The length of the string is 16 characters as defined by the EIC code. For details on EIC scheme please refer to ENTSO-E web site." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "energyIdentCodeEic"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "deprecated" , "European" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+eu:IdentifiedObject.shortName
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The attribute is used for an exchange of a human readable short name with length of the string 12 characters maximum." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "shortName"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "deprecated" , "European" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:IdentifiedObject.AlternativeIdentifier
+        rdf:type              rdf:Property ;
+        rdfs:comment          "All alternative identifiers of this identified object. No two identified objects can have the same alternative identifier." ;
+        rdfs:domain           cim:IdentifiedObject ;
+        rdfs:label            "AlternativeIdentifier"@en ;
+        rdfs:range            cim:Name ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:Name.UniqueIdentifiedObject ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+nc:IdentifiedObject.Name
+        rdf:type              rdf:Property ;
+        rdfs:comment          "All names of this identified object. Names may be but are not guaranteed to be unique." ;
+        rdfs:domain           cim:IdentifiedObject ;
+        rdfs:label            "Name"@en ;
+        rdfs:range            cim:Name ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:Name.IdentifiedObject ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:IdentifiedObject.ObjectType
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The object type of the IdentifiedObject." ;
+        rdfs:domain           cim:IdentifiedObject ;
+        rdfs:label            "ObjectType"@en ;
+        rdfs:range            nc:ObjectType ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ObjectType.IdentifiedObject ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:Name.IdentifiedObject
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Identified object that this name designates." ;
+        rdfs:domain           cim:Name ;
+        rdfs:label            "IdentifiedObject"@en ;
+        rdfs:range            cim:IdentifiedObject ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:IdentifiedObject.Name ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:Name.NameType  rdf:type    rdf:Property ;
+        rdfs:comment          "Type of this name." ;
+        rdfs:domain           cim:Name ;
+        rdfs:label            "NameType"@en ;
+        rdfs:range            cim:NameType ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:NameType.Name ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:Name.NamingAuthority
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Authority responsible for managing this name." ;
+        rdfs:domain           cim:Name ;
+        rdfs:label            "NamingAuthority"@en ;
+        rdfs:range            nc:NamingAuthority ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:NamingAuthority.Name ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:Name.UniqueIdentifiedObject
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Identified object that this alternative identifier designates." ;
+        rdfs:domain           cim:Name ;
+        rdfs:label            "UniqueIdentifiedObject"@en ;
+        rdfs:range            cim:IdentifiedObject ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:IdentifiedObject.AlternativeIdentifier ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:Name.language  rdf:type  rdf:Property ;
+        rdfs:comment       "Shall be specified as an IETF BCP 47 language tag (e.g. en-US).  Applies to the Name.name attribute. \nIETF language tags combine subtags from other standards such as ISO 639, ISO 15924, ISO 3166-1, and UN M.49. The tag structure has been standardized by the IETF in Best Current Practice (BCP) 47; the subtags are maintained by the IANA Language Subtag Registry." ;
+        rdfs:domain        cim:Name ;
+        rdfs:label         "language"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Name.mRID  rdf:type     rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        cim:Name ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:NameType.Name  rdf:type    rdf:Property ;
+        rdfs:comment          "All names of this type." ;
+        rdfs:domain           cim:NameType ;
+        rdfs:label            "Name"@en ;
+        rdfs:range            cim:Name ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:Name.NameType ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:NameType.NamingAuthority
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Authority responsible for managing this name type." ;
+        rdfs:domain           cim:NameType ;
+        rdfs:label            "NamingAuthority"@en ;
+        rdfs:range            nc:NamingAuthority ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:NamingAuthority.NameType ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:NameType.mRID  rdf:type  rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        cim:NameType ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:NamingAuthority  rdf:type    rdfs:Class ;
+        rdfs:comment            "Authority responsible for creation and management of names of a given name type and/or name; typically an organization or an enterprise system." ;
+        rdfs:label              "NamingAuthority"@en ;
+        cims:belongsToCategory  or:Package_ObjectRegistryProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:NamingAuthority.Name
+        rdf:type              rdf:Property ;
+        rdfs:comment          "All names managed by this authority." ;
+        rdfs:domain           nc:NamingAuthority ;
+        rdfs:label            "Name"@en ;
+        rdfs:range            cim:Name ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:Name.NamingAuthority ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:NamingAuthority.NameType
+        rdf:type              rdf:Property ;
+        rdfs:comment          "All name types managed by this authority." ;
+        rdfs:domain           nc:NamingAuthority ;
+        rdfs:label            "NameType"@en ;
+        rdfs:range            cim:NameType ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:NameType.NamingAuthority ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:NamingAuthority.description
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Description of the name authority." ;
+        rdfs:domain        nc:NamingAuthority ;
+        rdfs:label         "description"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:NamingAuthority.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:NamingAuthority ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:NamingAuthority.name
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Name of the name authority." ;
+        rdfs:domain        nc:NamingAuthority ;
+        rdfs:label         "name"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ObjectType  rdf:type         rdfs:Class ;
+        rdfs:comment            "Identifies the specialised type of an object when the instance object is serialised using a generalised class. It may be useful when the object type is not otherwise included in the exchange. For example, a Meter may be serialised as an EndDevice in message exchanges and need to have the ObjectType.type be specified as 'Meter' to provide context to the message receiver." ;
+        rdfs:label              "ObjectType"@en ;
+        cims:belongsToCategory  or:Package_ObjectRegistryProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ObjectType.IdentifiedObject
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The IdentifiedObject whose type is identified by ObjectType." ;
+        rdfs:domain           nc:ObjectType ;
+        rdfs:label            "IdentifiedObject"@en ;
+        rdfs:range            cim:IdentifiedObject ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:IdentifiedObject.ObjectType ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ObjectType.type  rdf:type  rdf:Property ;
+        rdfs:comment       "The specialised type of an object when the instance object is serialised using a generalised class. For example, a Meter being serialised as an EndDevice in a message exchange should have the type attribute specified as 'Meter'." ;
+        rdfs:domain        nc:ObjectType ;
+        rdfs:label         "type"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+or:Ontology  rdf:type         owl:Ontology ;
+        dcterms:conformsTo    "urn:iso:std:iec:61970-501:draft:ed-2" , "file://CIM100_CGMES31v01_501-20v02_NC23v62_MM10v01.eap" , "urn:iso:std:iec:61970-401:draft:ed-1" , "file://iec61970cim17v40_iec61968cim13v13a_iec62325cim03v17a.eap" , "urn:iso:std:iec:61970-301:ed-7:amd1" , "urn:iso:std:iec:61970-600-2:ed-1" ;
+        dcterms:creator       "ENTSO-E CIM WG NC project"@en ;
+        dcterms:description   "This vocabulary is describing the object registry profile."@en ;
+        dcterms:identifier    "urn:uuid:14166b65-abaa-4611-b466-34975c15c27d" ;
+        dcterms:language      "en-GB" ;
+        dcterms:license       "https://www.apache.org/licenses/LICENSE-2.0"@en ;
+        dcterms:modified      "2024-03-20"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        dcterms:publisher     "ENTSO-E"@en ;
+        dcterms:rightsHolder  "ENTSO-E"@en ;
+        dcterms:title         "Object Registry vocabulary"@en ;
+        owl:priorVersion      <http://entsoe.eu/ns/CIM/ObjectRegistry-EU/2.1> ;
+        owl:versionIRI        <https://ap.cim4.eu/ObjectRegistry/2.2> ;
+        owl:versionInfo       "2.2.0"@en ;
+        dcat:keyword          "OR" ;
+        dcat:theme            "vocabulary"@en .
+
+or:Package_DocObjectRegistryProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains datatypes used only in the RDFS header." ;
+        rdfs:label    "DocObjectRegistryProfile"@en .
+
+or:Package_ObjectRegistryProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains the equipment object registry profile." ;
+        rdfs:label    "ObjectRegistryProfile"@en .
+

--- a/r2.3/ap-voc/ttl/PowerSchedule-AP-Voc-RDFS2020.ttl
+++ b/r2.3/ap-voc/ttl/PowerSchedule-AP-Voc-RDFS2020.ttl
@@ -1,0 +1,1043 @@
+@prefix cim:     <https://cim.ucaiug.io/ns#> .
+@prefix cims:    <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/#> .
+@prefix nc:      <https://cim4.eu/ns/nc#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix profcim: <https://cim.ucaiug.io/ns/prof-cim#> .
+@prefix ps:      <https://ap.cim4.eu/PowerSchedule#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+
+cim:ActivePower  rdf:type       rdfs:Class ;
+        rdfs:comment            "Product of RMS value of the voltage and the RMS value of the in-phase component of the current." ;
+        rdfs:label              "ActivePower"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:ActivePower.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePower.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "W" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePower.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Boolean  rdf:type           rdfs:Class ;
+        rdfs:comment            "A type with the value space \"true\" and \"false\"." ;
+        rdfs:label              "Boolean"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Date  rdf:type              rdfs:Class ;
+        rdfs:comment            "Date as \"yyyy-mm-dd\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddZ\". A local timezone relative UTC is specified as \"yyyy-mm-dd(+/-)hh:mm\"." ;
+        rdfs:label              "Date"@en ;
+        cims:belongsToCategory  ps:Package_DocPowerScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:DateTime  rdf:type          rdfs:Class ;
+        rdfs:comment            "Date and time as \"yyyy-mm-ddThh:mm:ss.sss\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddThh:mm:ss.sssZ\". A local timezone relative UTC is specified as \"yyyy-mm-ddThh:mm:ss.sss-hh:mm\". The second component (shown here as \"ss.sss\") could have any number of digits in its fractional part to allow any kind of precision beyond seconds." ;
+        rdfs:label              "DateTime"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Decimal  rdf:type           rdfs:Class ;
+        rdfs:comment            "Decimal is the base-10 notational system for representing real numbers." ;
+        rdfs:label              "Decimal"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:EnergyConnection  rdf:type  rdfs:Class ;
+        rdfs:comment            "A connection of energy generation or consumption on the power system model." ;
+        rdfs:label              "EnergyConnection"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile .
+
+cim:EquivalentInjection
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "This class represents equivalent injections (generation or load).  Voltage regulation is allowed only at the point of connection." ;
+        rdfs:label              "EquivalentInjection"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile .
+
+cim:Float  rdf:type             rdfs:Class ;
+        rdfs:comment            "A floating point number. The range is unspecified and not limited." ;
+        rdfs:label              "Float"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:GeneratingUnit  rdf:type    rdfs:Class ;
+        rdfs:comment            "A single or set of synchronous machines for converting mechanical power into alternating-current power. For example, individual machines within a set may be defined for scheduling purposes while a single control signal is derived for the set. In this case there would be a GeneratingUnit for each member of the set and an additional GeneratingUnit corresponding to the set." ;
+        rdfs:label              "GeneratingUnit"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile .
+
+cim:HydroPump  rdf:type         rdfs:Class ;
+        rdfs:comment            "A synchronous motor-driven pump, typically associated with a pumped storage plant." ;
+        rdfs:label              "HydroPump"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile .
+
+cim:IdentifiedObject  rdf:type  rdfs:Class ;
+        rdfs:comment            "This is a root class to provide common identification for all classes needing identification and naming attributes." ;
+        rdfs:label              "IdentifiedObject"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile .
+
+cim:IdentifiedObject.description
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The description is a free human readable text describing or naming the object. It may be non unique and may not correlate to a naming hierarchy." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "description"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.name
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The name is any free human readable and possibly non unique text naming the object." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "name"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Integer  rdf:type           rdfs:Class ;
+        rdfs:comment            "An integer number. The range is unspecified and not limited." ;
+        rdfs:label              "Integer"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:PowerElectronicsUnit
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A generating unit or battery or aggregation that connects to the AC network using power electronics rather than rotating machines." ;
+        rdfs:label              "PowerElectronicsUnit"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile .
+
+cim:ReactivePower  rdf:type     rdfs:Class ;
+        rdfs:comment            "Product of RMS value of the voltage and the RMS value of the quadrature component of the current." ;
+        rdfs:label              "ReactivePower"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:ReactivePower.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ReactivePower ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ReactivePower.unit
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ReactivePower ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "VAr" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ReactivePower.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ReactivePower ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:String  rdf:type            rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited." ;
+        rdfs:label              "String"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:UnitMultiplier  rdf:type    rdfs:Class ;
+        rdfs:comment            "The unit multipliers defined for the CIM.  When applied to unit symbols, the unit symbol is treated as a derived unit. Regardless of the contents of the unit symbol text, the unit symbol shall be treated as if it were a single-character unit symbol. Unit symbols should not contain multipliers, and it should be left to the multiplier to define the multiple for an entire data type. \n\nFor example, if a unit symbol is \"m2Pers\" and the multiplier is \"k\", then the value is k(m**2/s), and the multiplier applies to the entire final value, not to any individual part of the value. This can be conceptualized by substituting a derived unit symbol for the unit type. If one imagines that the symbol \"Þ\" represents the derived unit \"m2Pers\", then applying the multiplier \"k\" can be conceptualized simply as \"kÞ\".\n\nFor example, the SI unit for mass is \"kg\" and not \"g\".  If the unit symbol is defined as \"kg\", then the multiplier is applied to \"kg\" as a whole and does not replace the \"k\" in front of the \"g\". In this case, the multiplier of \"m\" would be used with the unit symbol of \"kg\" to represent one gram.  As a text string, this violates the instructions in IEC 80000-1. However, because the unit symbol in CIM is treated as a derived unit instead of as an SI unit, it makes more sense to conceptualize the \"kg\" as if it were replaced by one of the proposed replacements for the SI mass symbol. If one imagines that the \"kg\" were replaced by a symbol \"Þ\", then it is easier to conceptualize the multiplier \"m\" as creating the proper unit \"mÞ\", and not the forbidden unit \"mkg\"." ;
+        rdfs:label              "UnitMultiplier"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitMultiplier.M  rdf:type  cim:UnitMultiplier ;
+        rdfs:comment     "Mega 10**6." ;
+        rdfs:label       "M"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol  rdf:type        rdfs:Class ;
+        rdfs:comment            "The derived units defined for usage in the CIM. In some cases, the derived unit is equal to an SI unit. Whenever possible, the standard derived symbol is used instead of the formula for the derived unit. For example, the unit symbol Farad is defined as \"F\" instead of \"CPerV\". In cases where a standard symbol does not exist for a derived unit, the formula for the unit is used as the unit symbol. For example, density does not have a standard symbol and so it is represented as \"kgPerm3\". With the exception of the \"kg\", which is an SI unit, the unit symbols do not contain multipliers and therefore represent the base derived unit to which a multiplier can be applied as a whole. \nEvery unit symbol is treated as an unparseable text as if it were a single-letter symbol. The meaning of each unit symbol is defined by the accompanying descriptive text and not by the text contents of the unit symbol.\nTo allow the widest possible range of serializations without requiring special character handling, several substitutions are made which deviate from the format described in IEC 80000-1. The division symbol \"/\" is replaced by the letters \"Per\". Exponents are written in plain text after the unit as \"m3\" instead of being formatted as \"m\" with a superscript of 3  or introducing a symbol as in \"m^3\". The degree symbol \"°\" is replaced with the letters \"deg\". Any clarification of the meaning for a substitution is included in the description for the unit symbol.\nNon-SI units are included in list of unit symbols to allow sources of data to be correctly labelled with their non-SI units (for example, a GPS sensor that is reporting numbers that represent feet instead of meters). This allows software to use the unit symbol information correctly convert and scale the raw data of those sources into SI-based units. \nThe integer values are used for harmonization with IEC 61850." ;
+        rdfs:label              "UnitSymbol"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitSymbol.VAr  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Reactive power in volt amperes reactive. The “reactive” or “imaginary” component of electrical power (VIsin(phi)). (See also real power and apparent power).\nNote: Different meter designs use different methods to arrive at their results. Some meters may compute reactive power as an arithmetic value, while others compute the value vectorially. The data consumer should determine the method in use and the suitability of the measurement for the intended purpose." ;
+        rdfs:label       "VAr"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.W  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Real power in watts (J/s). Electrical power may have real and reactive components. The real portion of electrical power (I&#178;R or VIcos(phi)), is expressed in Watts. See also apparent power and reactive power." ;
+        rdfs:label       "W"@en ;
+        cims:stereotype  "enum" .
+
+nc:AreaDispatchableUnit
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Allocates a given producing or consuming unit, including direct current corridor and collection of units, to a given control area (through the scheduling area) for supporting the control of the given area through dispatch instruction. " ;
+        rdfs:label              "AreaDispatchableUnit"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:AreaDispatchableUnit.PowerSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power schedule which has area dispatchable units." ;
+        rdfs:domain           nc:AreaDispatchableUnit ;
+        rdfs:label            "PowerSchedule"@en ;
+        rdfs:range            nc:PowerSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerSchedule.AreaDispatchableUnit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:BaseIrregularTimeSeries
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Time series that has irregular points in time." ;
+        rdfs:label              "BaseIrregularTimeSeries"@en ;
+        rdfs:subClassOf         nc:BaseTimeSeries ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:BaseTimeSeries  rdf:type     rdfs:Class ;
+        rdfs:comment            "Time series of values at points in time." ;
+        rdfs:label              "BaseTimeSeries"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:BaseTimeSeries.actionMethod
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Action method used to create the value. This is used for identification in the case where there is multiple time series for the same validity period and kind. " ;
+        rdfs:domain        nc:BaseTimeSeries ;
+        rdfs:label         "actionMethod"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseTimeSeries.generatedAtTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time this time series (entity) come to existents and available for use." ;
+        rdfs:domain        nc:BaseTimeSeries ;
+        rdfs:label         "generatedAtTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseTimeSeries.interpolationKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of interpolation done between time point." ;
+        rdfs:domain        nc:BaseTimeSeries ;
+        rdfs:label         "interpolationKind"@en ;
+        rdfs:range         nc:TimeSeriesInterpolationKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseTimeSeries.percentile
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The percentile is a number where a certain percentage of scores/ranking/values of a sample fall below that number. This is a way for expressing uncertainty in the number provided." ;
+        rdfs:domain        nc:BaseTimeSeries ;
+        rdfs:label         "percentile"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseTimeSeries.timeSeriesKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of base time series." ;
+        rdfs:domain        nc:BaseTimeSeries ;
+        rdfs:label         "timeSeriesKind"@en ;
+        rdfs:range         nc:BaseTimeSeriesKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseTimeSeriesKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of time series. " ;
+        rdfs:label              "BaseTimeSeriesKind"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:BaseTimeSeriesKind.actual
+        rdf:type         nc:BaseTimeSeriesKind ;
+        rdfs:comment     "Time series is actual data. The values represent measured or calculated values that represent the actual behaviour. " ;
+        rdfs:label       "actual"@en ;
+        cims:stereotype  "enum" .
+
+nc:BaseTimeSeriesKind.forecast
+        rdf:type         nc:BaseTimeSeriesKind ;
+        rdfs:comment     "Time series is forecast data. The values represent the result of scientific predictions based on historical time stamped data." ;
+        rdfs:label       "forecast"@en ;
+        cims:stereotype  "enum" .
+
+nc:BaseTimeSeriesKind.hindcast
+        rdf:type         nc:BaseTimeSeriesKind ;
+        rdfs:comment     "Time series is hindcast data. The value represent probable past (historic) condition given by calculation done using actual values. For instance, determine the among of wind based on the energy produced by wind. However, hindcast is typical the result of a simulated forecasts for historical periods." ;
+        rdfs:label       "hindcast"@en ;
+        cims:stereotype  "enum" .
+
+nc:BaseTimeSeriesKind.schedule
+        rdf:type         nc:BaseTimeSeriesKind ;
+        rdfs:comment     "Time series is schedule data. The values represent the result of a committed and plan forecast data that has been through a quality control and could incur penalty when not followed." ;
+        rdfs:label       "schedule"@en ;
+        cims:stereotype  "enum" .
+
+nc:BiddingZone  rdf:type        rdfs:Class ;
+        rdfs:comment            "A bidding zone is a market-based method for handling power transmission congestion. It consists of scheduling areas that include the relevant production (supply) and consumption (demand) to form an electrical area with the same market price without capacity allocation." ;
+        rdfs:label              "BiddingZone"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:BiddingZone.PowerSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power schedule which belongs to the power bidding zone." ;
+        rdfs:domain           nc:BiddingZone ;
+        rdfs:label            "PowerSchedule"@en ;
+        rdfs:range            nc:PowerSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerSchedule.BiddingZone ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:BiddingZoneBorder  rdf:type  rdfs:Class ;
+        rdfs:comment            "Defines the aggregated connection capacity between two Bidding Zones." ;
+        rdfs:label              "BiddingZoneBorder"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:BiddingZoneBorder.PowerSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power schedule which has bidding zone border." ;
+        rdfs:domain           nc:BiddingZoneBorder ;
+        rdfs:label            "PowerSchedule"@en ;
+        rdfs:range            nc:PowerSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerSchedule.BiddingZoneBorder ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:DCPole  rdf:type             rdfs:Class ;
+        rdfs:comment            "The direct current (DC) system pole (IEC 60633) is part of a DC system consisting of all the equipment in the DC substations and the interconnecting transmission lines, if any, which during normal operation exhibit a common direct voltage polarity with respect to earth." ;
+        rdfs:label              "DCPole"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:DCPole.PowerSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power schedule which has DC poles." ;
+        rdfs:domain           nc:DCPole ;
+        rdfs:label            "PowerSchedule"@en ;
+        rdfs:range            nc:PowerSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerSchedule.DCPole ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:DCTieCorridor  rdf:type      rdfs:Class ;
+        rdfs:comment            "A collection of one or more direct current poles that connect two different control areas." ;
+        rdfs:label              "DCTieCorridor"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:DCTieCorridor.MustRunSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Must run schedule which has DC tie corridors." ;
+        rdfs:domain           nc:DCTieCorridor ;
+        rdfs:label            "MustRunSchedule"@en ;
+        rdfs:range            nc:MustRunSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:MustRunSchedule.DCTieCorridor ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:DCTieCorridor.PowerSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power schedule which has DC tie corridors." ;
+        rdfs:domain           nc:DCTieCorridor ;
+        rdfs:label            "PowerSchedule"@en ;
+        rdfs:range            nc:PowerSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerSchedule.DCTieCorridor ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EnergyConnection.PowerSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The power schedule for this energy connection." ;
+        rdfs:domain           cim:EnergyConnection ;
+        rdfs:label            "PowerSchedule"@en ;
+        rdfs:range            nc:PowerSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerSchedule.EnergyConnection ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EnergyGroup  rdf:type        rdfs:Class ;
+        rdfs:comment            "An energy group is an aggregation of energy components which have the same energy characteristic, e.g. fuel type and technology. It can be used to allocate energy. " ;
+        rdfs:label              "EnergyGroup"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:EnergyGroup.PowerSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power schedule which is associated with an energy group." ;
+        rdfs:domain           nc:EnergyGroup ;
+        rdfs:label            "PowerSchedule"@en ;
+        rdfs:range            nc:PowerSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerSchedule.EnergyGroup ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EquivalentInjection.PowerSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power schedule which has equivalent injection." ;
+        rdfs:domain           cim:EquivalentInjection ;
+        rdfs:label            "PowerSchedule"@en ;
+        rdfs:range            nc:PowerSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerSchedule.EquivalentInjection ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:GeneratingUnit.MustRunSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Must run schedule which has generating units." ;
+        rdfs:domain           cim:GeneratingUnit ;
+        rdfs:label            "MustRunSchedule"@en ;
+        rdfs:range            nc:MustRunSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:MustRunSchedule.GeneratingUnit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:GeneratingUnit.PowerSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power schedule which has generating unit." ;
+        rdfs:domain           cim:GeneratingUnit ;
+        rdfs:label            "PowerSchedule"@en ;
+        rdfs:range            nc:PowerSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerSchedule.GeneratingUnit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:HydroPump.PowerSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power schedule which has hydro pump." ;
+        rdfs:domain           cim:HydroPump ;
+        rdfs:label            "PowerSchedule"@en ;
+        rdfs:range            nc:PowerSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerSchedule.HydroPump ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:MustRunSchedule  rdf:type    rdfs:Class ;
+        rdfs:comment            "Time series represent irregular must-run instruction values at given points in time. This could be instruction to a reliability must-run (RMR) generation facility that is necessary to run to meet certain operating conditions in order to maintain the security of power systems in a competitive environment." ;
+        rdfs:label              "MustRunSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:MustRunSchedule.DCTieCorridor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Hydro pump which belongs to the power schedule." ;
+        rdfs:domain           nc:MustRunSchedule ;
+        rdfs:label            "DCTieCorridor"@en ;
+        rdfs:range            nc:DCTieCorridor ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DCTieCorridor.MustRunSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:MustRunSchedule.GeneratingUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Generating unit which belongs to the must run schedule." ;
+        rdfs:domain           nc:MustRunSchedule ;
+        rdfs:label            "GeneratingUnit"@en ;
+        rdfs:range            cim:GeneratingUnit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GeneratingUnit.MustRunSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:MustRunSchedule.MustRunTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Value for the point in time." ;
+        rdfs:domain           nc:MustRunSchedule ;
+        rdfs:label            "MustRunTimePoint"@en ;
+        rdfs:range            nc:MustRunTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:MustRunTimePoint.MustRunSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:MustRunTimePoint  rdf:type   rdfs:Class ;
+        rdfs:comment            "Must-run instruction value at a given point in time." ;
+        rdfs:label              "MustRunTimePoint"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:MustRunTimePoint.MustRunSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Time series the time point values belongs to." ;
+        rdfs:domain           nc:MustRunTimePoint ;
+        rdfs:label            "MustRunSchedule"@en ;
+        rdfs:range            nc:MustRunSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:MustRunSchedule.MustRunTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:MustRunTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:MustRunTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:MustRunTimePoint.mustRun
+        rdf:type           rdf:Property ;
+        rdfs:comment       "True, if the must-run instruction is active this time point. Otherwise false." ;
+        rdfs:domain        nc:MustRunTimePoint ;
+        rdfs:label         "mustRun"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:MustRunTimePoint.mustRunP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Minimum active power injection that is needed to meet must-run requirement. This value can be higher or equal to minimum operational limit. Load sign convention is used, i.e. positive sign means flow out from a node." ;
+        rdfs:domain        nc:MustRunTimePoint ;
+        rdfs:label         "mustRunP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:MustRunTimePoint.mustRunQ
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Minimum reactive power injection that is needed to meet must-run requirement. This value can be higher or equal to minimum operational limit. Load sign convention is used, i.e. positive sign means flow out from a node." ;
+        rdfs:domain        nc:MustRunTimePoint ;
+        rdfs:label         "mustRunQ"@en ;
+        cims:dataType      cim:ReactivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerElectronicsUnit.PowerSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power schedule which has power electronics unit." ;
+        rdfs:domain           cim:PowerElectronicsUnit ;
+        rdfs:label            "PowerSchedule"@en ;
+        rdfs:range            nc:PowerSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerSchedule.PowerElectronicsUnit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Energy remedial action describes actions to rearrange power schedules." ;
+        rdfs:label              "PowerRemedialAction"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:PowerRemedialAction.PowerSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power schedule which contains the power remedial action." ;
+        rdfs:domain           nc:PowerRemedialAction ;
+        rdfs:label            "PowerSchedule"@en ;
+        rdfs:range            nc:PowerSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerSchedule.PowerRemedialAction ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerSchedule  rdf:type      rdfs:Class ;
+        rdfs:comment            "Time series represent irregular power, active and reactive, values at given points in time." ;
+        rdfs:label              "PowerSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerSchedule.AreaDispatchableUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Area disptachable unit which belongs to the power schedule." ;
+        rdfs:domain           nc:PowerSchedule ;
+        rdfs:label            "AreaDispatchableUnit"@en ;
+        rdfs:range            nc:AreaDispatchableUnit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AreaDispatchableUnit.PowerSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerSchedule.BiddingZone
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Bidding zone which has power schedules." ;
+        rdfs:domain           nc:PowerSchedule ;
+        rdfs:label            "BiddingZone"@en ;
+        rdfs:range            nc:BiddingZone ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:BiddingZone.PowerSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerSchedule.BiddingZoneBorder
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Bidding zone border which belongs to the power schedule." ;
+        rdfs:domain           nc:PowerSchedule ;
+        rdfs:label            "BiddingZoneBorder"@en ;
+        rdfs:range            nc:BiddingZoneBorder ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:BiddingZoneBorder.PowerSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerSchedule.DCPole
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC pole which belongs to the power schedule." ;
+        rdfs:domain           nc:PowerSchedule ;
+        rdfs:label            "DCPole"@en ;
+        rdfs:range            nc:DCPole ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DCPole.PowerSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerSchedule.DCTieCorridor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "DC tie corridor which belongs to the power schedule." ;
+        rdfs:domain           nc:PowerSchedule ;
+        rdfs:label            "DCTieCorridor"@en ;
+        rdfs:range            nc:DCTieCorridor ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DCTieCorridor.PowerSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerSchedule.EnergyConnection
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The energy connection that has a power schedule." ;
+        rdfs:domain           nc:PowerSchedule ;
+        rdfs:label            "EnergyConnection"@en ;
+        rdfs:range            cim:EnergyConnection ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EnergyConnection.PowerSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerSchedule.EnergyGroup
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Energy group which belongs to a power schedule." ;
+        rdfs:domain           nc:PowerSchedule ;
+        rdfs:label            "EnergyGroup"@en ;
+        rdfs:range            nc:EnergyGroup ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EnergyGroup.PowerSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerSchedule.EquivalentInjection
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Equivalent injection which belongs to the power schedule." ;
+        rdfs:domain           nc:PowerSchedule ;
+        rdfs:label            "EquivalentInjection"@en ;
+        rdfs:range            cim:EquivalentInjection ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EquivalentInjection.PowerSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerSchedule.GeneratingUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Generating unit which belongs to the power schedule." ;
+        rdfs:domain           nc:PowerSchedule ;
+        rdfs:label            "GeneratingUnit"@en ;
+        rdfs:range            cim:GeneratingUnit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GeneratingUnit.PowerSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerSchedule.HydroPump
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Hydro pump which belongs to the power schedule." ;
+        rdfs:domain           nc:PowerSchedule ;
+        rdfs:label            "HydroPump"@en ;
+        rdfs:range            cim:HydroPump ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:HydroPump.PowerSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerSchedule.PowerElectronicsUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power electronics unit which belongs to the power schedule." ;
+        rdfs:domain           nc:PowerSchedule ;
+        rdfs:label            "PowerElectronicsUnit"@en ;
+        rdfs:range            cim:PowerElectronicsUnit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerElectronicsUnit.PowerSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerSchedule.PowerRemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power remedial action which belongs to the Remedial Action Schedule." ;
+        rdfs:domain           nc:PowerSchedule ;
+        rdfs:label            "PowerRemedialAction"@en ;
+        rdfs:range            nc:PowerRemedialAction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerRemedialAction.PowerSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerSchedule.PowerTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Value for the point in time." ;
+        rdfs:domain           nc:PowerSchedule ;
+        rdfs:label            "PowerTimePoint"@en ;
+        rdfs:range            nc:PowerTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerTimePoint.PowerSchedule ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:PowerSchedule.SchedulingArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Scheduling area which has power schedules." ;
+        rdfs:domain           nc:PowerSchedule ;
+        rdfs:label            "SchedulingArea"@en ;
+        rdfs:range            nc:SchedulingArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SchedulingArea.PowerSchedule ;
+        cims:multiplicity     cims:M:0..1 .
+
+nc:PowerSchedule.direction
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of direction." ;
+        rdfs:domain        nc:PowerSchedule ;
+        rdfs:label         "direction"@en ;
+        rdfs:range         nc:RelativeDirectionKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerSchedule.powerScheduleKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of power schedule." ;
+        rdfs:domain        nc:PowerSchedule ;
+        rdfs:label         "powerScheduleKind"@en ;
+        rdfs:range         nc:PowerScheduleKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerScheduleKind  rdf:type  rdfs:Class ;
+        rdfs:comment            "Kind of power schedule." ;
+        rdfs:label              "PowerScheduleKind"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:PowerScheduleKind.meritOrder
+        rdf:type         nc:PowerScheduleKind ;
+        rdfs:comment     "Power schedule is a merit order that includes ranking of the power block. Power block provides the maximum power allocation possible." ;
+        rdfs:label       "meritOrder"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerScheduleKind.mustRun
+        rdf:type         nc:PowerScheduleKind ;
+        rdfs:comment     "Power schedule is a must run schedule that identifies the unit that must run for a given time point." ;
+        rdfs:label       "mustRun"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerScheduleKind.power
+        rdf:type         nc:PowerScheduleKind ;
+        rdfs:comment     "Power schedule that has no additional meaning than allocating power to unit for a given time point." ;
+        rdfs:label       "power"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerScheduleKind.price
+        rdf:type         nc:PowerScheduleKind ;
+        rdfs:comment     "Power schedule includes prices for a given a power per time point." ;
+        rdfs:label       "price"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerTimePoint  rdf:type     rdfs:Class ;
+        rdfs:comment            "Power, active and reactive, value at a given point in time." ;
+        rdfs:label              "PowerTimePoint"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerTimePoint.PowerSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Time series the time point values belongs to." ;
+        rdfs:domain           nc:PowerTimePoint ;
+        rdfs:label            "PowerSchedule"@en ;
+        rdfs:range            nc:PowerSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerSchedule.PowerTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerTimePoint.activatedP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Active power activated as part of redispatch. Negative number means that the value is scheduling down. Positive number means that the value is scheduling up." ;
+        rdfs:domain        nc:PowerTimePoint ;
+        rdfs:label         "activatedP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerTimePoint.activatedPrice
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Price for the activated active power per unit e.g. per MW." ;
+        rdfs:domain        nc:PowerTimePoint ;
+        rdfs:label         "activatedPrice"@en ;
+        cims:dataType      cim:Decimal ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerTimePoint.activatedQ
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Reactive power activated as part of redispatch. Negative number means that the value is scheduling down. Positive number means that the value is scheduling up." ;
+        rdfs:domain        nc:PowerTimePoint ;
+        rdfs:label         "activatedQ"@en ;
+        cims:dataType      cim:ReactivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:PowerTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerTimePoint.meritOrder
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Ranking the energy blocks. Ranking can be based on historical values or other sources. It is required if power schedule is kind merit order." ;
+        rdfs:domain        nc:PowerTimePoint ;
+        rdfs:label         "meritOrder"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerTimePoint.p  rdf:type  rdf:Property ;
+        rdfs:comment       "Active power injection. Load sign convention is used, i.e. positive sign means flow out from a node." ;
+        rdfs:domain        nc:PowerTimePoint ;
+        rdfs:label         "p"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerTimePoint.price
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Price for the scheduled active power per unit of active power. e.g. per MW." ;
+        rdfs:domain        nc:PowerTimePoint ;
+        rdfs:label         "price"@en ;
+        cims:dataType      cim:Decimal ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerTimePoint.q  rdf:type  rdf:Property ;
+        rdfs:comment       "Reactive power injection. Load sign convention is used, i.e. positive sign means flow out from a node." ;
+        rdfs:domain        nc:PowerTimePoint ;
+        rdfs:label         "q"@en ;
+        cims:dataType      cim:ReactivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+nc:RelativeDirectionKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of direction for the changes." ;
+        rdfs:label              "RelativeDirectionKind"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:RelativeDirectionKind.down
+        rdf:type         nc:RelativeDirectionKind ;
+        rdfs:comment     "Down signifies that the changes are decreasing from the current status." ;
+        rdfs:label       "down"@en ;
+        cims:stereotype  "enum" .
+
+nc:RelativeDirectionKind.none
+        rdf:type         nc:RelativeDirectionKind ;
+        rdfs:comment     "There is no direction on the changes." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+nc:RelativeDirectionKind.up
+        rdf:type         nc:RelativeDirectionKind ;
+        rdfs:comment     "Up signifies that the changes are increasing from the current status." ;
+        rdfs:label       "up"@en ;
+        cims:stereotype  "enum" .
+
+nc:RelativeDirectionKind.upAndDown
+        rdf:type         nc:RelativeDirectionKind ;
+        rdfs:comment     "Up and down signifies that both up and down values are equal." ;
+        rdfs:label       "upAndDown"@en ;
+        cims:stereotype  "enum" .
+
+nc:SchedulingArea  rdf:type     rdfs:Class ;
+        rdfs:comment            "An area where production and/or consumption of energy can be forecasted, scheduled and measured. The area is operated by only one system operator, typically a Transmission System Operator (TSO). The area can consist of a sub area, which has the same definition as the main area, but it can be operated by another system operator (typically Distributed System Operator (DSO) or a Closed Distributed System Operator (CDSO)). This includes microgrid concept. A substation is the smallest grouping that can be included in the area. The area size should be considered in terms of the possibility of accumulated reading (settlement metering) and the capability of operating as an island." ;
+        rdfs:label              "SchedulingArea"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:SchedulingArea.PowerSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power schedule which belongs to the scheduling area." ;
+        rdfs:domain           nc:SchedulingArea ;
+        rdfs:label            "PowerSchedule"@en ;
+        rdfs:range            nc:PowerSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerSchedule.SchedulingArea ;
+        cims:multiplicity     cims:M:0..n .
+
+nc:TimeSeriesInterpolationKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kinds of interpolation of values between two time point. " ;
+        rdfs:label              "TimeSeriesInterpolationKind"@en ;
+        cims:belongsToCategory  ps:Package_PowerScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:TimeSeriesInterpolationKind.linear
+        rdf:type         nc:TimeSeriesInterpolationKind ;
+        rdfs:comment     "Linear interpolation is applied for values between two time points." ;
+        rdfs:label       "linear"@en ;
+        cims:stereotype  "enum" .
+
+nc:TimeSeriesInterpolationKind.next
+        rdf:type         nc:TimeSeriesInterpolationKind ;
+        rdfs:comment     "The value between two time points is set to next value." ;
+        rdfs:label       "next"@en ;
+        cims:stereotype  "enum" .
+
+nc:TimeSeriesInterpolationKind.none
+        rdf:type         nc:TimeSeriesInterpolationKind ;
+        rdfs:comment     "No interpolation is applied." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+nc:TimeSeriesInterpolationKind.previous
+        rdf:type         nc:TimeSeriesInterpolationKind ;
+        rdfs:comment     "The value between two time points is set to previous value." ;
+        rdfs:label       "previous"@en ;
+        cims:stereotype  "enum" .
+
+nc:TimeSeriesInterpolationKind.zero
+        rdf:type         nc:TimeSeriesInterpolationKind ;
+        rdfs:comment     "The value between two time points is set to zero." ;
+        rdfs:label       "zero"@en ;
+        cims:stereotype  "enum" .
+
+profcim:IRI  rdf:type           rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as rdf:resource in RDFXML.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "IRI"@en ;
+        cims:belongsToCategory  ps:Package_DocPowerScheduleProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringFixedLanguage
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited.\nThe primitive is serialized as literal without language support." ;
+        rdfs:label              "StringFixedLanguage"@en ;
+        cims:belongsToCategory  ps:Package_DocPowerScheduleProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringIRI  rdf:type     rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as literal without language support.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "StringIRI"@en ;
+        cims:belongsToCategory  ps:Package_DocPowerScheduleProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:URL  rdf:type           rdfs:Class ;
+        rdfs:comment            "A Uniform Resource Locator (URL), colloquially termed a web address, is a reference to a web resource that specifies its location on a computer network and a mechanism for retrieving it. A URL is a specific type of Uniform Resource Identifier (URI), although many people use the two terms interchangeably.URLs occur most commonly to reference web pages (http), but are also used for file transfer (ftp), email (mailto), database access (JDBC), and many other applications." ;
+        rdfs:label              "URL"@en ;
+        cims:belongsToCategory  ps:Package_DocPowerScheduleProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+ps:Ontology  rdf:type         owl:Ontology ;
+        dcterms:conformsTo    "file://iec61970cim17v40_iec61968cim13v13a_iec62325cim03v17a.eap" , "file://CIM100_CGMES31v01_501-20v02_NC23v62_MM10v01.eap" , "urn:iso:std:iec:61970-301:ed-7:amd1" , "urn:iso:std:iec:61970-501:draft:ed-2" , "urn:iso:std:iec:61970-600-2:ed-1" , "urn:iso:std:iec:61970-401:draft:ed-1" ;
+        dcterms:creator       "ENTSO-E CIM WG NC project "@en ;
+        dcterms:description   "This vocabulary is describing the object registry profile."@en ;
+        dcterms:identifier    "urn:uuid:470c9792-7798-4eb6-b7f2-6e18293c5f7b" ;
+        dcterms:language      "en-GB" ;
+        dcterms:license       "https://www.apache.org/licenses/LICENSE-2.0"@en ;
+        dcterms:modified      "2024-03-20"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        dcterms:publisher     "ENTSO-E"@en ;
+        dcterms:rightsHolder  "ENTSO-E"@en ;
+        dcterms:title         "Power schedule vocabulary"@en ;
+        owl:priorVersion      <http://entsoe.eu/ns/CIM/PowerSchedule-EU/2.2> ;
+        owl:versionIRI        <https://ap.cim4.eu/PowerSchedule/2.3> ;
+        owl:versionInfo       "2.3.0"@en ;
+        dcat:keyword          "PS" ;
+        dcat:theme            "vocabulary"@en .
+
+ps:Package_DocPowerScheduleProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains datatypes used only in the RDFS header." ;
+        rdfs:label    "DocPowerScheduleProfile"@en .
+
+ps:Package_PowerScheduleProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains the power schedule profile." ;
+        rdfs:label    "PowerScheduleProfile"@en .
+

--- a/r2.3/ap-voc/ttl/PowerSystemProject-AP-Voc-RDFS2020.ttl
+++ b/r2.3/ap-voc/ttl/PowerSystemProject-AP-Voc-RDFS2020.ttl
@@ -1,0 +1,513 @@
+@prefix cim:     <https://cim.ucaiug.io/ns#> .
+@prefix cims:    <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/#> .
+@prefix nc:      <https://cim4.eu/ns/nc#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix profcim: <https://cim.ucaiug.io/ns/prof-cim#> .
+@prefix psp:     <https://ap.cim4.eu/PowerSystemProject#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+
+cim:Date  rdf:type              rdfs:Class ;
+        rdfs:comment            "Date as \"yyyy-mm-dd\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddZ\". A local timezone relative UTC is specified as \"yyyy-mm-dd(+/-)hh:mm\"." ;
+        rdfs:label              "Date"@en ;
+        cims:belongsToCategory  psp:Package_PowerSystemProjectProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:DateTime  rdf:type          rdfs:Class ;
+        rdfs:comment            "Date and time as \"yyyy-mm-ddThh:mm:ss.sss\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddThh:mm:ss.sssZ\". A local timezone relative UTC is specified as \"yyyy-mm-ddThh:mm:ss.sss-hh:mm\". The second component (shown here as \"ss.sss\") could have any number of digits in its fractional part to allow any kind of precision beyond seconds." ;
+        rdfs:label              "DateTime"@en ;
+        cims:belongsToCategory  psp:Package_PowerSystemProjectProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Integer  rdf:type           rdfs:Class ;
+        rdfs:comment            "An integer number. The range is unspecified and not limited." ;
+        rdfs:label              "Integer"@en ;
+        cims:belongsToCategory  psp:Package_PowerSystemProjectProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:String  rdf:type            rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited." ;
+        rdfs:label              "String"@en ;
+        cims:belongsToCategory  psp:Package_PowerSystemProjectProfile ;
+        cims:stereotype         "Primitive" .
+
+dcat:Resource  rdf:type         rdfs:Class ;
+        rdfs:comment            "Resource published or curated by a single agent." ;
+        rdfs:label              "Resource"@en ;
+        cims:belongsToCategory  psp:Package_PowerSystemProjectProfile ;
+        cims:stereotype         "dcat" .
+
+dcat:Resource.hasVersion
+        rdf:type           rdf:Property ;
+        rdfs:comment       "This resource has a more specific, versioned resource." ;
+        rdfs:domain        dcat:Resource ;
+        rdfs:label         "hasVersion"@en ;
+        cims:dataType      profcim:IRI ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcat" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcat:Resource.isVersionOf
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A related resource of which the described resource is a version, edition, or adaptation.\nChanges in version imply substantive changes in content rather than differences in format. This property is intended to be used with non-literal values. This property is an inverse property of hasVersion." ;
+        rdfs:domain        dcat:Resource ;
+        rdfs:label         "isVersionOf"@en ;
+        cims:dataType      profcim:IRI ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "dcat" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcat:Resource.keyword
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A keyword or tag describing a resource." ;
+        rdfs:domain        dcat:Resource ;
+        rdfs:label         "keyword"@en ;
+        cims:dataType      profcim:StringFixedLanguage ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcat" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcat:Resource.version
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The version indicator (name or identifier) of a resource." ;
+        rdfs:domain        dcat:Resource ;
+        rdfs:label         "version"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcat" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcat:Resource.versionNotes
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A description of changes between this version and the previous version of the resource." ;
+        rdfs:domain        dcat:Resource ;
+        rdfs:label         "versionNotes"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "adms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:PowerSystemProjectGroup.description
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A free-text account of the resource.\nDescription may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource." ;
+        rdfs:domain        nc:PowerSystemProjectGroup ;
+        rdfs:label         "description"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:PowerSystemProjectGroup.identifier
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A unique identifier of the resource being described or cataloged.\nThe identifier might be used as part of the IRI of the resource, but still having it represented explicitly is useful.\nThe identifier is a text string which is assigned to the resource to provide an unambiguous reference within a particular context." ;
+        rdfs:domain        nc:PowerSystemProjectGroup ;
+        rdfs:label         "identifier"@en ;
+        cims:dataType      profcim:StringIRI ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:PowerSystemProjectGroup.title
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A name given to the resource." ;
+        rdfs:domain        nc:PowerSystemProjectGroup ;
+        rdfs:label         "title"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:Resource.accessRights
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Information about who access the resource or an indication of its security status.\nAccess Rights may include information regarding access or restrictions based on privacy, security, or other policies." ;
+        rdfs:domain        dcat:Resource ;
+        rdfs:label         "accessRights"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:Resource.conformsTo
+        rdf:type           rdf:Property ;
+        rdfs:comment       "An established standard to which the described resource conforms." ;
+        rdfs:domain        dcat:Resource ;
+        rdfs:label         "conformsTo"@en ;
+        cims:dataType      profcim:StringIRI ;
+        cims:multiplicity  cims:M:0..n ;
+        cims:stereotype    "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:Resource.creator
+        rdf:type           rdf:Property ;
+        rdfs:comment       "An entity responsible for making the resource.\nRecommended practice is to identify the creator with a URI. If this is not possible or feasible, a literal value that identifies the creator may be provided." ;
+        rdfs:domain        dcat:Resource ;
+        rdfs:label         "creator"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:Resource.description
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A free-text account of the resource.\nDescription may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource." ;
+        rdfs:domain        dcat:Resource ;
+        rdfs:label         "description"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:Resource.identifier
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A unique identifier of the resource being described or cataloged.\nThe identifier might be used as part of the IRI of the resource, but still having it represented explicitly is useful.\nThe identifier is a text string which is assigned to the resource to provide an unambiguous reference within a particular context." ;
+        rdfs:domain        dcat:Resource ;
+        rdfs:label         "identifier"@en ;
+        cims:dataType      profcim:StringIRI ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:Resource.issued
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Date of formal issuance of the resource.\nRecommended practice is to describe the date, date/time, or period of time as recommended for the property Date, of which this is a subproperty." ;
+        rdfs:domain        dcat:Resource ;
+        rdfs:label         "issued"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:Resource.license
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A legal document under which the resource is made available.\nRecommended practice is to identify the license document with a URI. If this is not possible or feasible, a literal value that identifies the license may be provided." ;
+        rdfs:domain        dcat:Resource ;
+        rdfs:label         "license"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:Resource.modified
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Most recent date on which the item was changed, updated or modified.\nRecommended practice is to describe the date, date/time, or period of time as recommended for the property Date, of which this is a subproperty." ;
+        rdfs:domain        dcat:Resource ;
+        rdfs:label         "modified"@en ;
+        cims:dataType      cim:Date ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:Resource.publisher
+        rdf:type           rdf:Property ;
+        rdfs:comment       "An entity responsible for making the resource available." ;
+        rdfs:domain        dcat:Resource ;
+        rdfs:label         "publisher"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:Resource.rights
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A statement that concerns all rights not addressed with dct:license or dct:accessRights, such as copyright statements." ;
+        rdfs:domain        dcat:Resource ;
+        rdfs:label         "rights"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:Resource.rightsHolder
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Information about rights held in and over the resource.\nTypically, rights information includes a statement about various property rights associated with the resource, including intellectual property rights. Recommended practice is to refer to a rights statement with a URI. If this is not possible or feasible, a literal value (name, label, or short text) may be provided." ;
+        rdfs:domain        dcat:Resource ;
+        rdfs:label         "rightsHolder"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+dcterms:Resource.title
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A name given to the resource." ;
+        rdfs:domain        dcat:Resource ;
+        rdfs:label         "title"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "dcterms" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AvailabilitySchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A given (un)availability schedule with a given status and cause that include multiple equipment that need to follow the same scheduling periods." ;
+        rdfs:label              "AvailabilitySchedule"@en ;
+        cims:belongsToCategory  psp:Package_PowerSystemProjectProfile ;
+        cims:stereotype         "NC" .
+
+nc:AvailabilitySchedule.PowerSystemProject
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The power system project that has this availability schedule." ;
+        rdfs:domain           nc:AvailabilitySchedule ;
+        rdfs:label            "PowerSystemProject"@en ;
+        rdfs:range            nc:PowerSystemProject ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerSystemProject.AvailabilitySchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:DifferenceModel  rdf:type    rdfs:Class ;
+        rdfs:comment            "A set of statements describing the changes in the network model. The statement is defined in the difference model. " ;
+        rdfs:label              "DifferenceModel"@en ;
+        rdfs:subClassOf         dcat:Resource ;
+        cims:belongsToCategory  psp:Package_PowerSystemProjectProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+nc:DifferenceModel.PowerSystemProject
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The power system project that is described by this difference model." ;
+        rdfs:domain           nc:DifferenceModel ;
+        rdfs:label            "PowerSystemProject"@en ;
+        rdfs:range            nc:PowerSystemProject ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerSystemProject.DifferenceModel ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerSystemProject
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Knowledge data for the power system project that describe the status and the planned implementation of the changes into the as-built model." ;
+        rdfs:label              "PowerSystemProject"@en ;
+        rdfs:subClassOf         dcat:Resource ;
+        cims:belongsToCategory  psp:Package_PowerSystemProjectProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerSystemProject.AlternativeProject
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Alternative project. Only one of the projects will be commissioned." ;
+        rdfs:domain           nc:PowerSystemProject ;
+        rdfs:label            "AlternativeProject"@en ;
+        rdfs:range            nc:PowerSystemProject ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerSystemProject.PriorityProject ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerSystemProject.AvailabilitySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The availability schedule associated with this power system project." ;
+        rdfs:domain           nc:PowerSystemProject ;
+        rdfs:label            "AvailabilitySchedule"@en ;
+        rdfs:range            nc:AvailabilitySchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AvailabilitySchedule.PowerSystemProject ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerSystemProject.DependentOnProject
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Grouping of projects that are depending on each other. A project can only be linked to one dependent project." ;
+        rdfs:domain           nc:PowerSystemProject ;
+        rdfs:label            "DependentOnProject"@en ;
+        rdfs:range            nc:PowerSystemProject ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerSystemProject.Project ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerSystemProject.DifferenceModel
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The difference model describing this power system project." ;
+        rdfs:domain           nc:PowerSystemProject ;
+        rdfs:label            "DifferenceModel"@en ;
+        rdfs:range            nc:DifferenceModel ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DifferenceModel.PowerSystemProject ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerSystemProject.PriorityProject
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The project that has an alternative project." ;
+        rdfs:domain           nc:PowerSystemProject ;
+        rdfs:label            "PriorityProject"@en ;
+        rdfs:range            nc:PowerSystemProject ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerSystemProject.AlternativeProject ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerSystemProject.Project
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The project that has a dependent on project." ;
+        rdfs:domain           nc:PowerSystemProject ;
+        rdfs:label            "Project"@en ;
+        rdfs:range            nc:PowerSystemProject ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerSystemProject.DependentOnProject ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerSystemProject.ProjectGroup
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power system project group to which this project belongs." ;
+        rdfs:domain           nc:PowerSystemProject ;
+        rdfs:label            "ProjectGroup"@en ;
+        rdfs:range            nc:PowerSystemProjectGroup ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerSystemProjectGroup.Project ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerSystemProject.ShadowProject
+        rdf:type              rdf:Property ;
+        rdfs:comment          "A shadowing project that includes the same change set, but different timeline." ;
+        rdfs:domain           nc:PowerSystemProject ;
+        rdfs:label            "ShadowProject"@en ;
+        rdfs:range            nc:PowerSystemProject ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerSystemProject.SilhouetteProject ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerSystemProject.SilhouetteProject
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The project that has a shadow project." ;
+        rdfs:domain           nc:PowerSystemProject ;
+        rdfs:label            "SilhouetteProject"@en ;
+        rdfs:range            nc:PowerSystemProject ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerSystemProject.ShadowProject ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerSystemProject.cancelled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "From this date the project is in cancelled state. No further development will be done to the project or associated change set in this state." ;
+        rdfs:domain        nc:PowerSystemProject ;
+        rdfs:label         "cancelled"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerSystemProject.commissioned
+        rdf:type           rdf:Property ;
+        rdfs:comment       "From this date the project is in commissioned state. Any conducting equipment in the change set can be energized from this day. No further changes will be done to the change set." ;
+        rdfs:domain        nc:PowerSystemProject ;
+        rdfs:label         "commissioned"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerSystemProject.committed
+        rdf:type           rdf:Property ;
+        rdfs:comment       "From this date the project is in committed state. The change set will from this day be part of the as-build model." ;
+        rdfs:domain        nc:PowerSystemProject ;
+        rdfs:label         "committed"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerSystemProject.inBuild
+        rdf:type           rdf:Property ;
+        rdfs:comment       "From this day the project is in build state. Alternative project have been evaluated. Any procurement has started and the change set is being updated to an as-build model." ;
+        rdfs:domain        nc:PowerSystemProject ;
+        rdfs:label         "inBuild"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerSystemProject.inPlan
+        rdf:type           rdf:Property ;
+        rdfs:comment       "From this date the project is in planning state. Study or procurement strategy has triggered the start of a project involving changes to one or more models. Alternative projects and change sets are evaluated.  " ;
+        rdfs:domain        nc:PowerSystemProject ;
+        rdfs:label         "inPlan"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerSystemProject.officialExpectedCommissioning
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Published official commissioning date." ;
+        rdfs:domain        nc:PowerSystemProject ;
+        rdfs:label         "officialExpectedCommissioning"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerSystemProject.priority
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Priority between competing project. Use 0 for do not care. Use 1 for highest priority. Use 2 as priority is less than 1 and so on." ;
+        rdfs:domain        nc:PowerSystemProject ;
+        rdfs:label         "priority"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerSystemProjectGroup
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A container with project that are grouped together. Primarily used for navigation and to highlight the phases that an overall project can go though." ;
+        rdfs:label              "PowerSystemProjectGroup"@en ;
+        cims:belongsToCategory  psp:Package_PowerSystemProjectProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerSystemProjectGroup.Project
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The project included in the power system project group." ;
+        rdfs:domain           nc:PowerSystemProjectGroup ;
+        rdfs:label            "Project"@en ;
+        rdfs:range            nc:PowerSystemProject ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerSystemProject.ProjectGroup ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+profcim:IRI  rdf:type           rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as rdf:resource in RDFXML.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "IRI"@en ;
+        cims:belongsToCategory  psp:Package_PowerSystemProjectProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringFixedLanguage
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited.\nThe primitive is serialized as literal without language support." ;
+        rdfs:label              "StringFixedLanguage"@en ;
+        cims:belongsToCategory  psp:Package_PowerSystemProjectProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringIRI  rdf:type     rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as literal without language support.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "StringIRI"@en ;
+        cims:belongsToCategory  psp:Package_PowerSystemProjectProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:URL  rdf:type           rdfs:Class ;
+        rdfs:comment            "A Uniform Resource Locator (URL), colloquially termed a web address, is a reference to a web resource that specifies its location on a computer network and a mechanism for retrieving it. A URL is a specific type of Uniform Resource Identifier (URI), although many people use the two terms interchangeably.URLs occur most commonly to reference web pages (http), but are also used for file transfer (ftp), email (mailto), database access (JDBC), and many other applications." ;
+        rdfs:label              "URL"@en ;
+        cims:belongsToCategory  psp:Package_PowerSystemProjectProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+psp:Ontology  rdf:type        owl:Ontology ;
+        dcterms:conformsTo    "urn:iso:std:iec:61970-600-2:ed-1" , "urn:iso:std:iec:61970-501:draft:ed-2" , "urn:iso:std:iec:61970-301:ed-7:amd1" , "file://iec61970cim17v40_iec61968cim13v13a_iec62325cim03v17a.eap" , "file://CIM100_CGMES31v01_501-20v02_NC23v62_MM10v01.eap" , "urn:iso:std:iec:61970-401:draft:ed-1" ;
+        dcterms:creator       "ENTSO-E CIM WG NC project "@en ;
+        dcterms:description   "This vocabulary is describing the power system profile."@en ;
+        dcterms:identifier    "urn:uuid:29bfa45c-7d04-42f1-97c1-2e0f70f476a0" ;
+        dcterms:language      "en-GB" ;
+        dcterms:license       "https://www.apache.org/licenses/LICENSE-2.0"@en ;
+        dcterms:modified      "2024-03-20"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        dcterms:publisher     "ENTSO-E"@en ;
+        dcterms:rightsHolder  "ENTSO-E"@en ;
+        dcterms:title         "Power System Project Vocabulary"@en ;
+        owl:versionIRI        <https://ap.cim4.eu/PowerSystemProject/2.3> ;
+        owl:versionInfo       "2.3.0"@en ;
+        dcat:keyword          "PSP" ;
+        dcat:theme            "vocabulary"@en .
+
+psp:Package_PowerSystemProjectProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains power system project profile." ;
+        rdfs:label    "PowerSystemProjectProfile"@en .
+

--- a/r2.3/ap-voc/ttl/RemedialAction-AP-Voc-RDFS2020.ttl
+++ b/r2.3/ap-voc/ttl/RemedialAction-AP-Voc-RDFS2020.ttl
@@ -1,0 +1,3757 @@
+@prefix cim:     <https://cim.ucaiug.io/ns#> .
+@prefix cims:    <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/#> .
+@prefix nc:      <https://cim4.eu/ns/nc#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix profcim: <https://cim.ucaiug.io/ns/prof-cim#> .
+@prefix ra:      <https://ap.cim4.eu/RemedialAction#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+
+cim:ACDCConverter  rdf:type     rdfs:Class ;
+        rdfs:comment            "A unit with valves for three phases, together with unit control equipment, essential protective and switching devices, DC storage capacitors, phase reactors and auxiliaries, if any, used for conversion." ;
+        rdfs:label              "ACDCConverter"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:ACDCTerminal  rdf:type      rdfs:Class ;
+        rdfs:comment            "An electrical connection point (AC or DC) to a piece of conducting equipment. Terminals are connected at physical connection points called connectivity nodes." ;
+        rdfs:label              "ACDCTerminal"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:ActivePower  rdf:type       rdfs:Class ;
+        rdfs:comment            "Product of RMS value of the voltage and the RMS value of the in-phase component of the current." ;
+        rdfs:label              "ActivePower"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:ActivePower.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePower.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "W" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePower.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:BatteryUnit  rdf:type       rdfs:Class ;
+        rdfs:comment            "An electrochemical energy storage device." ;
+        rdfs:label              "BatteryUnit"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:Boolean  rdf:type           rdfs:Class ;
+        rdfs:comment            "A type with the value space \"true\" and \"false\"." ;
+        rdfs:label              "Boolean"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Contingency  rdf:type       rdfs:Class ;
+        rdfs:comment            "An event threatening system reliability, consisting of one or more contingency elements." ;
+        rdfs:label              "Contingency"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:Currency  rdf:type          rdfs:Class ;
+        rdfs:comment            "Monetary currencies.  ISO 4217 standard including 3-character currency code." ;
+        rdfs:label              "Currency"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:Currency.AED  rdf:type  cim:Currency ;
+        rdfs:comment     "United Arab Emirates dirham." ;
+        rdfs:label       "AED"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AFN  rdf:type  cim:Currency ;
+        rdfs:comment     "Afghan afghani." ;
+        rdfs:label       "AFN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ALL  rdf:type  cim:Currency ;
+        rdfs:comment     "Albanian lek." ;
+        rdfs:label       "ALL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AMD  rdf:type  cim:Currency ;
+        rdfs:comment     "Armenian dram." ;
+        rdfs:label       "AMD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ANG  rdf:type  cim:Currency ;
+        rdfs:comment     "Netherlands Antillean guilder." ;
+        rdfs:label       "ANG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AOA  rdf:type  cim:Currency ;
+        rdfs:comment     "Angolan kwanza." ;
+        rdfs:label       "AOA"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ARS  rdf:type  cim:Currency ;
+        rdfs:comment     "Argentine peso." ;
+        rdfs:label       "ARS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AUD  rdf:type  cim:Currency ;
+        rdfs:comment     "Australian dollar." ;
+        rdfs:label       "AUD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AWG  rdf:type  cim:Currency ;
+        rdfs:comment     "Aruban florin." ;
+        rdfs:label       "AWG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AZN  rdf:type  cim:Currency ;
+        rdfs:comment     "Azerbaijani manat." ;
+        rdfs:label       "AZN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BAM  rdf:type  cim:Currency ;
+        rdfs:comment     "Bosnia and Herzegovina convertible mark." ;
+        rdfs:label       "BAM"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BBD  rdf:type  cim:Currency ;
+        rdfs:comment     "Barbados dollar." ;
+        rdfs:label       "BBD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BDT  rdf:type  cim:Currency ;
+        rdfs:comment     "Bangladeshi taka." ;
+        rdfs:label       "BDT"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BGN  rdf:type  cim:Currency ;
+        rdfs:comment     "Bulgarian lev." ;
+        rdfs:label       "BGN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BHD  rdf:type  cim:Currency ;
+        rdfs:comment     "Bahraini dinar." ;
+        rdfs:label       "BHD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BIF  rdf:type  cim:Currency ;
+        rdfs:comment     "Burundian franc." ;
+        rdfs:label       "BIF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BMD  rdf:type  cim:Currency ;
+        rdfs:comment     "Bermudian dollar (customarily known as Bermuda dollar)." ;
+        rdfs:label       "BMD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BND  rdf:type  cim:Currency ;
+        rdfs:comment     "Brunei dollar." ;
+        rdfs:label       "BND"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BOB  rdf:type  cim:Currency ;
+        rdfs:comment     "Boliviano." ;
+        rdfs:label       "BOB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BOV  rdf:type  cim:Currency ;
+        rdfs:comment     "Bolivian Mvdol (funds code)." ;
+        rdfs:label       "BOV"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BRL  rdf:type  cim:Currency ;
+        rdfs:comment     "Brazilian real." ;
+        rdfs:label       "BRL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BSD  rdf:type  cim:Currency ;
+        rdfs:comment     "Bahamian dollar." ;
+        rdfs:label       "BSD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BTN  rdf:type  cim:Currency ;
+        rdfs:comment     "Bhutanese ngultrum." ;
+        rdfs:label       "BTN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BWP  rdf:type  cim:Currency ;
+        rdfs:comment     "Botswana pula." ;
+        rdfs:label       "BWP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BYR  rdf:type  cim:Currency ;
+        rdfs:comment     "Belarusian ruble." ;
+        rdfs:label       "BYR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BZD  rdf:type  cim:Currency ;
+        rdfs:comment     "Belize dollar." ;
+        rdfs:label       "BZD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CAD  rdf:type  cim:Currency ;
+        rdfs:comment     "Canadian dollar." ;
+        rdfs:label       "CAD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CDF  rdf:type  cim:Currency ;
+        rdfs:comment     "Congolese franc." ;
+        rdfs:label       "CDF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CHF  rdf:type  cim:Currency ;
+        rdfs:comment     "Swiss franc." ;
+        rdfs:label       "CHF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CLF  rdf:type  cim:Currency ;
+        rdfs:comment     "Unidad de Fomento (funds code), Chile." ;
+        rdfs:label       "CLF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CLP  rdf:type  cim:Currency ;
+        rdfs:comment     "Chilean peso." ;
+        rdfs:label       "CLP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CNY  rdf:type  cim:Currency ;
+        rdfs:comment     "Chinese yuan." ;
+        rdfs:label       "CNY"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.COP  rdf:type  cim:Currency ;
+        rdfs:comment     "Colombian peso." ;
+        rdfs:label       "COP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.COU  rdf:type  cim:Currency ;
+        rdfs:comment     "Unidad de Valor Real." ;
+        rdfs:label       "COU"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CRC  rdf:type  cim:Currency ;
+        rdfs:comment     "Costa Rican colon." ;
+        rdfs:label       "CRC"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CUC  rdf:type  cim:Currency ;
+        rdfs:comment     "Cuban convertible peso." ;
+        rdfs:label       "CUC"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CUP  rdf:type  cim:Currency ;
+        rdfs:comment     "Cuban peso." ;
+        rdfs:label       "CUP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CVE  rdf:type  cim:Currency ;
+        rdfs:comment     "Cape Verde escudo." ;
+        rdfs:label       "CVE"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CZK  rdf:type  cim:Currency ;
+        rdfs:comment     "Czech koruna." ;
+        rdfs:label       "CZK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.DJF  rdf:type  cim:Currency ;
+        rdfs:comment     "Djiboutian franc." ;
+        rdfs:label       "DJF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.DKK  rdf:type  cim:Currency ;
+        rdfs:comment     "Danish krone." ;
+        rdfs:label       "DKK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.DOP  rdf:type  cim:Currency ;
+        rdfs:comment     "Dominican peso." ;
+        rdfs:label       "DOP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.DZD  rdf:type  cim:Currency ;
+        rdfs:comment     "Algerian dinar." ;
+        rdfs:label       "DZD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.EEK  rdf:type  cim:Currency ;
+        rdfs:comment     "Estonian kroon." ;
+        rdfs:label       "EEK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.EGP  rdf:type  cim:Currency ;
+        rdfs:comment     "Egyptian pound." ;
+        rdfs:label       "EGP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ERN  rdf:type  cim:Currency ;
+        rdfs:comment     "Eritrean nakfa." ;
+        rdfs:label       "ERN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ETB  rdf:type  cim:Currency ;
+        rdfs:comment     "Ethiopian birr." ;
+        rdfs:label       "ETB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.EUR  rdf:type  cim:Currency ;
+        rdfs:comment     "Euro." ;
+        rdfs:label       "EUR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.FJD  rdf:type  cim:Currency ;
+        rdfs:comment     "Fiji dollar." ;
+        rdfs:label       "FJD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.FKP  rdf:type  cim:Currency ;
+        rdfs:comment     "Falkland Islands pound." ;
+        rdfs:label       "FKP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GBP  rdf:type  cim:Currency ;
+        rdfs:comment     "Pound sterling." ;
+        rdfs:label       "GBP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GEL  rdf:type  cim:Currency ;
+        rdfs:comment     "Georgian lari." ;
+        rdfs:label       "GEL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GHS  rdf:type  cim:Currency ;
+        rdfs:comment     "Ghanaian cedi." ;
+        rdfs:label       "GHS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GIP  rdf:type  cim:Currency ;
+        rdfs:comment     "Gibraltar pound." ;
+        rdfs:label       "GIP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GMD  rdf:type  cim:Currency ;
+        rdfs:comment     "Gambian dalasi." ;
+        rdfs:label       "GMD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GNF  rdf:type  cim:Currency ;
+        rdfs:comment     "Guinean franc." ;
+        rdfs:label       "GNF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GTQ  rdf:type  cim:Currency ;
+        rdfs:comment     "Guatemalan quetzal." ;
+        rdfs:label       "GTQ"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GYD  rdf:type  cim:Currency ;
+        rdfs:comment     "Guyanese dollar." ;
+        rdfs:label       "GYD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HKD  rdf:type  cim:Currency ;
+        rdfs:comment     "Hong Kong dollar." ;
+        rdfs:label       "HKD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HNL  rdf:type  cim:Currency ;
+        rdfs:comment     "Honduran lempira." ;
+        rdfs:label       "HNL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HRK  rdf:type  cim:Currency ;
+        rdfs:comment     "Croatian kuna." ;
+        rdfs:label       "HRK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HTG  rdf:type  cim:Currency ;
+        rdfs:comment     "Haitian gourde." ;
+        rdfs:label       "HTG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HUF  rdf:type  cim:Currency ;
+        rdfs:comment     "Hungarian forint." ;
+        rdfs:label       "HUF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.IDR  rdf:type  cim:Currency ;
+        rdfs:comment     "Indonesian rupiah." ;
+        rdfs:label       "IDR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ILS  rdf:type  cim:Currency ;
+        rdfs:comment     "Israeli new sheqel." ;
+        rdfs:label       "ILS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.INR  rdf:type  cim:Currency ;
+        rdfs:comment     "Indian rupee." ;
+        rdfs:label       "INR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.IQD  rdf:type  cim:Currency ;
+        rdfs:comment     "Iraqi dinar." ;
+        rdfs:label       "IQD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.IRR  rdf:type  cim:Currency ;
+        rdfs:comment     "Iranian rial." ;
+        rdfs:label       "IRR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ISK  rdf:type  cim:Currency ;
+        rdfs:comment     "Icelandic króna." ;
+        rdfs:label       "ISK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.JMD  rdf:type  cim:Currency ;
+        rdfs:comment     "Jamaican dollar." ;
+        rdfs:label       "JMD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.JOD  rdf:type  cim:Currency ;
+        rdfs:comment     "Jordanian dinar." ;
+        rdfs:label       "JOD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.JPY  rdf:type  cim:Currency ;
+        rdfs:comment     "Japanese yen." ;
+        rdfs:label       "JPY"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KES  rdf:type  cim:Currency ;
+        rdfs:comment     "Kenyan shilling." ;
+        rdfs:label       "KES"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KGS  rdf:type  cim:Currency ;
+        rdfs:comment     "Kyrgyzstani som." ;
+        rdfs:label       "KGS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KHR  rdf:type  cim:Currency ;
+        rdfs:comment     "Cambodian riel." ;
+        rdfs:label       "KHR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KMF  rdf:type  cim:Currency ;
+        rdfs:comment     "Comoro franc." ;
+        rdfs:label       "KMF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KPW  rdf:type  cim:Currency ;
+        rdfs:comment     "North Korean won." ;
+        rdfs:label       "KPW"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KRW  rdf:type  cim:Currency ;
+        rdfs:comment     "South Korean won." ;
+        rdfs:label       "KRW"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KWD  rdf:type  cim:Currency ;
+        rdfs:comment     "Kuwaiti dinar." ;
+        rdfs:label       "KWD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KYD  rdf:type  cim:Currency ;
+        rdfs:comment     "Cayman Islands dollar." ;
+        rdfs:label       "KYD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KZT  rdf:type  cim:Currency ;
+        rdfs:comment     "Kazakhstani tenge." ;
+        rdfs:label       "KZT"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LAK  rdf:type  cim:Currency ;
+        rdfs:comment     "Lao kip." ;
+        rdfs:label       "LAK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LBP  rdf:type  cim:Currency ;
+        rdfs:comment     "Lebanese pound." ;
+        rdfs:label       "LBP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LKR  rdf:type  cim:Currency ;
+        rdfs:comment     "Sri Lanka rupee." ;
+        rdfs:label       "LKR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LRD  rdf:type  cim:Currency ;
+        rdfs:comment     "Liberian dollar." ;
+        rdfs:label       "LRD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LSL  rdf:type  cim:Currency ;
+        rdfs:comment     "Lesotho loti." ;
+        rdfs:label       "LSL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LTL  rdf:type  cim:Currency ;
+        rdfs:comment     "Lithuanian litas." ;
+        rdfs:label       "LTL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LVL  rdf:type  cim:Currency ;
+        rdfs:comment     "Latvian lats." ;
+        rdfs:label       "LVL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LYD  rdf:type  cim:Currency ;
+        rdfs:comment     "Libyan dinar." ;
+        rdfs:label       "LYD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MAD  rdf:type  cim:Currency ;
+        rdfs:comment     "Moroccan dirham." ;
+        rdfs:label       "MAD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MDL  rdf:type  cim:Currency ;
+        rdfs:comment     "Moldovan leu." ;
+        rdfs:label       "MDL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MGA  rdf:type  cim:Currency ;
+        rdfs:comment     "Malagasy ariary." ;
+        rdfs:label       "MGA"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MKD  rdf:type  cim:Currency ;
+        rdfs:comment     "Macedonian denar." ;
+        rdfs:label       "MKD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MMK  rdf:type  cim:Currency ;
+        rdfs:comment     "Myanma kyat." ;
+        rdfs:label       "MMK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MNT  rdf:type  cim:Currency ;
+        rdfs:comment     "Mongolian tugrik." ;
+        rdfs:label       "MNT"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MOP  rdf:type  cim:Currency ;
+        rdfs:comment     "Macanese pataca." ;
+        rdfs:label       "MOP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MRO  rdf:type  cim:Currency ;
+        rdfs:comment     "Mauritanian ouguiya." ;
+        rdfs:label       "MRO"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MUR  rdf:type  cim:Currency ;
+        rdfs:comment     "Mauritian rupee." ;
+        rdfs:label       "MUR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MVR  rdf:type  cim:Currency ;
+        rdfs:comment     "Maldivian rufiyaa." ;
+        rdfs:label       "MVR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MWK  rdf:type  cim:Currency ;
+        rdfs:comment     "Malawian kwacha." ;
+        rdfs:label       "MWK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MXN  rdf:type  cim:Currency ;
+        rdfs:comment     "Mexican peso." ;
+        rdfs:label       "MXN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MYR  rdf:type  cim:Currency ;
+        rdfs:comment     "Malaysian ringgit." ;
+        rdfs:label       "MYR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MZN  rdf:type  cim:Currency ;
+        rdfs:comment     "Mozambican metical." ;
+        rdfs:label       "MZN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NAD  rdf:type  cim:Currency ;
+        rdfs:comment     "Namibian dollar." ;
+        rdfs:label       "NAD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NGN  rdf:type  cim:Currency ;
+        rdfs:comment     "Nigerian naira." ;
+        rdfs:label       "NGN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NIO  rdf:type  cim:Currency ;
+        rdfs:comment     "Cordoba oro." ;
+        rdfs:label       "NIO"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NOK  rdf:type  cim:Currency ;
+        rdfs:comment     "Norwegian krone." ;
+        rdfs:label       "NOK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NPR  rdf:type  cim:Currency ;
+        rdfs:comment     "Nepalese rupee." ;
+        rdfs:label       "NPR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NZD  rdf:type  cim:Currency ;
+        rdfs:comment     "New Zealand dollar." ;
+        rdfs:label       "NZD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.OMR  rdf:type  cim:Currency ;
+        rdfs:comment     "Omani rial." ;
+        rdfs:label       "OMR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PAB  rdf:type  cim:Currency ;
+        rdfs:comment     "Panamanian balboa." ;
+        rdfs:label       "PAB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PEN  rdf:type  cim:Currency ;
+        rdfs:comment     "Peruvian nuevo sol." ;
+        rdfs:label       "PEN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PGK  rdf:type  cim:Currency ;
+        rdfs:comment     "Papua New Guinean kina." ;
+        rdfs:label       "PGK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PHP  rdf:type  cim:Currency ;
+        rdfs:comment     "Philippine peso." ;
+        rdfs:label       "PHP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PKR  rdf:type  cim:Currency ;
+        rdfs:comment     "Pakistani rupee." ;
+        rdfs:label       "PKR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PLN  rdf:type  cim:Currency ;
+        rdfs:comment     "Polish zloty." ;
+        rdfs:label       "PLN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PYG  rdf:type  cim:Currency ;
+        rdfs:comment     "Paraguayan guaraní." ;
+        rdfs:label       "PYG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.QAR  rdf:type  cim:Currency ;
+        rdfs:comment     "Qatari rial." ;
+        rdfs:label       "QAR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.RON  rdf:type  cim:Currency ;
+        rdfs:comment     "Romanian new leu." ;
+        rdfs:label       "RON"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.RSD  rdf:type  cim:Currency ;
+        rdfs:comment     "Serbian dinar." ;
+        rdfs:label       "RSD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.RUB  rdf:type  cim:Currency ;
+        rdfs:comment     "Russian rouble." ;
+        rdfs:label       "RUB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.RWF  rdf:type  cim:Currency ;
+        rdfs:comment     "Rwandan franc." ;
+        rdfs:label       "RWF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SAR  rdf:type  cim:Currency ;
+        rdfs:comment     "Saudi riyal." ;
+        rdfs:label       "SAR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SBD  rdf:type  cim:Currency ;
+        rdfs:comment     "Solomon Islands dollar." ;
+        rdfs:label       "SBD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SCR  rdf:type  cim:Currency ;
+        rdfs:comment     "Seychelles rupee." ;
+        rdfs:label       "SCR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SDG  rdf:type  cim:Currency ;
+        rdfs:comment     "Sudanese pound." ;
+        rdfs:label       "SDG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SEK  rdf:type  cim:Currency ;
+        rdfs:comment     "Swedish krona/kronor." ;
+        rdfs:label       "SEK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SGD  rdf:type  cim:Currency ;
+        rdfs:comment     "Singapore dollar." ;
+        rdfs:label       "SGD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SHP  rdf:type  cim:Currency ;
+        rdfs:comment     "Saint Helena pound." ;
+        rdfs:label       "SHP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SLL  rdf:type  cim:Currency ;
+        rdfs:comment     "Sierra Leonean leone." ;
+        rdfs:label       "SLL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SOS  rdf:type  cim:Currency ;
+        rdfs:comment     "Somali shilling." ;
+        rdfs:label       "SOS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SRD  rdf:type  cim:Currency ;
+        rdfs:comment     "Surinamese dollar." ;
+        rdfs:label       "SRD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.STD  rdf:type  cim:Currency ;
+        rdfs:comment     "São Tomé and Príncipe dobra." ;
+        rdfs:label       "STD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SYP  rdf:type  cim:Currency ;
+        rdfs:comment     "Syrian pound." ;
+        rdfs:label       "SYP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SZL  rdf:type  cim:Currency ;
+        rdfs:comment     "Lilangeni." ;
+        rdfs:label       "SZL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.THB  rdf:type  cim:Currency ;
+        rdfs:comment     "Thai baht." ;
+        rdfs:label       "THB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TJS  rdf:type  cim:Currency ;
+        rdfs:comment     "Tajikistani somoni." ;
+        rdfs:label       "TJS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TMT  rdf:type  cim:Currency ;
+        rdfs:comment     "Turkmenistani manat." ;
+        rdfs:label       "TMT"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TND  rdf:type  cim:Currency ;
+        rdfs:comment     "Tunisian dinar." ;
+        rdfs:label       "TND"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TOP  rdf:type  cim:Currency ;
+        rdfs:comment     "Tongan pa'anga." ;
+        rdfs:label       "TOP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TRY  rdf:type  cim:Currency ;
+        rdfs:comment     "Turkish lira." ;
+        rdfs:label       "TRY"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TTD  rdf:type  cim:Currency ;
+        rdfs:comment     "Trinidad and Tobago dollar." ;
+        rdfs:label       "TTD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TWD  rdf:type  cim:Currency ;
+        rdfs:comment     "New Taiwan dollar." ;
+        rdfs:label       "TWD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TZS  rdf:type  cim:Currency ;
+        rdfs:comment     "Tanzanian shilling." ;
+        rdfs:label       "TZS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.UAH  rdf:type  cim:Currency ;
+        rdfs:comment     "Ukrainian hryvnia." ;
+        rdfs:label       "UAH"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.UGX  rdf:type  cim:Currency ;
+        rdfs:comment     "Ugandan shilling." ;
+        rdfs:label       "UGX"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.USD  rdf:type  cim:Currency ;
+        rdfs:comment     "United States dollar." ;
+        rdfs:label       "USD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.UYU  rdf:type  cim:Currency ;
+        rdfs:comment     "Uruguayan peso." ;
+        rdfs:label       "UYU"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.UZS  rdf:type  cim:Currency ;
+        rdfs:comment     "Uzbekistan som." ;
+        rdfs:label       "UZS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.VEF  rdf:type  cim:Currency ;
+        rdfs:comment     "Venezuelan bolívar fuerte." ;
+        rdfs:label       "VEF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.VND  rdf:type  cim:Currency ;
+        rdfs:comment     "Vietnamese Dong." ;
+        rdfs:label       "VND"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.VUV  rdf:type  cim:Currency ;
+        rdfs:comment     "Vanuatu vatu." ;
+        rdfs:label       "VUV"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.WST  rdf:type  cim:Currency ;
+        rdfs:comment     "Samoan tala." ;
+        rdfs:label       "WST"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.XAF  rdf:type  cim:Currency ;
+        rdfs:comment     "CFA franc BEAC." ;
+        rdfs:label       "XAF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.XCD  rdf:type  cim:Currency ;
+        rdfs:comment     "East Caribbean dollar." ;
+        rdfs:label       "XCD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.XOF  rdf:type  cim:Currency ;
+        rdfs:comment     "CFA Franc BCEAO." ;
+        rdfs:label       "XOF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.XPF  rdf:type  cim:Currency ;
+        rdfs:comment     "CFP franc." ;
+        rdfs:label       "XPF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.YER  rdf:type  cim:Currency ;
+        rdfs:comment     "Yemeni rial." ;
+        rdfs:label       "YER"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ZAR  rdf:type  cim:Currency ;
+        rdfs:comment     "South African rand." ;
+        rdfs:label       "ZAR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ZMK  rdf:type  cim:Currency ;
+        rdfs:comment     "Zambian kwacha." ;
+        rdfs:label       "ZMK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ZWL  rdf:type  cim:Currency ;
+        rdfs:comment     "Zimbabwe dollar." ;
+        rdfs:label       "ZWL"@en ;
+        cims:stereotype  "enum" .
+
+cim:DCTerminal  rdf:type        rdfs:Class ;
+        rdfs:comment            "An electrical connection point to generic DC conducting equipment." ;
+        rdfs:label              "DCTerminal"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:Date  rdf:type              rdfs:Class ;
+        rdfs:comment            "Date as \"yyyy-mm-dd\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddZ\". A local timezone relative UTC is specified as \"yyyy-mm-dd(+/-)hh:mm\"." ;
+        rdfs:label              "Date"@en ;
+        cims:belongsToCategory  ra:Package_DocRemedialActionProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:DateTime  rdf:type          rdfs:Class ;
+        rdfs:comment            "Date and time as \"yyyy-mm-ddThh:mm:ss.sss\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddThh:mm:ss.sssZ\". A local timezone relative UTC is specified as \"yyyy-mm-ddThh:mm:ss.sss-hh:mm\". The second component (shown here as \"ss.sss\") could have any number of digits in its fractional part to allow any kind of precision beyond seconds." ;
+        rdfs:label              "DateTime"@en ;
+        cims:belongsToCategory  ra:Package_DocRemedialActionProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Duration  rdf:type          rdfs:Class ;
+        rdfs:comment            "Duration as \"PnYnMnDTnHnMnS\" which conforms to ISO 8601, where nY expresses a number of years, nM a number of months, nD a number of days. The letter T separates the date expression from the time expression and, after it, nH identifies a number of hours, nM a number of minutes and nS a number of seconds. The number of seconds could be expressed as a decimal number, but all other numbers are integers." ;
+        rdfs:label              "Duration"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:EnergyConsumer  rdf:type    rdfs:Class ;
+        rdfs:comment            "Generic user of energy - a  point of consumption on the power system model.\nEnergyConsumer.pfixed, .qfixed, .pfixedPct and .qfixedPct have meaning only if there is no LoadResponseCharacteristic associated with EnergyConsumer or if LoadResponseCharacteristic.exponentModel is set to False." ;
+        rdfs:label              "EnergyConsumer"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:EnergySource  rdf:type      rdfs:Class ;
+        rdfs:comment            "A generic equivalent for an energy supplier on a transmission or distribution voltage level." ;
+        rdfs:label              "EnergySource"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:Equipment  rdf:type         rdfs:Class ;
+        rdfs:comment            "The parts of a power system that are physical devices, electronic or mechanical." ;
+        rdfs:label              "Equipment"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:EquivalentInjection
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "This class represents equivalent injections (generation or load).  Voltage regulation is allowed only at the point of connection." ;
+        rdfs:label              "EquivalentInjection"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:ExternalNetworkInjection
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "This class represents the external network and it is used for IEC 60909 calculations." ;
+        rdfs:label              "ExternalNetworkInjection"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:Float  rdf:type             rdfs:Class ;
+        rdfs:comment            "A floating point number. The range is unspecified and not limited." ;
+        rdfs:label              "Float"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:IdentifiedObject  rdf:type  rdfs:Class ;
+        rdfs:comment            "This is a root class to provide common identification for all classes needing identification and naming attributes." ;
+        rdfs:label              "IdentifiedObject"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:IdentifiedObject.description
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The description is a free human readable text describing or naming the object. It may be non unique and may not correlate to a naming hierarchy." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "description"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.name
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The name is any free human readable and possibly non unique text naming the object." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "name"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Integer  rdf:type           rdfs:Class ;
+        rdfs:comment            "An integer number. The range is unspecified and not limited." ;
+        rdfs:label              "Integer"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Line  rdf:type              rdfs:Class ;
+        rdfs:comment            "Contains equipment beyond a substation belonging to a power transmission line. " ;
+        rdfs:label              "Line"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:Measurement  rdf:type       rdfs:Class ;
+        rdfs:comment            "A Measurement represents any measured, calculated or non-measured non-calculated quantity. Any piece of equipment may contain Measurements, e.g. a substation may have temperature measurements and door open indications, a transformer may have oil temperature and tank pressure measurements, a bay may contain a number of power flow measurements and a Breaker may contain a switch status measurement. \nThe PSR - Measurement association is intended to capture this use of Measurement and is included in the naming hierarchy based on EquipmentContainer. The naming hierarchy typically has Measurements as leaves, e.g. Substation-VoltageLevel-Bay-Switch-Measurement.\nSome Measurements represent quantities related to a particular sensor location in the network, e.g. a voltage transformer (VT) or potential transformer (PT) at a busbar or a current transformer (CT) at the bar between a breaker and an isolator. The sensing position is not captured in the PSR - Measurement association. Instead it is captured by the Measurement - Terminal association that is used to define the sensing location in the network topology. The location is defined by the connection of the Terminal to ConductingEquipment. \nIf both a Terminal and PSR are associated, and the PSR is of type ConductingEquipment, the associated Terminal should belong to that ConductingEquipment instance.\nWhen the sensor location is needed both Measurement-PSR and Measurement-Terminal are used. The Measurement-Terminal association is never used alone." ;
+        rdfs:label              "Measurement"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:OperationalLimit  rdf:type  rdfs:Class ;
+        rdfs:comment            "A value and normal value associated with a specific kind of limit. \nThe sub class value and normalValue attributes vary inversely to the associated OperationalLimitType.acceptableDuration (acceptableDuration for short).  \nIf a particular piece of equipment has multiple operational limits of the same kind (apparent power, current, etc.), the limit with the greatest acceptableDuration shall have the smallest limit value and the limit with the smallest acceptableDuration shall have the largest limit value.  Note: A large current can only be allowed to flow through a piece of equipment for a short duration without causing damage, but a lesser current can be allowed to flow for a longer duration. " ;
+        rdfs:label              "OperationalLimit"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:PerCent  rdf:type           rdfs:Class ;
+        rdfs:comment            "Percentage on a defined base.   For example, specify as 100 to indicate at the defined base." ;
+        rdfs:label              "PerCent"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:PerCent.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent.value  rdf:type  rdf:Property ;
+        rdfs:comment       "Normally 0 to 100 on a defined base." ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PinTerminalKind  rdf:type   rdfs:Class ;
+        rdfs:comment            "Categorisation of type of compare done on Terminal." ;
+        rdfs:label              "PinTerminalKind"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:PinTerminalKind.activePower
+        rdf:type         cim:PinTerminalKind ;
+        rdfs:comment     "Active Power on the Terminal." ;
+        rdfs:label       "activePower"@en ;
+        cims:stereotype  "enum" .
+
+cim:PinTerminalKind.apparentPower
+        rdf:type         cim:PinTerminalKind ;
+        rdfs:comment     "Apparent Power on the Terminal." ;
+        rdfs:label       "apparentPower"@en ;
+        cims:stereotype  "enum" .
+
+cim:PinTerminalKind.reactivePower
+        rdf:type         cim:PinTerminalKind ;
+        rdfs:comment     "Reactive Power on the Terminal." ;
+        rdfs:label       "reactivePower"@en ;
+        cims:stereotype  "enum" .
+
+cim:PinTerminalKind.voltage
+        rdf:type         cim:PinTerminalKind ;
+        rdfs:comment     "Voltage on the Terminal." ;
+        rdfs:label       "voltage"@en ;
+        cims:stereotype  "enum" .
+
+cim:PowerElectronicsConnection
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A connection to the AC network for energy production or consumption that uses power electronics rather than rotating machines." ;
+        rdfs:label              "PowerElectronicsConnection"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:PowerSystemResource
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A power system resource (PSR) can be an item of equipment such as a switch, an equipment container containing many individual items of equipment such as a substation, or an organisational entity such as sub-control area. Power system resources can have measurements associated." ;
+        rdfs:label              "PowerSystemResource"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:ReactivePower  rdf:type     rdfs:Class ;
+        rdfs:comment            "Product of RMS value of the voltage and the RMS value of the quadrature component of the current." ;
+        rdfs:label              "ReactivePower"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:ReactivePower.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ReactivePower ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ReactivePower.unit
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ReactivePower ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "VAr" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ReactivePower.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ReactivePower ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:RegulatingControl
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Specifies a set of equipment that works together to control a power system quantity such as voltage or flow. \nRemote bus voltage control is possible by specifying the controlled terminal located at some place remote from the controlling equipment.\nThe specified terminal shall be associated with the connectivity node of the controlled point.  The most specific subtype of RegulatingControl shall be used in case such equipment participate in the control, e.g. TapChangerControl for tap changers.\nFor flow control, load sign convention is used, i.e. positive sign means flow out from a TopologicalNode (bus) into the conducting equipment.\nThe attribute minAllowedTargetValue and maxAllowedTargetValue are required in the following cases:\n- For a power generating module operated in power factor control mode to specify maximum and minimum power factor values;\n- Whenever it is necessary to have an off center target voltage for the tap changer regulator. For instance, due to long cables to off shore wind farms and the need to have a simpler setup at the off shore transformer platform, the voltage is controlled from the land at the connection point for the off shore wind farm. Since there usually is a voltage rise along the cable, there is typical and overvoltage of up 3-4 kV compared to the on shore station. Thus in normal operation the tap changer on the on shore station is operated with a target set point, which is in the lower parts of the dead band.\nThe attributes minAllowedTargetValue and maxAllowedTargetValue are not related to the attribute targetDeadband and thus they are not treated as an alternative of the targetDeadband. They are needed due to limitations in the local substation controller. The attribute targetDeadband is used to prevent the power flow from move the tap position in circles (hunting) that is to be used regardless of the attributes minAllowedTargetValue and maxAllowedTargetValue." ;
+        rdfs:label              "RegulatingControl"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:RotatingMachine  rdf:type   rdfs:Class ;
+        rdfs:comment            "A rotating machine which may be used as a generator or motor." ;
+        rdfs:label              "RotatingMachine"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:Seconds  rdf:type           rdfs:Class ;
+        rdfs:comment            "Time, in seconds." ;
+        rdfs:label              "Seconds"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Seconds.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:Seconds ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Seconds.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Seconds ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "s" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Seconds.value  rdf:type  rdf:Property ;
+        rdfs:comment       "Time, in seconds" ;
+        rdfs:domain        cim:Seconds ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ShuntCompensator  rdf:type  rdfs:Class ;
+        rdfs:comment            "A shunt capacitor or reactor or switchable bank of shunt capacitors or reactors. A section of a shunt compensator is an individual capacitor or reactor. A negative value for bPerSection indicates that the compensator is a reactor. ShuntCompensator is a single terminal device.  Ground is implied." ;
+        rdfs:label              "ShuntCompensator"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:StaticVarCompensator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A facility for providing variable and controllable shunt reactive power. The SVC typically consists of a stepdown transformer, filter, thyristor-controlled reactor, and thyristor-switched capacitor arms.\n\nThe SVC may operate in fixed MVar output mode or in voltage control mode. When in voltage control mode, the output of the SVC will be proportional to the deviation of voltage at the controlled bus from the voltage setpoint.  The SVC characteristic slope defines the proportion.  If the voltage at the controlled bus is equal to the voltage setpoint, the SVC MVar output is zero." ;
+        rdfs:label              "StaticVarCompensator"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:String  rdf:type            rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited." ;
+        rdfs:label              "String"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Substation  rdf:type        rdfs:Class ;
+        rdfs:comment            "A collection of equipment for purposes other than generation or utilization, through which electric energy in bulk is passed for the purposes of switching or modifying its characteristics. " ;
+        rdfs:label              "Substation"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:Switch  rdf:type            rdfs:Class ;
+        rdfs:comment            "A generic device designed to close, or open, or both, one or more electric circuits.  All switches are two terminal devices including grounding switches. The ACDCTerminal.connected at the two sides of the switch shall not be considered for assessing switch connectivity, i.e. only Switch.open, .normalOpen and .locked are relevant." ;
+        rdfs:label              "Switch"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:TapChanger  rdf:type        rdfs:Class ;
+        rdfs:comment            "Mechanism for changing transformer winding tap positions." ;
+        rdfs:label              "TapChanger"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:Terminal  rdf:type          rdfs:Class ;
+        rdfs:comment            "An AC electrical connection point to a piece of conducting equipment. Terminals are connected at physical connection points called connectivity nodes." ;
+        rdfs:label              "Terminal"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile .
+
+cim:UnitMultiplier  rdf:type    rdfs:Class ;
+        rdfs:comment            "The unit multipliers defined for the CIM.  When applied to unit symbols, the unit symbol is treated as a derived unit. Regardless of the contents of the unit symbol text, the unit symbol shall be treated as if it were a single-character unit symbol. Unit symbols should not contain multipliers, and it should be left to the multiplier to define the multiple for an entire data type. \n\nFor example, if a unit symbol is \"m2Pers\" and the multiplier is \"k\", then the value is k(m**2/s), and the multiplier applies to the entire final value, not to any individual part of the value. This can be conceptualized by substituting a derived unit symbol for the unit type. If one imagines that the symbol \"Þ\" represents the derived unit \"m2Pers\", then applying the multiplier \"k\" can be conceptualized simply as \"kÞ\".\n\nFor example, the SI unit for mass is \"kg\" and not \"g\".  If the unit symbol is defined as \"kg\", then the multiplier is applied to \"kg\" as a whole and does not replace the \"k\" in front of the \"g\". In this case, the multiplier of \"m\" would be used with the unit symbol of \"kg\" to represent one gram.  As a text string, this violates the instructions in IEC 80000-1. However, because the unit symbol in CIM is treated as a derived unit instead of as an SI unit, it makes more sense to conceptualize the \"kg\" as if it were replaced by one of the proposed replacements for the SI mass symbol. If one imagines that the \"kg\" were replaced by a symbol \"Þ\", then it is easier to conceptualize the multiplier \"m\" as creating the proper unit \"mÞ\", and not the forbidden unit \"mkg\"." ;
+        rdfs:label              "UnitMultiplier"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitMultiplier.M  rdf:type  cim:UnitMultiplier ;
+        rdfs:comment     "Mega 10**6." ;
+        rdfs:label       "M"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitMultiplier.none
+        rdf:type         cim:UnitMultiplier ;
+        rdfs:comment     "No multiplier or equivalently multiply by 1." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol  rdf:type        rdfs:Class ;
+        rdfs:comment            "The derived units defined for usage in the CIM. In some cases, the derived unit is equal to an SI unit. Whenever possible, the standard derived symbol is used instead of the formula for the derived unit. For example, the unit symbol Farad is defined as \"F\" instead of \"CPerV\". In cases where a standard symbol does not exist for a derived unit, the formula for the unit is used as the unit symbol. For example, density does not have a standard symbol and so it is represented as \"kgPerm3\". With the exception of the \"kg\", which is an SI unit, the unit symbols do not contain multipliers and therefore represent the base derived unit to which a multiplier can be applied as a whole. \nEvery unit symbol is treated as an unparseable text as if it were a single-letter symbol. The meaning of each unit symbol is defined by the accompanying descriptive text and not by the text contents of the unit symbol.\nTo allow the widest possible range of serializations without requiring special character handling, several substitutions are made which deviate from the format described in IEC 80000-1. The division symbol \"/\" is replaced by the letters \"Per\". Exponents are written in plain text after the unit as \"m3\" instead of being formatted as \"m\" with a superscript of 3  or introducing a symbol as in \"m^3\". The degree symbol \"°\" is replaced with the letters \"deg\". Any clarification of the meaning for a substitution is included in the description for the unit symbol.\nNon-SI units are included in list of unit symbols to allow sources of data to be correctly labelled with their non-SI units (for example, a GPS sensor that is reporting numbers that represent feet instead of meters). This allows software to use the unit symbol information correctly convert and scale the raw data of those sources into SI-based units. \nThe integer values are used for harmonization with IEC 61850." ;
+        rdfs:label              "UnitSymbol"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitSymbol.VAr  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Reactive power in volt amperes reactive. The “reactive” or “imaginary” component of electrical power (VIsin(phi)). (See also real power and apparent power).\nNote: Different meter designs use different methods to arrive at their results. Some meters may compute reactive power as an arithmetic value, while others compute the value vectorially. The data consumer should determine the method in use and the suitability of the measurement for the intended purpose." ;
+        rdfs:label       "VAr"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.W  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Real power in watts (J/s). Electrical power may have real and reactive components. The real portion of electrical power (I&#178;R or VIcos(phi)), is expressed in Watts. See also apparent power and reactive power." ;
+        rdfs:label       "W"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.none  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Dimension less quantity, e.g. count, per unit, etc." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.s  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Time in seconds." ;
+        rdfs:label       "s"@en ;
+        cims:stereotype  "enum" .
+
+nc:ACDCConverter.DCConverterAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The action that is applied to an ACDCConverter." ;
+        rdfs:domain           cim:ACDCConverter ;
+        rdfs:label            "DCConverterAction"@en ;
+        rdfs:range            nc:ACDCConverterAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ACDCConverterAction.ACDCConverter ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ACDCConverterAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Alternate current Direct current (ACDC) converter action." ;
+        rdfs:label              "ACDCConverterAction"@en ;
+        rdfs:subClassOf         nc:SetPointAction ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ACDCConverterAction.ACDCConverter
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The ACDCConverter that is associated with an action." ;
+        rdfs:domain           nc:ACDCConverterAction ;
+        rdfs:label            "ACDCConverter"@en ;
+        rdfs:range            cim:ACDCConverter ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ACDCConverter.DCConverterAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilityRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Availability remedial action is a remedial action that cancels or reschedules an availability schedule." ;
+        rdfs:label              "AvailabilityRemedialAction"@en ;
+        rdfs:subClassOf         nc:RemedialAction ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:BatteryUnit.BatteryUnitAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The action that is applied to a BatteryUnit." ;
+        rdfs:domain           cim:BatteryUnit ;
+        rdfs:label            "BatteryUnitAction"@en ;
+        rdfs:range            nc:BatteryUnitAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:BatteryUnitAction.BatteryUnit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:BatteryUnitAction  rdf:type  rdfs:Class ;
+        rdfs:comment            "Battery unit setpoint action." ;
+        rdfs:label              "BatteryUnitAction"@en ;
+        rdfs:subClassOf         nc:SetPointAction ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:BatteryUnitAction.BatteryUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The BatteryUnit that is associated with an action." ;
+        rdfs:domain           nc:BatteryUnitAction ;
+        rdfs:label            "BatteryUnit"@en ;
+        rdfs:range            cim:BatteryUnit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:BatteryUnit.BatteryUnitAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:BiddingZone  rdf:type        rdfs:Class ;
+        rdfs:comment            "A bidding zone is a market-based method for handling power transmission congestion. It consists of scheduling areas that include the relevant production (supply) and consumption (demand) to form an electrical area with the same market price without capacity allocation." ;
+        rdfs:label              "BiddingZone"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" .
+
+nc:BiddingZone.BiddingZoneAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The bidding zone action that relates to this bidding zone." ;
+        rdfs:domain           nc:BiddingZone ;
+        rdfs:label            "BiddingZoneAction"@en ;
+        rdfs:range            nc:BiddingZoneAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:BiddingZoneAction.BiddingZone ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:BiddingZone.PowerRemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The power remedial action applied to this BiddingZone." ;
+        rdfs:domain           nc:BiddingZone ;
+        rdfs:label            "PowerRemedialAction"@en ;
+        rdfs:range            nc:PowerRemedialAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerRemedialAction.BiddingZone ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:BiddingZoneAction  rdf:type  rdfs:Class ;
+        rdfs:comment            "Bidding zone set point action." ;
+        rdfs:label              "BiddingZoneAction"@en ;
+        rdfs:subClassOf         nc:SetPointAction ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:BiddingZoneAction.BiddingZone
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The bidding zone that has this bidding zone action." ;
+        rdfs:domain           nc:BiddingZoneAction ;
+        rdfs:label            "BiddingZone"@en ;
+        rdfs:range            nc:BiddingZone ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:BiddingZone.BiddingZoneAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:BiddingZoneBorder  rdf:type  rdfs:Class ;
+        rdfs:comment            "Defines the aggregated connection capacity between two Bidding Zones." ;
+        rdfs:label              "BiddingZoneBorder"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" .
+
+nc:BiddingZoneBorder.PowerRemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power remedial action applied to this Bidding Zone Border." ;
+        rdfs:domain           nc:BiddingZoneBorder ;
+        rdfs:label            "PowerRemedialAction"@en ;
+        rdfs:range            nc:PowerRemedialAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerRemedialAction.BiddingZoneBorder ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:CalculationKind  rdf:type    rdfs:Class ;
+        rdfs:comment            "Kind of calculation operation that can be done to Measurement." ;
+        rdfs:label              "CalculationKind"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:CalculationKind.division
+        rdf:type         nc:CalculationKind ;
+        rdfs:comment     "Division operation on the input values (operands)." ;
+        rdfs:label       "division"@en ;
+        cims:stereotype  "enum" .
+
+nc:CalculationKind.multiplication
+        rdf:type         nc:CalculationKind ;
+        rdfs:comment     "Multiplication operation on the input values (operands)." ;
+        rdfs:label       "multiplication"@en ;
+        cims:stereotype  "enum" .
+
+nc:CalculationKind.squareRoot
+        rdf:type         nc:CalculationKind ;
+        rdfs:comment     "Square root operator - only one input value (operands)." ;
+        rdfs:label       "squareRoot"@en ;
+        cims:stereotype  "enum" .
+
+nc:CalculationKind.summation
+        rdf:type         nc:CalculationKind ;
+        rdfs:comment     "Summation operation on the input values (operands)." ;
+        rdfs:label       "summation"@en ;
+        cims:stereotype  "enum" .
+
+nc:Contingency.ContingencyWithRemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The contingency and remedial action combination for this contingency." ;
+        rdfs:domain           cim:Contingency ;
+        rdfs:label            "ContingencyWithRemedialAction"@en ;
+        rdfs:range            nc:ContingencyWithRemedialAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ContingencyWithRemedialAction.Contingency ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Contingency.PinContingency
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The pin that uses this input." ;
+        rdfs:domain           cim:Contingency ;
+        rdfs:label            "PinContingency"@en ;
+        rdfs:range            nc:PinContingency ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PinContingency.Contingency ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ContingencyWithRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Combination of a contingency and a remedial action. ContingencyWithRemedialAction shall not be instantiated for preventive RemedialAction (RemedialAction.kind equals RemedialActionKind.preventive)." ;
+        rdfs:label              "ContingencyWithRemedialAction"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ContingencyWithRemedialAction.Contingency
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The contingency that is associated with a remedial action, i.e. the contingency that is the cause for the creation of a remedial action and justifies it or would usually be resolved with a remedial action." ;
+        rdfs:domain           nc:ContingencyWithRemedialAction ;
+        rdfs:label            "Contingency"@en ;
+        rdfs:range            cim:Contingency ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Contingency.ContingencyWithRemedialAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:ContingencyWithRemedialAction.RemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The remedial action defined for this contingency and remedial action combination." ;
+        rdfs:domain           nc:ContingencyWithRemedialAction ;
+        rdfs:label            "RemedialAction"@en ;
+        rdfs:range            nc:RemedialAction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialAction.ContingencyWithRemedialAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:ContingencyWithRemedialAction.combinationConstraintKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Defines the combination constraint of the Contingency and Remedial Action. If included, this remedial action can only be applied for this contingency. Else if excluded, this remedial action should not be used for this contingency. Else if considered, this remedial action can be considered for this contingency." ;
+        rdfs:domain        nc:ContingencyWithRemedialAction ;
+        rdfs:label         "combinationConstraintKind"@en ;
+        rdfs:range         nc:ElementCombinationConstraintKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ContingencyWithRemedialAction.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:ContingencyWithRemedialAction ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ContingencyWithRemedialAction.normalEnabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "If true, the contingency with remedial action is enabled, otherwise it is disabled under normal operating conditions." ;
+        rdfs:domain        nc:ContingencyWithRemedialAction ;
+        rdfs:label         "normalEnabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ControlFunctionBlock
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Control function block is a function block that contains an algorithm for controlling the equipment." ;
+        rdfs:label              "ControlFunctionBlock"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" .
+
+nc:ControlFunctionBlock.ControlFunctionBlockAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The action that is applied to this control function block." ;
+        rdfs:domain           nc:ControlFunctionBlock ;
+        rdfs:label            "ControlFunctionBlockAction"@en ;
+        rdfs:range            nc:ControlFunctionBlockAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ControlFunctionBlockAction.ControlFunctionBlock ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ControlFunctionBlockAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Action for setting the control function block target values." ;
+        rdfs:label              "ControlFunctionBlockAction"@en ;
+        rdfs:subClassOf         nc:SetPointAction ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ControlFunctionBlockAction.ControlFunctionBlock
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The control function block that is associated with a ControlFunctionBlockAction." ;
+        rdfs:domain           nc:ControlFunctionBlockAction ;
+        rdfs:label            "ControlFunctionBlock"@en ;
+        rdfs:range            nc:ControlFunctionBlock ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ControlFunctionBlock.ControlFunctionBlockAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:CountertradeRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Countertrade is a remedial action to relieve physical congestions where the location of activated resources within the bidding zone is not known." ;
+        rdfs:label              "CountertradeRemedialAction"@en ;
+        rdfs:subClassOf         nc:PowerRemedialAction ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:CountertradeRemedialAction.maxEconomicPMargin
+        rdf:type           rdf:Property ;
+        rdfs:comment       "High economic active power limit given by the percentage of the relevant units operating p.   e.g. If a generating unit (G1) with maximum operating active power of 100 MW and a conform load with active maximum load of 50 MW (L1). Max economic p margin of 90% will give the limit of the shift key to be 90 MW for the G1 and 45 MW for the L1.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:CountertradeRemedialAction ;
+        rdfs:label         "maxEconomicPMargin"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CountertradeRemedialAction.minEconomicPMargin
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Low economic active power limit given by the percentage of the relevant units operating p.   e.g. If a generating unit (G1) with minimum operating active power of 10 MW and a conform load with active maximum load of 5 MW (L1). Min economic p margin of 90%  will give the limit of the shift key to be 11 MW for the G1 and 5.5 MW for the L1.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:CountertradeRemedialAction ;
+        rdfs:label         "minEconomicPMargin"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCTerminal.PinDCTerminal
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The pin DC terminal for this DC terminal." ;
+        rdfs:domain           cim:DCTerminal ;
+        rdfs:label            "PinDCTerminal"@en ;
+        rdfs:range            nc:PinDCTerminal ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PinDCTerminal.DCTerminal ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ElementCombinationConstraintKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of constraint for an element combination." ;
+        rdfs:label              "ElementCombinationConstraintKind"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:ElementCombinationConstraintKind.considered
+        rdf:type         nc:ElementCombinationConstraintKind ;
+        rdfs:comment     "Element combination can be considered." ;
+        rdfs:label       "considered"@en ;
+        cims:stereotype  "enum" .
+
+nc:ElementCombinationConstraintKind.excluded
+        rdf:type         nc:ElementCombinationConstraintKind ;
+        rdfs:comment     "Element combination is excluded." ;
+        rdfs:label       "excluded"@en ;
+        cims:stereotype  "enum" .
+
+nc:ElementCombinationConstraintKind.included
+        rdf:type         nc:ElementCombinationConstraintKind ;
+        rdfs:comment     "Element combination is included." ;
+        rdfs:label       "included"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyConsumer.LoadAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The action appled to an EnergyConsumer." ;
+        rdfs:domain           cim:EnergyConsumer ;
+        rdfs:label            "LoadAction"@en ;
+        rdfs:range            nc:LoadAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:LoadAction.EnergyConsumer ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EnergySource.EnergySourceAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The energy source action applied to an EnergySource." ;
+        rdfs:domain           cim:EnergySource ;
+        rdfs:label            "EnergySourceAction"@en ;
+        rdfs:range            nc:EnergySourceModification ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EnergySourceModification.EnergySource ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EnergySourceModification
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Energy source action." ;
+        rdfs:label              "EnergySourceModification"@en ;
+        rdfs:subClassOf         nc:SetPointAction ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EnergySourceModification.EnergySource
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The EnergySource which is associated with an EnergySourceAction." ;
+        rdfs:domain           nc:EnergySourceModification ;
+        rdfs:label            "EnergySource"@en ;
+        rdfs:range            cim:EnergySource ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EnergySource.EnergySourceAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:Equipment.PinEquipment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The pin that uses this input." ;
+        rdfs:domain           cim:Equipment ;
+        rdfs:label            "PinEquipment"@en ;
+        rdfs:range            nc:PinEquipment ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PinEquipment.Equipment ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Equipment.PinEquipmentTripping
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Pin equipment that is used as gate input." ;
+        rdfs:domain           cim:Equipment ;
+        rdfs:label            "PinEquipmentTripping"@en ;
+        rdfs:range            nc:PinEquipmentTripping ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PinEquipmentTripping.Equipment ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EquipmentController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Equipment controller is an automation function that can control one or multiple equipment function to achieve all the targets inside the given tolerance. " ;
+        rdfs:label              "EquipmentController"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" .
+
+nc:EquipmentController.EquipmentControllerAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Equipment controller action for this equipment controller." ;
+        rdfs:domain           nc:EquipmentController ;
+        rdfs:label            "EquipmentControllerAction"@en ;
+        rdfs:range            nc:EquipmentControllerAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EquipmentControllerAction.EquipmentController ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EquipmentControllerAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Action for setting the equipment controller action." ;
+        rdfs:label              "EquipmentControllerAction"@en ;
+        rdfs:subClassOf         nc:SetPointAction ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EquipmentControllerAction.EquipmentController
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Equipment controller that has associated equipment controller actions." ;
+        rdfs:domain           nc:EquipmentControllerAction ;
+        rdfs:label            "EquipmentController"@en ;
+        rdfs:range            nc:EquipmentController ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EquipmentController.EquipmentControllerAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:EquivalentInjection.EquivalentInjectionAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The action that is applied to an EquivalentInjection." ;
+        rdfs:domain           cim:EquivalentInjection ;
+        rdfs:label            "EquivalentInjectionAction"@en ;
+        rdfs:range            nc:EquivalentInjectionAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EquivalentInjectionAction.EquivalentInjection ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EquivalentInjectionAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Equivalent injection action." ;
+        rdfs:label              "EquivalentInjectionAction"@en ;
+        rdfs:subClassOf         nc:SetPointAction ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EquivalentInjectionAction.EquivalentInjection
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The EquivalentInjection that is associated with an action." ;
+        rdfs:domain           nc:EquivalentInjectionAction ;
+        rdfs:label            "EquivalentInjection"@en ;
+        rdfs:range            cim:EquivalentInjection ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EquivalentInjection.EquivalentInjectionAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:ExternalNetworkInjection.ExternalNetworkInjectionAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The action that is applied to an ExternalNetworkInjection." ;
+        rdfs:domain           cim:ExternalNetworkInjection ;
+        rdfs:label            "ExternalNetworkInjectionAction"@en ;
+        rdfs:range            nc:ExternalNetworkInjectionAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ExternalNetworkInjectionAction.ExternalNetworkInjection ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ExternalNetworkInjectionAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "External network injection action." ;
+        rdfs:label              "ExternalNetworkInjectionAction"@en ;
+        rdfs:subClassOf         nc:SetPointAction ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ExternalNetworkInjectionAction.ExternalNetworkInjection
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The ExternalNetworkInjection that is associated with an action." ;
+        rdfs:domain           nc:ExternalNetworkInjectionAction ;
+        rdfs:label            "ExternalNetworkInjection"@en ;
+        rdfs:range            cim:ExternalNetworkInjection ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ExternalNetworkInjection.ExternalNetworkInjectionAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:FunctionInputVariable
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Functional input variable defines the domain of the function." ;
+        rdfs:label              "FunctionInputVariable"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" .
+
+nc:Gate  rdf:type               rdfs:Class ;
+        rdfs:comment            "Logical gate that supports a logical operation based on the input." ;
+        rdfs:label              "Gate"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:Gate.GateInputPin  rdf:type  rdf:Property ;
+        rdfs:comment          "This is the input to the gate." ;
+        rdfs:domain           nc:Gate ;
+        rdfs:label            "GateInputPin"@en ;
+        rdfs:range            nc:GateInputPin ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GateInputPin.Gate ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:Gate.PinGate  rdf:type     rdf:Property ;
+        rdfs:comment          "The pin for this gate output." ;
+        rdfs:domain           nc:Gate ;
+        rdfs:label            "PinGate"@en ;
+        rdfs:range            nc:PinGate ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PinGate.GateOutput ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Gate.RemedialActionScheme
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The remedial action scheme which has an armed gate." ;
+        rdfs:domain           nc:Gate ;
+        rdfs:label            "RemedialActionScheme"@en ;
+        rdfs:range            nc:RemedialActionScheme ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialActionScheme.GateArmed ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Gate.StageTrigger  rdf:type  rdf:Property ;
+        rdfs:comment          "The stage trigger associated with the gate trigger." ;
+        rdfs:domain           nc:Gate ;
+        rdfs:label            "StageTrigger"@en ;
+        rdfs:range            nc:StageTrigger ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:StageTrigger.GateTrigger ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Gate.StageTriggerArmed
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The stage trigger associated with the armed gate." ;
+        rdfs:domain           nc:Gate ;
+        rdfs:label            "StageTriggerArmed"@en ;
+        rdfs:range            nc:StageTrigger ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:StageTrigger.GateArmed ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Gate.StageTriggerCom
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The stage trigger associated with the communication gate." ;
+        rdfs:domain           nc:Gate ;
+        rdfs:label            "StageTriggerCom"@en ;
+        rdfs:range            nc:StageTrigger ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:StageTrigger.GateComCondition ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Gate.TriggerCondition
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The trigger condition that has a gate trigger." ;
+        rdfs:domain           nc:Gate ;
+        rdfs:label            "TriggerCondition"@en ;
+        rdfs:range            nc:TriggerCondition ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:TriggerCondition.GateTrigger ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Gate.kind  rdf:type     rdf:Property ;
+        rdfs:comment       "The logical operation of the gate." ;
+        rdfs:domain        nc:Gate ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         nc:GateLogicKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GateInputPin  rdf:type       rdfs:Class ;
+        rdfs:comment            "Input pin for a logical gate. The condition described in the input pin gives a logical true or false. The result from measurement and calculation are converted to a true or false." ;
+        rdfs:label              "GateInputPin"@en ;
+        rdfs:subClassOf         nc:FunctionInputVariable ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" .
+
+nc:GateInputPin.Gate  rdf:type  rdf:Property ;
+        rdfs:comment          "The Gate that has this input." ;
+        rdfs:domain           nc:GateInputPin ;
+        rdfs:label            "Gate"@en ;
+        rdfs:range            nc:Gate ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Gate.GateInputPin ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:GateInputPin.absoluteValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Indicates if the absolute value is used for comparison. If true, use the absolute value. If false, use the complex value (vector). " ;
+        rdfs:domain        nc:GateInputPin ;
+        rdfs:label         "absoluteValue"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GateInputPin.duration
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time duration for which the condition is satisfied before acting. Default is 0 seconds." ;
+        rdfs:domain        nc:GateInputPin ;
+        rdfs:label         "duration"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GateInputPin.isValuePreFault
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Indicates if the gate input pin value is referring to the value prior to a fault (e.g. simulated by a contingency or due to a SIPS activation in a N-x-y case). If it is true, it means that the value is referring to pre-fault. If it is false or not populated, then it is post-fault." ;
+        rdfs:domain        nc:GateInputPin ;
+        rdfs:label         "isValuePreFault"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GateInputPin.logicKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The logical operator kind used for comparison." ;
+        rdfs:domain        nc:GateInputPin ;
+        rdfs:label         "logicKind"@en ;
+        rdfs:range         nc:LogicalOperatorsKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GateInputPin.negate
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Invert/negate the result of the comparison." ;
+        rdfs:domain        nc:GateInputPin ;
+        rdfs:label         "negate"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GateInputPin.thresholdPercentage
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The threshold percentage that should be used for compare with the percentage change between input value and threshold value.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:GateInputPin ;
+        rdfs:label         "thresholdPercentage"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GateInputPin.thresholdValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The threshold value that should be used for compare with the input value." ;
+        rdfs:domain        nc:GateInputPin ;
+        rdfs:label         "thresholdValue"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GateLogicKind  rdf:type      rdfs:Class ;
+        rdfs:comment            "Define the different logical operations." ;
+        rdfs:label              "GateLogicKind"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:GateLogicKind.and  rdf:type  nc:GateLogicKind ;
+        rdfs:comment     "A logical AND operation. True when all inputs are true." ;
+        rdfs:label       "and"@en ;
+        cims:stereotype  "enum" .
+
+nc:GateLogicKind.nand
+        rdf:type         nc:GateLogicKind ;
+        rdfs:comment     "A logical NAND operation. False when all inputs are true." ;
+        rdfs:label       "nand"@en ;
+        cims:stereotype  "enum" .
+
+nc:GateLogicKind.nor  rdf:type  nc:GateLogicKind ;
+        rdfs:comment     "A logical NOR operation. False when one or more inputs are true." ;
+        rdfs:label       "nor"@en ;
+        cims:stereotype  "enum" .
+
+nc:GateLogicKind.not  rdf:type  nc:GateLogicKind ;
+        rdfs:comment     "A logical NOT operation. Only one input and true input will give false out and false in will give true out. An inverter." ;
+        rdfs:label       "not"@en ;
+        cims:stereotype  "enum" .
+
+nc:GateLogicKind.or  rdf:type  nc:GateLogicKind ;
+        rdfs:comment     "A logical OR operation. True when one or more inputs are true." ;
+        rdfs:label       "or"@en ;
+        cims:stereotype  "enum" .
+
+nc:GateLogicKind.xnor
+        rdf:type         nc:GateLogicKind ;
+        rdfs:comment     "A logical XNOR operation. The function is the inverse of the exclusive OR (XOR) gate. All input false or true will give true. Otherwise false." ;
+        rdfs:label       "xnor"@en ;
+        cims:stereotype  "enum" .
+
+nc:GateLogicKind.xor  rdf:type  nc:GateLogicKind ;
+        rdfs:comment     "A logical XOR operation.  All input false or true will give false. Otherwise true." ;
+        rdfs:label       "xor"@en ;
+        cims:stereotype  "enum" .
+
+nc:GridStateAlteration
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Grid state alteration is a change of values describing state (operating point) of one element in the grid model compared to the base case." ;
+        rdfs:label              "GridStateAlteration"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" .
+
+nc:GridStateAlteration.GridStateAlterationCollection
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The collection that has a GridStateAlteration." ;
+        rdfs:domain           nc:GridStateAlteration ;
+        rdfs:label            "GridStateAlterationCollection"@en ;
+        rdfs:range            nc:GridStateAlterationCollection ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GridStateAlterationCollection.GridStateAlteration ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:GridStateAlteration.GridStateAlterationRemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The grid state alteration remedial action associated with a given grid state alteration." ;
+        rdfs:domain           nc:GridStateAlteration ;
+        rdfs:label            "GridStateAlterationRemedialAction"@en ;
+        rdfs:range            nc:GridStateAlterationRemedialAction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GridStateAlterationRemedialAction.GridStateAlteration ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:GridStateAlteration.PropertyReference
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The property reference for this grid state alteration." ;
+        rdfs:domain           nc:GridStateAlteration ;
+        rdfs:label            "PropertyReference"@en ;
+        rdfs:range            nc:PropertyReference ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PropertyReference.GridStateAlteration ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:GridStateAlteration.RangeConstraint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The range constraint associated with a given GridStateAlteration." ;
+        rdfs:domain           nc:GridStateAlteration ;
+        rdfs:label            "RangeConstraint"@en ;
+        rdfs:range            nc:RangeConstraint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RangeConstraint.GridStateAlteration ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:GridStateAlteration.maximumPerDay
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum number of alterations per day." ;
+        rdfs:domain        nc:GridStateAlteration ;
+        rdfs:label         "maximumPerDay"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GridStateAlteration.minimumActivation
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Minimum time duration between activating the same grid state alteration." ;
+        rdfs:domain        nc:GridStateAlteration ;
+        rdfs:label         "minimumActivation"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GridStateAlteration.normalEnabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The default/normal value used when other active signal/values are missing." ;
+        rdfs:domain        nc:GridStateAlteration ;
+        rdfs:label         "normalEnabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GridStateAlteration.timePerStage
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Time to implement a stage of a grid state alteration. If a grid state alteration consists of multiple stages (e.g. A step on a power transformer), this duration comes in addition to the timeToImplement and need to be multiplied by the number of stages. A stage can also be defined as MW in the case of regulating production." ;
+        rdfs:domain        nc:GridStateAlteration ;
+        rdfs:label         "timePerStage"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GridStateAlterationCollection
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A collection of grid state alterations." ;
+        rdfs:label              "GridStateAlterationCollection"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:GridStateAlterationCollection.GridStateAlteration
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The GridStateAlteration that belongs to the collection." ;
+        rdfs:domain           nc:GridStateAlterationCollection ;
+        rdfs:label            "GridStateAlteration"@en ;
+        rdfs:range            nc:GridStateAlteration ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GridStateAlteration.GridStateAlterationCollection ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:GridStateAlterationCollection.StageAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The stage action related to this GridStateAlterationCollection." ;
+        rdfs:domain           nc:GridStateAlterationCollection ;
+        rdfs:label            "StageAction"@en ;
+        rdfs:range            nc:Stage ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:Stage.GridStateAlterationCollection ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:GridStateAlterationRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Grid state alteration remedial action describes one or many grid state alterations applied to a grid model state or a particular scenario in order to resolve one or more identified constraints. " ;
+        rdfs:label              "GridStateAlterationRemedialAction"@en ;
+        rdfs:subClassOf         nc:RemedialAction ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:GridStateAlterationRemedialAction.GridStateAlteration
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The grid state alteration which is part of the grid state alteration remedial action." ;
+        rdfs:domain           nc:GridStateAlterationRemedialAction ;
+        rdfs:label            "GridStateAlteration"@en ;
+        rdfs:range            nc:GridStateAlteration ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GridStateAlteration.GridStateAlterationRemedialAction ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:IntertemporalPropertyRange
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "It represents the intertemporal range, which means that this is the maximum change of an attribute value between two time stamps or per time unit (e.g. hour). Both up and down directions are defined by the direction attribute, i.e. There are different schedules per direction. \nThe class is not instantiated for PropertyReference which refers to Boolean type attributes. \nFor instance the following example illustrates the approach:\n- A tap changer related grid state alteration having two intertemporal range schedules.\n-   For a particular point in time, the value from up schedule is 6 and the value from down schedule is 3.\n- Then, the GridStateIntensity for the same point in time cannot be more than plus 6 taps from the current, or more than minus 3 taps from the current." ;
+        rdfs:label              "IntertemporalPropertyRange"@en ;
+        rdfs:subClassOf         nc:RangeConstraint ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:LoadAction  rdf:type         rdfs:Class ;
+        rdfs:comment            "Load action." ;
+        rdfs:label              "LoadAction"@en ;
+        rdfs:subClassOf         nc:SetPointAction ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:LoadAction.EnergyConsumer
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The EnergyConsumer that is associated with a load action." ;
+        rdfs:domain           nc:LoadAction ;
+        rdfs:label            "EnergyConsumer"@en ;
+        rdfs:range            cim:EnergyConsumer ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EnergyConsumer.LoadAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:LogicalOperatorsKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kinds of logical operators for comparison." ;
+        rdfs:label              "LogicalOperatorsKind"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:LogicalOperatorsKind.equals
+        rdf:type         nc:LogicalOperatorsKind ;
+        rdfs:comment     "Equals (like) comparison operation." ;
+        rdfs:label       "equals"@en ;
+        cims:stereotype  "enum" .
+
+nc:LogicalOperatorsKind.greaterThan
+        rdf:type         nc:LogicalOperatorsKind ;
+        rdfs:comment     "Greater than comparison operation." ;
+        rdfs:label       "greaterThan"@en ;
+        cims:stereotype  "enum" .
+
+nc:LogicalOperatorsKind.greaterThanOrEquals
+        rdf:type         nc:LogicalOperatorsKind ;
+        rdfs:comment     "Greater than or equals comparison operation." ;
+        rdfs:label       "greaterThanOrEquals"@en ;
+        cims:stereotype  "enum" .
+
+nc:LogicalOperatorsKind.lessThan
+        rdf:type         nc:LogicalOperatorsKind ;
+        rdfs:comment     "Less than comparison operation." ;
+        rdfs:label       "lessThan"@en ;
+        cims:stereotype  "enum" .
+
+nc:LogicalOperatorsKind.lessThanOrEquals
+        rdf:type         nc:LogicalOperatorsKind ;
+        rdfs:comment     "Less than or equals comparison operation." ;
+        rdfs:label       "lessThanOrEquals"@en ;
+        cims:stereotype  "enum" .
+
+nc:LogicalOperatorsKind.notEqual
+        rdf:type         nc:LogicalOperatorsKind ;
+        rdfs:comment     "Not equal (unlike) comparison operation." ;
+        rdfs:label       "notEqual"@en ;
+        cims:stereotype  "enum" .
+
+nc:Measurement.MeasurementCalculatorInput
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The calculator input used for this measurement." ;
+        rdfs:domain           cim:Measurement ;
+        rdfs:label            "MeasurementCalculatorInput"@en ;
+        rdfs:range            nc:MeasurementCalculatorInput ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:MeasurementCalculatorInput.Measurement ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Measurement.PinMeasurement
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The pin that uses this input." ;
+        rdfs:domain           cim:Measurement ;
+        rdfs:label            "PinMeasurement"@en ;
+        rdfs:range            nc:PinMeasurement ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PinMeasurement.Measurement ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:MeasurementCalculator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Result of a calculation of one or more measurement. " ;
+        rdfs:label              "MeasurementCalculator"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:MeasurementCalculator.MeasurementCalculatorInput
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The input used for the calculator." ;
+        rdfs:domain           nc:MeasurementCalculator ;
+        rdfs:label            "MeasurementCalculatorInput"@en ;
+        rdfs:range            nc:MeasurementCalculatorInput ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:MeasurementCalculatorInput.MeasurementCalculator ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:MeasurementCalculator.PinMeasurement
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The pin that uses this input." ;
+        rdfs:domain           nc:MeasurementCalculator ;
+        rdfs:label            "PinMeasurement"@en ;
+        rdfs:range            nc:PinMeasurement ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PinMeasurement.MeasurementCalculator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:MeasurementCalculator.kind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Calculation operation executed on the operands." ;
+        rdfs:domain        nc:MeasurementCalculator ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         nc:CalculationKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:MeasurementCalculatorInput
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Input to measurement calculation. It supports Analog, Discrete and Accumulator measurements." ;
+        rdfs:label              "MeasurementCalculatorInput"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:MeasurementCalculatorInput.Measurement
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Measurement used as input to a calculation." ;
+        rdfs:domain           nc:MeasurementCalculatorInput ;
+        rdfs:label            "Measurement"@en ;
+        rdfs:range            cim:Measurement ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Measurement.MeasurementCalculatorInput ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:MeasurementCalculatorInput.MeasurementCalculator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The measurement calculator using this calculator input." ;
+        rdfs:domain           nc:MeasurementCalculatorInput ;
+        rdfs:label            "MeasurementCalculator"@en ;
+        rdfs:range            nc:MeasurementCalculator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:MeasurementCalculator.MeasurementCalculatorInput ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:MeasurementCalculatorInput.absoluteValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Indicates if the absolute value is used for comparison. If true, use the absolute value. If false, use the complex value (vector). " ;
+        rdfs:domain        nc:MeasurementCalculatorInput ;
+        rdfs:label         "absoluteValue"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:MeasurementCalculatorInput.order
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Positive number that defines the order of the operand in the calculation. 0 means default in which case the order is not relevant." ;
+        rdfs:domain        nc:MeasurementCalculatorInput ;
+        rdfs:label         "order"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:OperationalLimit.PinOperationallLimit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The operational limit pin pin that uses this operational limit." ;
+        rdfs:domain           cim:OperationalLimit ;
+        rdfs:label            "PinOperationallLimit"@en ;
+        rdfs:range            nc:PinOperationalLimit ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PinOperationalLimit.OperationalLimit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PTCActivePowerSupport
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Defines the active power capability (support) of the scheme in relation to a PowerTransferCorridor." ;
+        rdfs:label              "PTCActivePowerSupport"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PTCActivePowerSupport.PowerTransferCorridor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The PowerTransferCorridor that has a specific active power support." ;
+        rdfs:domain           nc:PTCActivePowerSupport ;
+        rdfs:label            "PowerTransferCorridor"@en ;
+        rdfs:range            nc:PowerTransferCorridor ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerTransferCorridor.PTCActivePowerSupport ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PTCActivePowerSupport.RemedialActionScheme
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The RemedialActionScheme which has active power support from the PowerTransferCorridor." ;
+        rdfs:domain           nc:PTCActivePowerSupport ;
+        rdfs:label            "RemedialActionScheme"@en ;
+        rdfs:range            nc:RemedialActionScheme ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialActionScheme.PTCActivePowerSupport ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PTCActivePowerSupport.maximum
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum support that a System Integrity Protection Scheme (SIPS) can provide to a Power Transfer Corridor (PTC). This is normally limited by the maximum power system disconnect allowed." ;
+        rdfs:domain        nc:PTCActivePowerSupport ;
+        rdfs:label         "maximum"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PTCActivePowerSupport.normal
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Normal support that a System Integrity Protection Scheme (SIPS) is expected to provide when enabled to a Power Transfer Corridor (PTC)." ;
+        rdfs:domain        nc:PTCActivePowerSupport ;
+        rdfs:label         "normal"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PinContingency  rdf:type     rdfs:Class ;
+        rdfs:comment            "Input pin associated with a Contingency. It is used for comparison." ;
+        rdfs:label              "PinContingency"@en ;
+        rdfs:subClassOf         nc:GateInputPin ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PinContingency.Contingency
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The Contingency that is used in the input pin." ;
+        rdfs:domain           nc:PinContingency ;
+        rdfs:label            "Contingency"@en ;
+        rdfs:range            cim:Contingency ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Contingency.PinContingency ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PinDCTerminal  rdf:type      rdfs:Class ;
+        rdfs:comment            "Input pin associated with a DCTerminal. It is used for comparison." ;
+        rdfs:label              "PinDCTerminal"@en ;
+        rdfs:subClassOf         nc:GateInputPin ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PinDCTerminal.DCTerminal
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The DC terminal that has this pin DC terminal." ;
+        rdfs:domain           nc:PinDCTerminal ;
+        rdfs:label            "DCTerminal"@en ;
+        rdfs:range            cim:DCTerminal ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DCTerminal.PinDCTerminal ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PinDCTerminal.kind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The kind of quantity which is used as an input value." ;
+        rdfs:domain        nc:PinDCTerminal ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         nc:PinDCTerminalKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PinDCTerminalKind  rdf:type  rdfs:Class ;
+        rdfs:comment            "The kind of quantities that can serve as an input value for the DCTerminal pin." ;
+        rdfs:label              "PinDCTerminalKind"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:PinDCTerminalKind.current
+        rdf:type         nc:PinDCTerminalKind ;
+        rdfs:comment     "Direct current in the DCTerminal." ;
+        rdfs:label       "current"@en ;
+        cims:stereotype  "enum" .
+
+nc:PinDCTerminalKind.voltage
+        rdf:type         nc:PinDCTerminalKind ;
+        rdfs:comment     "Direct current voltage in the DCTerminal." ;
+        rdfs:label       "voltage"@en ;
+        cims:stereotype  "enum" .
+
+nc:PinEquipment  rdf:type       rdfs:Class ;
+        rdfs:comment            "Input pin associated with an Equipment. It is used for the comparison." ;
+        rdfs:label              "PinEquipment"@en ;
+        rdfs:subClassOf         nc:GateInputPin ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PinEquipment.Equipment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The Equipment that is used in the input pin." ;
+        rdfs:domain           nc:PinEquipment ;
+        rdfs:label            "Equipment"@en ;
+        rdfs:range            cim:Equipment ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Equipment.PinEquipment ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PinEquipment.PropertyReference
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The property reference for this pin equipment." ;
+        rdfs:domain           nc:PinEquipment ;
+        rdfs:label            "PropertyReference"@en ;
+        rdfs:range            nc:PropertyReference ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PropertyReference.PinEquipment ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PinEquipmentTripping
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Input pin associated with an Equipment. It is used to determine if the equipment is tripped between two consecutive stages, i.e. the equipment is in service at pre-fault stage and it is out of service at post-fault stage." ;
+        rdfs:label              "PinEquipmentTripping"@en ;
+        rdfs:subClassOf         nc:GateInputPin ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PinEquipmentTripping.Equipment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Equipment that is tripped." ;
+        rdfs:domain           nc:PinEquipmentTripping ;
+        rdfs:label            "Equipment"@en ;
+        rdfs:range            cim:Equipment ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Equipment.PinEquipmentTripping ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PinGate  rdf:type            rdfs:Class ;
+        rdfs:comment            "An output from one gate represents an input to another gate." ;
+        rdfs:label              "PinGate"@en ;
+        rdfs:subClassOf         nc:GateInputPin ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PinGate.GateOutput
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The output of the gate." ;
+        rdfs:domain           nc:PinGate ;
+        rdfs:label            "GateOutput"@en ;
+        rdfs:range            nc:Gate ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Gate.PinGate ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PinMeasurement  rdf:type     rdfs:Class ;
+        rdfs:comment            "Input pin associated with a Measurement. It is used for comparison." ;
+        rdfs:label              "PinMeasurement"@en ;
+        rdfs:subClassOf         nc:GateInputPin ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PinMeasurement.Measurement
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The Measurement that is used in the input pin." ;
+        rdfs:domain           nc:PinMeasurement ;
+        rdfs:label            "Measurement"@en ;
+        rdfs:range            cim:Measurement ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Measurement.PinMeasurement ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PinMeasurement.MeasurementCalculator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The result of the calculation used as input to a gate." ;
+        rdfs:domain           nc:PinMeasurement ;
+        rdfs:label            "MeasurementCalculator"@en ;
+        rdfs:range            nc:MeasurementCalculator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:MeasurementCalculator.PinMeasurement ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PinOperationalLimit
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Input pin associated with the limits of a Terminal. It is used for comparison." ;
+        rdfs:label              "PinOperationalLimit"@en ;
+        rdfs:subClassOf         nc:GateInputPin ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PinOperationalLimit.OperationalLimit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The operational limit that is used in the input pin." ;
+        rdfs:domain           nc:PinOperationalLimit ;
+        rdfs:label            "OperationalLimit"@en ;
+        rdfs:range            cim:OperationalLimit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:OperationalLimit.PinOperationallLimit ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PinPowerTransferCorridor
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Input pin associated with a PowerTransferCorridor. It is used for comparison." ;
+        rdfs:label              "PinPowerTransferCorridor"@en ;
+        rdfs:subClassOf         nc:GateInputPin ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PinPowerTransferCorridor.PowerTransferCorridor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The PowerTransferCorridor that is used in the input pin." ;
+        rdfs:domain           nc:PinPowerTransferCorridor ;
+        rdfs:label            "PowerTransferCorridor"@en ;
+        rdfs:range            nc:PowerTransferCorridor ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerTransferCorridor.PinPowerTransferCorridor ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PinPowerTransferCorridor.kind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The kind of quantity which is used as an input value." ;
+        rdfs:domain        nc:PinPowerTransferCorridor ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         nc:PinPowerTransferCorridorKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PinPowerTransferCorridorKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The kind of quantities that can serve as an input value for the PowerTransferCorridor pin." ;
+        rdfs:label              "PinPowerTransferCorridorKind"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:PinPowerTransferCorridorKind.activePower
+        rdf:type         nc:PinPowerTransferCorridorKind ;
+        rdfs:comment     "Active power in the branch group." ;
+        rdfs:label       "activePower"@en ;
+        cims:stereotype  "enum" .
+
+nc:PinPowerTransferCorridorKind.reactivePower
+        rdf:type         nc:PinPowerTransferCorridorKind ;
+        rdfs:comment     "Reactive power in the branch group." ;
+        rdfs:label       "reactivePower"@en ;
+        cims:stereotype  "enum" .
+
+nc:PinTerminal  rdf:type        rdfs:Class ;
+        rdfs:comment            "Input pin associated with a Terminal. It is used for comparison." ;
+        rdfs:label              "PinTerminal"@en ;
+        rdfs:subClassOf         nc:GateInputPin ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PinTerminal.Terminal
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The Terminal that is used in the input pin." ;
+        rdfs:domain           nc:PinTerminal ;
+        rdfs:label            "Terminal"@en ;
+        rdfs:range            cim:Terminal ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Terminal.PinTerminal ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PinTerminal.kind  rdf:type  rdf:Property ;
+        rdfs:comment       "The kind of quantity which is used as an input value." ;
+        rdfs:domain        nc:PinTerminal ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         cim:PinTerminalKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerElectronicsConnection.PowerElectronicsConnectionAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The action that is applied to a PowerElectronicsConnection." ;
+        rdfs:domain           cim:PowerElectronicsConnection ;
+        rdfs:label            "PowerElectronicsConnectionAction"@en ;
+        rdfs:range            nc:PowerElectronicsConnectionAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerElectronicsConnectionAction.PowerElectronicsConnection ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerElectronicsConnectionAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Power electronics setpoint action. " ;
+        rdfs:label              "PowerElectronicsConnectionAction"@en ;
+        rdfs:subClassOf         nc:SetPointAction ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerElectronicsConnectionAction.PowerElectronicsConnection
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The PowerElectronicsConnection that is applied to an action." ;
+        rdfs:domain           nc:PowerElectronicsConnectionAction ;
+        rdfs:label            "PowerElectronicsConnection"@en ;
+        rdfs:range            cim:PowerElectronicsConnection ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerElectronicsConnection.PowerElectronicsConnectionAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Energy remedial action describes actions to rearrange power schedules." ;
+        rdfs:label              "PowerRemedialAction"@en ;
+        rdfs:subClassOf         nc:RemedialAction ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" .
+
+nc:PowerRemedialAction.BiddingZone
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The Bidding Zone where the power remedial action is done." ;
+        rdfs:domain           nc:PowerRemedialAction ;
+        rdfs:label            "BiddingZone"@en ;
+        rdfs:range            nc:BiddingZone ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:BiddingZone.PowerRemedialAction ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerRemedialAction.BiddingZoneBorder
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Bidding zone border where the power remedial action is done." ;
+        rdfs:domain           nc:PowerRemedialAction ;
+        rdfs:label            "BiddingZoneBorder"@en ;
+        rdfs:range            nc:BiddingZoneBorder ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:BiddingZoneBorder.PowerRemedialAction ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerRemedialAction.PowerShiftKeyStrategy
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power Shift Key Strategy which applies to this power remedial action." ;
+        rdfs:domain           nc:PowerRemedialAction ;
+        rdfs:label            "PowerShiftKeyStrategy"@en ;
+        rdfs:range            nc:PowerShiftKeyStrategy ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerShiftKeyStrategy.PowerRemedialAction ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerShiftKeyStrategy
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Strategy of the power shift key." ;
+        rdfs:label              "PowerShiftKeyStrategy"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerShiftKeyStrategy.PowerRemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power remedial acion which has power shift key strategy." ;
+        rdfs:domain           nc:PowerShiftKeyStrategy ;
+        rdfs:label            "PowerRemedialAction"@en ;
+        rdfs:range            nc:PowerRemedialAction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerRemedialAction.PowerShiftKeyStrategy ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerTransferCorridor
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A power transfer corridor is defined as a set of circuits (transmission lines or transformers) separating two portions of the power system, or a subset of circuits exposed to a substantial portion of the transmission exchange between two parts of the system." ;
+        rdfs:label              "PowerTransferCorridor"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" .
+
+nc:PowerTransferCorridor.ObservingTerminal
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The terminal that identifies the power transfer corridor." ;
+        rdfs:domain           nc:PowerTransferCorridor ;
+        rdfs:label            "ObservingTerminal"@en ;
+        rdfs:range            cim:Terminal ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Terminal.PowerTransferCorridor ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerTransferCorridor.PTCActivePowerSupport
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The active power capability associated with this PowerTransferCorridor." ;
+        rdfs:domain           nc:PowerTransferCorridor ;
+        rdfs:label            "PTCActivePowerSupport"@en ;
+        rdfs:range            nc:PTCActivePowerSupport ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PTCActivePowerSupport.PowerTransferCorridor ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerTransferCorridor.PinPowerTransferCorridor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The pin that uses this input." ;
+        rdfs:domain           nc:PowerTransferCorridor ;
+        rdfs:label            "PinPowerTransferCorridor"@en ;
+        rdfs:range            nc:PinPowerTransferCorridor ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PinPowerTransferCorridor.PowerTransferCorridor ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PropertyReference  rdf:type  rdfs:Class ;
+        rdfs:comment            "The reference to a class and one of its properties." ;
+        rdfs:label              "PropertyReference"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" .
+
+nc:PropertyReference.GridStateAlteration
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The grid state alteration for this property reference." ;
+        rdfs:domain           nc:PropertyReference ;
+        rdfs:label            "GridStateAlteration"@en ;
+        rdfs:range            nc:GridStateAlteration ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GridStateAlteration.PropertyReference ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PropertyReference.PinEquipment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The pin equipment that has this property reference." ;
+        rdfs:domain           nc:PropertyReference ;
+        rdfs:label            "PinEquipment"@en ;
+        rdfs:range            nc:PinEquipment ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PinEquipment.PropertyReference ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PropertyReference.StaticPropertyRange
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Static property range that has this property reference." ;
+        rdfs:domain           nc:PropertyReference ;
+        rdfs:label            "StaticPropertyRange"@en ;
+        rdfs:range            nc:StaticPropertyRange ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:StaticPropertyRange.PropertyReference ;
+        cims:multiplicity     cims:M:0..n .
+
+nc:RangeConstraint  rdf:type    rdfs:Class ;
+        rdfs:comment            "Defines the rage constraint." ;
+        rdfs:label              "RangeConstraint"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" .
+
+nc:RangeConstraint.GridStateAlteration
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The grid state alteration which has static range." ;
+        rdfs:domain           nc:RangeConstraint ;
+        rdfs:label            "GridStateAlteration"@en ;
+        rdfs:range            nc:GridStateAlteration ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GridStateAlteration.RangeConstraint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:RangeConstraint.direction
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Defines the direction of the attribute value referenced by the PropertyReference." ;
+        rdfs:domain        nc:RangeConstraint ;
+        rdfs:label         "direction"@en ;
+        rdfs:range         nc:RelativeDirectionKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RangeConstraint.normalValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The normal (initial) value. The meaning of the value is defined by the attribute referenced by the PropertyReference. The value can be integer, float or boolean. In case of boolean 1 equals true and 0 equals false.\nIf the valueKind is incremental or incrementalPercentage, then the value shall be positive (greater than zero).\nIf the valueKind is incrementalPercentage, then the value shall be in the range [0, 100]." ;
+        rdfs:domain        nc:RangeConstraint ;
+        rdfs:label         "normalValue"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RangeConstraint.valueKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of value offset for the range that applies to the attribute referenced by the PropertyReference." ;
+        rdfs:domain        nc:RangeConstraint ;
+        rdfs:label         "valueKind"@en ;
+        rdfs:range         nc:ValueOffsetKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RedispatchRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Redispatch remedial action is a remedial action that through rearranging power schedules is eliminating breaches of constraints." ;
+        rdfs:label              "RedispatchRemedialAction"@en ;
+        rdfs:subClassOf         nc:PowerRemedialAction ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:Region  rdf:type             rdfs:Class ;
+        rdfs:comment            "A region where the system operator belongs to." ;
+        rdfs:label              "Region"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" .
+
+nc:Region.RemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The remedial action which is considered in the region." ;
+        rdfs:domain           nc:Region ;
+        rdfs:label            "RemedialAction"@en ;
+        rdfs:range            nc:RemedialAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialAction.AppointedToRegion ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RegulatingControl.RegulatingControlAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The action that is applied to a regulating control." ;
+        rdfs:domain           cim:RegulatingControl ;
+        rdfs:label            "RegulatingControlAction"@en ;
+        rdfs:range            nc:RegulatingControlAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RegulatingControlAction.RegulatingControl ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RegulatingControlAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Control action means the set point change of a regulating control power system resource in the grid model compared to the base case." ;
+        rdfs:label              "RegulatingControlAction"@en ;
+        rdfs:subClassOf         nc:GridStateAlteration ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+nc:RegulatingControlAction.RegulatingControl
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The regulating control which has an action." ;
+        rdfs:domain           nc:RegulatingControlAction ;
+        rdfs:label            "RegulatingControl"@en ;
+        rdfs:range            cim:RegulatingControl ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RegulatingControl.RegulatingControlAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:RelativeDirectionKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of direction for the changes." ;
+        rdfs:label              "RelativeDirectionKind"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:RelativeDirectionKind.down
+        rdf:type         nc:RelativeDirectionKind ;
+        rdfs:comment     "Down signifies that the changes are decreasing from the current status." ;
+        rdfs:label       "down"@en ;
+        cims:stereotype  "enum" .
+
+nc:RelativeDirectionKind.none
+        rdf:type         nc:RelativeDirectionKind ;
+        rdfs:comment     "There is no direction on the changes." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+nc:RelativeDirectionKind.up
+        rdf:type         nc:RelativeDirectionKind ;
+        rdfs:comment     "Up signifies that the changes are increasing from the current status." ;
+        rdfs:label       "up"@en ;
+        cims:stereotype  "enum" .
+
+nc:RelativeDirectionKind.upAndDown
+        rdf:type         nc:RelativeDirectionKind ;
+        rdfs:comment     "Up and down signifies that both up and down values are equal." ;
+        rdfs:label       "upAndDown"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialAction  rdf:type     rdfs:Class ;
+        rdfs:comment            "Remedial action describes one or more actions that can be performed on a given power system model situation to eliminate one or more identified breaches of constraints. The remedial action can be costly, and have a cost characteristic, or non costly. " ;
+        rdfs:label              "RemedialAction"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" .
+
+nc:RemedialAction.AppointedToRegion
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The region in which the remedial action is appointed." ;
+        rdfs:domain           nc:RemedialAction ;
+        rdfs:label            "AppointedToRegion"@en ;
+        rdfs:range            nc:Region ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Region.RemedialAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialAction.ContingencyWithRemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The contingency and remedial action combination." ;
+        rdfs:domain           nc:RemedialAction ;
+        rdfs:label            "ContingencyWithRemedialAction"@en ;
+        rdfs:range            nc:ContingencyWithRemedialAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ContingencyWithRemedialAction.RemedialAction ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialAction.DependentRemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action dependent on a remedial action." ;
+        rdfs:domain           nc:RemedialAction ;
+        rdfs:label            "DependentRemedialAction"@en ;
+        rdfs:range            nc:RemedialActionDependency ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialActionDependency.RemedialAction ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialAction.RemedialActionSystemOperator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "System operator operating remedial actions." ;
+        rdfs:domain           nc:RemedialAction ;
+        rdfs:label            "RemedialActionSystemOperator"@en ;
+        rdfs:range            nc:SystemOperator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SystemOperator.RemedialAction ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialAction.impactThresholdMargin
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Impact threshold margin for the use of the remedial action. Meaning that the remedial action should not be used if it cannot resolve violation with more than the given impact threshold margin.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:RemedialAction ;
+        rdfs:label         "impactThresholdMargin"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialAction.isCrossBorderRelevant
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Indicates if the remedial action is cross border relevant.  True, means that the remedial action is cross border relevant." ;
+        rdfs:domain        nc:RemedialAction ;
+        rdfs:label         "isCrossBorderRelevant"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialAction.isManual
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Indicates if the remedial action is manually executed which involves one or many actions performed by human. A SIPS remedial action cannot be manual.  True, means that the remedial action is manual. False, means that the remedial action is automatically executed without human communication." ;
+        rdfs:domain        nc:RemedialAction ;
+        rdfs:label         "isManual"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialAction.kind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The kind of the remedial action. If curative remedial action, it is required to have an association with ContingencyWithRemedialAction.\nIf preventive remedial action, RemedialAction class shall not have association with ContingencyWithRemedialAction." ;
+        rdfs:domain        nc:RemedialAction ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         nc:RemedialActionKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialAction.normalAvailable
+        rdf:type           rdf:Property ;
+        rdfs:comment       "It identifies if the remedial action is available under normal condition. True means available, False means unavailable." ;
+        rdfs:domain        nc:RemedialAction ;
+        rdfs:label         "normalAvailable"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialAction.penaltyFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Defines the relative penalty for a given remedial action. This is a positive number greater than zero and default is one, meaning the remedial action does not have negative nor positive effect on the quality of the solution. A remedial action that provide changes in the transmission loss can have negative (Between zero and one) or positive effect (Bigger than one) given by 1 / (1 – Incremental Transmission Loss). In a similar way remedial action using generating units or compensation units can have negative or positive effect. Typical value would be between 0.8 and 1.1." ;
+        rdfs:domain        nc:RemedialAction ;
+        rdfs:label         "penaltyFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialAction.timeToImplement
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Time to implement a remedial action." ;
+        rdfs:domain        nc:RemedialAction ;
+        rdfs:label         "timeToImplement"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionDependency
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Remedial action dependency is making two remedial actions depending on each other. Multiple dependency is done by multiple instances of this class. The dependency can arrive by having one of the following examples.\n<ul>\n\t<li>The dependent remedial action is controlled by different system operator (Modeling Authority)  (e.g. SIPS that goes across control area).</li>\n\t<li>The dependent remedial action is representing  two or more remedial action that represent the same grid state alteration but with different modeling resolution (e.g. detail direct current model versus a simplified model).</li>\n\t<li>The remedial action can be combined with other remedial action without the need to create multiple remedial action with the same grid alteration for enabling dependency.</li>\n</ul>" ;
+        rdfs:label              "RemedialActionDependency"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RemedialActionDependency.DependingRemedialActionGroup
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action group which the remedial action is depending on." ;
+        rdfs:domain           nc:RemedialActionDependency ;
+        rdfs:label            "DependingRemedialActionGroup"@en ;
+        rdfs:range            nc:RemedialActionGroup ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialActionGroup.RemedialAction ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionDependency.RemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action which has dependent remedial actions." ;
+        rdfs:domain           nc:RemedialActionDependency ;
+        rdfs:label            "RemedialAction"@en ;
+        rdfs:range            nc:RemedialAction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialAction.DependentRemedialAction ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionDependency.kind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Type of dependency between two remedial actions." ;
+        rdfs:domain        nc:RemedialActionDependency ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         nc:RemedialActionDependencyKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionDependency.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:RemedialActionDependency ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionDependency.normalEnabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "If true, the remedial action dependency with contingency shall be considered under normal operating conditions." ;
+        rdfs:domain        nc:RemedialActionDependency ;
+        rdfs:label         "normalEnabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionDependencyKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of dependency between remedial actions." ;
+        rdfs:label              "RemedialActionDependencyKind"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:RemedialActionDependencyKind.balanced
+        rdf:type         nc:RemedialActionDependencyKind ;
+        rdfs:comment     "This applies only to a set of power remedial actions and means that the remedial action needs to be balanced between the area (directly or indirectly to the bidding zone) that it is applied to." ;
+        rdfs:label       "balanced"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionDependencyKind.exclusive
+        rdf:type         nc:RemedialActionDependencyKind ;
+        rdfs:comment     "Remedial actions are exclusive depending on each other. e.g. Only one of the remedial actions can be selected at the same time." ;
+        rdfs:label       "exclusive"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionDependencyKind.inclusive
+        rdf:type         nc:RemedialActionDependencyKind ;
+        rdfs:comment     "Remedial actions are inclusive depending on each other. e.g. Both remedial action need to be picked if one of them is needed." ;
+        rdfs:label       "inclusive"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionDependencyKind.none
+        rdf:type         nc:RemedialActionDependencyKind ;
+        rdfs:comment     "Remedial actions are not depending on each other. However, the two remedial actions should be evaluated together." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionDependencyKind.restrictive
+        rdf:type         nc:RemedialActionDependencyKind ;
+        rdfs:comment     "Remedial actions are restrictive depending on each other. The need to include or to exclude might depend on the model. e.g. In the case of simplified DC model and detailed DC model. In the case where the simplified remedial action is used but not the remedial action for the detail model and opposite for the DC model." ;
+        rdfs:label       "restrictive"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionGroup
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Grouping of remedial actions that can be operated together." ;
+        rdfs:label              "RemedialActionGroup"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RemedialActionGroup.RemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action dependecy on a remedial action group." ;
+        rdfs:domain           nc:RemedialActionGroup ;
+        rdfs:label            "RemedialAction"@en ;
+        rdfs:range            nc:RemedialActionDependency ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialActionDependency.DependingRemedialActionGroup ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The different kinds for a remedial action." ;
+        rdfs:label              "RemedialActionKind"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:RemedialActionKind.curative
+        rdf:type         nc:RemedialActionKind ;
+        rdfs:comment     "Curative remedial action means a remedial action that is the result of an operational planning process and is activated straight subsequent to the occurrence of the respective contingency for compliance with the (N-1) criterion, taking into account transitory admissible overloads and their accepted duration." ;
+        rdfs:label       "curative"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionKind.preventive
+        rdf:type         nc:RemedialActionKind ;
+        rdfs:comment     "Preventive remedial action means a remedial action that is the result of an operational planning process and needs to be activated prior to the investigated timeframe for compliance with the (N-1) criterion." ;
+        rdfs:label       "preventive"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionScheme
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Remedial Action Scheme (RAS), Special Protection Schemes (SPS), System Protection Schemes (SPS) or System Integrity Protection Schemes (SIPS).\nA Remedial Action Scheme consists of one or more stages that can trigger and execute a protection action." ;
+        rdfs:label              "RemedialActionScheme"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RemedialActionScheme.ArmedRemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action scheme schedule that has this armed remedial action." ;
+        rdfs:domain           nc:RemedialActionScheme ;
+        rdfs:label            "ArmedRemedialAction"@en ;
+        rdfs:range            nc:SchemeRemedialAction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SchemeRemedialAction.RemedialActionScheme ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionScheme.GateArmed
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Gate that through a gate logic and input pin defines arming of a Remedial Action Scheme." ;
+        rdfs:domain           nc:RemedialActionScheme ;
+        rdfs:label            "GateArmed"@en ;
+        rdfs:range            nc:Gate ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Gate.RemedialActionScheme ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionScheme.PTCActivePowerSupport
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The active power support of the PowerTransferCorridor related to this RemedialActionScheme." ;
+        rdfs:domain           nc:RemedialActionScheme ;
+        rdfs:label            "PTCActivePowerSupport"@en ;
+        rdfs:range            nc:PTCActivePowerSupport ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PTCActivePowerSupport.RemedialActionScheme ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionScheme.Stage
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The stage for this remedial action scheme." ;
+        rdfs:domain           nc:RemedialActionScheme ;
+        rdfs:label            "Stage"@en ;
+        rdfs:range            nc:Stage ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:Stage.RemedialActionScheme ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:RemedialActionScheme.TriggerCondition
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The triggering condition of this Remedial Action Scheme." ;
+        rdfs:domain           nc:RemedialActionScheme ;
+        rdfs:label            "TriggerCondition"@en ;
+        rdfs:range            nc:TriggerCondition ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:TriggerCondition.RemedialActionScheme ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionScheme.kind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of Remedial Action Scheme." ;
+        rdfs:domain        nc:RemedialActionScheme ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         nc:RemedialActionSchemeKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionScheme.normalArmed
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Defines the normal arming status of the remedial action scheme. " ;
+        rdfs:domain        nc:RemedialActionScheme ;
+        rdfs:label         "normalArmed"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionSchemeKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Classification of Remedial Action Scheme." ;
+        rdfs:label              "RemedialActionSchemeKind"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:RemedialActionSchemeKind.rasp
+        rdf:type         nc:RemedialActionSchemeKind ;
+        rdfs:comment     "Remedial Action Schema Plan (RASP). The triggering conditions are met through calculation or manual intervention." ;
+        rdfs:label       "rasp"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionSchemeKind.sips
+        rdf:type         nc:RemedialActionSchemeKind ;
+        rdfs:comment     "System Integrity Protection Scheme (SIPS). The triggering conditions are met through field measurements." ;
+        rdfs:label       "sips"@en ;
+        cims:stereotype  "enum" .
+
+nc:RotatingMachine.RotatingMachineAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The action applied to a rotating machine." ;
+        rdfs:domain           cim:RotatingMachine ;
+        rdfs:label            "RotatingMachineAction"@en ;
+        rdfs:range            nc:RotatingMachineAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RotatingMachineAction.RotatingMachine ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RotatingMachineAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Rotating machine action." ;
+        rdfs:label              "RotatingMachineAction"@en ;
+        rdfs:subClassOf         nc:SetPointAction ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RotatingMachineAction.RotatingMachine
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The rotating machine that has an action." ;
+        rdfs:domain           nc:RotatingMachineAction ;
+        rdfs:label            "RotatingMachine"@en ;
+        rdfs:range            cim:RotatingMachine ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RotatingMachine.RotatingMachineAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:SchemeRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Scheme remedial action is remedial action that involves a scheme that can include conditional logic and stages of grid alteration. The primary remedial action is the arming of these schemes, that will then perform curative remedial action when the condition is met. System Integrity Protection Scheme (SIPS) and Special Protection Scheme (SPS) are example of this. " ;
+        rdfs:label              "SchemeRemedialAction"@en ;
+        rdfs:subClassOf         nc:RemedialAction ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SchemeRemedialAction.RemedialActionScheme
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Armed remedial action for a remedial action scheme." ;
+        rdfs:domain           nc:SchemeRemedialAction ;
+        rdfs:label            "RemedialActionScheme"@en ;
+        rdfs:range            nc:RemedialActionScheme ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialActionScheme.ArmedRemedialAction ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:SetPointAction  rdf:type     rdfs:Class ;
+        rdfs:comment            "Setpoint action." ;
+        rdfs:label              "SetPointAction"@en ;
+        rdfs:subClassOf         nc:GridStateAlteration ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" .
+
+nc:ShuntCompensator.ShuntCompensatorAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The action that is applied to a ShuntCompensator." ;
+        rdfs:domain           cim:ShuntCompensator ;
+        rdfs:label            "ShuntCompensatorAction"@en ;
+        rdfs:range            nc:ShuntCompensatorModification ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ShuntCompensatorModification.ShuntCompensator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ShuntCompensatorModification
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Shunt compensator action." ;
+        rdfs:label              "ShuntCompensatorModification"@en ;
+        rdfs:subClassOf         nc:SetPointAction ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ShuntCompensatorModification.ShuntCompensator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The ShuntCompensator that is associated with an action." ;
+        rdfs:domain           nc:ShuntCompensatorModification ;
+        rdfs:label            "ShuntCompensator"@en ;
+        rdfs:range            cim:ShuntCompensator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ShuntCompensator.ShuntCompensatorAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:Stage  rdf:type              rdfs:Class ;
+        rdfs:comment            "Stage of a remedial action scheme." ;
+        rdfs:label              "Stage"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:Stage.GridStateAlterationCollection
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The GridStateAlterationCollection which belongs to the Stage." ;
+        rdfs:domain           nc:Stage ;
+        rdfs:label            "GridStateAlterationCollection"@en ;
+        rdfs:range            nc:GridStateAlterationCollection ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GridStateAlterationCollection.StageAction ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:Stage.RemedialActionScheme
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The remedial action scheme that has a stage." ;
+        rdfs:domain           nc:Stage ;
+        rdfs:label            "RemedialActionScheme"@en ;
+        rdfs:range            nc:RemedialActionScheme ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialActionScheme.Stage ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:Stage.StageTrigger
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The state trigger that is part of this stage." ;
+        rdfs:domain           nc:Stage ;
+        rdfs:label            "StageTrigger"@en ;
+        rdfs:range            nc:StageTrigger ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:StageTrigger.Stage ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:Stage.priority  rdf:type  rdf:Property ;
+        rdfs:comment       "The priority of the stage.   0 = do not care (default) 1 = highest priority. 2 is less than 1 and so on. A stage with higher priority needs be activated before a lower stage can be activated." ;
+        rdfs:domain        nc:Stage ;
+        rdfs:label         "priority"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:StageTrigger  rdf:type       rdfs:Class ;
+        rdfs:comment            "Stage that is triggered either by TriggerCondition or by gate condition within a stage." ;
+        rdfs:label              "StageTrigger"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:StageTrigger.GateArmed
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The gate that is the input pin which defines arming of the StageTrigger." ;
+        rdfs:domain           nc:StageTrigger ;
+        rdfs:label            "GateArmed"@en ;
+        rdfs:range            nc:Gate ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Gate.StageTriggerArmed ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:StageTrigger.GateComCondition
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The gate that is the input pin which defines a communication condition." ;
+        rdfs:domain           nc:StageTrigger ;
+        rdfs:label            "GateComCondition"@en ;
+        rdfs:range            nc:Gate ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Gate.StageTriggerCom ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:StageTrigger.GateTrigger
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The gate that is the input pin which triggers the protective reactions." ;
+        rdfs:domain           nc:StageTrigger ;
+        rdfs:label            "GateTrigger"@en ;
+        rdfs:range            nc:Gate ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Gate.StageTrigger ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:StageTrigger.Stage
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The stage that has this stage trigger." ;
+        rdfs:domain           nc:StageTrigger ;
+        rdfs:label            "Stage"@en ;
+        rdfs:range            nc:Stage ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Stage.StageTrigger ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:StageTrigger.normalArmed
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The default/normal value used when other active signal/values are missing." ;
+        rdfs:domain        nc:StageTrigger ;
+        rdfs:label         "normalArmed"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:StageTrigger.priority
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Priority of trigger. 0 = don t care (default) 1 = highest priority. 2 is less than 1 and so on. A trigger with the highest priority will trigger first." ;
+        rdfs:domain        nc:StageTrigger ;
+        rdfs:label         "priority"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:StaticPropertyRange
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Defines the static range, which means that this is the minimum and/or maximum of an attribute value. The value provided by the schedule replaces the value of the attribute to which the schedule refers to.\nIn case that the PropertyReference refers to Boolean type attributes, RangeConstraint.direction shall be none or upAndDown and the RangeConstraint.valueKind shall be absolute. If the direction is none then optimization of the attribute referenced by the PropertyReference is not possible if the current status is already as the value in the range. Otherwise if the direction is upAndDown, the optimization can change from true to false or vice versa independently of the initial value in the operational scenario.\nFor instance for a tap changer related grid state alteration for a particular point in time, if the range of TapChanger.step is to be restricted, the value of the schedule will represent that new TapChanger.step range." ;
+        rdfs:label              "StaticPropertyRange"@en ;
+        rdfs:subClassOf         nc:RangeConstraint ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:StaticPropertyRange.PropertyReference
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Property reference for this static property range." ;
+        rdfs:domain           nc:StaticPropertyRange ;
+        rdfs:label            "PropertyReference"@en ;
+        rdfs:range            nc:PropertyReference ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PropertyReference.StaticPropertyRange ;
+        cims:multiplicity     cims:M:1 .
+
+nc:StaticVarCompensator.StaticVarCompensatorAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The action which is applied to a StaticVarCompensator." ;
+        rdfs:domain           cim:StaticVarCompensator ;
+        rdfs:label            "StaticVarCompensatorAction"@en ;
+        rdfs:range            nc:StaticVarCompensatorAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:StaticVarCompensatorAction.StaticVarCompensator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:StaticVarCompensatorAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Static Var compensator action." ;
+        rdfs:label              "StaticVarCompensatorAction"@en ;
+        rdfs:subClassOf         nc:SetPointAction ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:StaticVarCompensatorAction.StaticVarCompensator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The StaticVarCompensator which is associated with an action." ;
+        rdfs:domain           nc:StaticVarCompensatorAction ;
+        rdfs:label            "StaticVarCompensator"@en ;
+        rdfs:range            cim:StaticVarCompensator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:StaticVarCompensator.StaticVarCompensatorAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:Switch.TopologyAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The action assigned to a switch." ;
+        rdfs:domain           cim:Switch ;
+        rdfs:label            "TopologyAction"@en ;
+        rdfs:range            nc:TopologyAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:TopologyAction.Switch ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SystemOperator  rdf:type     rdfs:Class ;
+        rdfs:comment            "System operator." ;
+        rdfs:label              "SystemOperator"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" .
+
+nc:SystemOperator.RemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action defined by this system operator." ;
+        rdfs:domain           nc:SystemOperator ;
+        rdfs:label            "RemedialAction"@en ;
+        rdfs:range            nc:RemedialAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialAction.RemedialActionSystemOperator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:TapChanger.TapPositionAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The action that is applied to a tap changer." ;
+        rdfs:domain           cim:TapChanger ;
+        rdfs:label            "TapPositionAction"@en ;
+        rdfs:range            nc:TapPositionAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:TapPositionAction.TapChanger ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:TapPositionAction  rdf:type  rdfs:Class ;
+        rdfs:comment            "Tap position action represents a change of a tap changer position in the grid model compared to the base case." ;
+        rdfs:label              "TapPositionAction"@en ;
+        rdfs:subClassOf         nc:GridStateAlteration ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:TapPositionAction.TapChanger
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The tap changer that has a tap position action associated." ;
+        rdfs:domain           nc:TapPositionAction ;
+        rdfs:label            "TapChanger"@en ;
+        rdfs:range            cim:TapChanger ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:TapChanger.TapPositionAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:Terminal.PinTerminal
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The pin that uses this input." ;
+        rdfs:domain           cim:Terminal ;
+        rdfs:label            "PinTerminal"@en ;
+        rdfs:range            nc:PinTerminal ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PinTerminal.Terminal ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Terminal.PowerTransferCorridor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The power transfer corridor which is identified by  terminal." ;
+        rdfs:domain           cim:Terminal ;
+        rdfs:label            "PowerTransferCorridor"@en ;
+        rdfs:range            nc:PowerTransferCorridor ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerTransferCorridor.ObservingTerminal ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:TopologyAction  rdf:type     rdfs:Class ;
+        rdfs:comment            "Topology action means the connection or disconnection of a switch in the grid model compared to the base case." ;
+        rdfs:label              "TopologyAction"@en ;
+        rdfs:subClassOf         nc:GridStateAlteration ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:TopologyAction.Switch
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The switch that has a topology action associated." ;
+        rdfs:domain           nc:TopologyAction ;
+        rdfs:label            "Switch"@en ;
+        rdfs:range            cim:Switch ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Switch.TopologyAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:TriggerCondition  rdf:type   rdfs:Class ;
+        rdfs:comment            "The condition that triggers a remedial action scheme." ;
+        rdfs:label              "TriggerCondition"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:TriggerCondition.GateTrigger
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The gate that is the condition for the trigger." ;
+        rdfs:domain           nc:TriggerCondition ;
+        rdfs:label            "GateTrigger"@en ;
+        rdfs:range            nc:Gate ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Gate.TriggerCondition ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:TriggerCondition.RemedialActionScheme
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The remedial action scheme that has the trigger condition." ;
+        rdfs:domain           nc:TriggerCondition ;
+        rdfs:label            "RemedialActionScheme"@en ;
+        rdfs:range            nc:RemedialActionScheme ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialActionScheme.TriggerCondition ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:ValueOffsetKind  rdf:type    rdfs:Class ;
+        rdfs:comment            "The kind of the value offset." ;
+        rdfs:label              "ValueOffsetKind"@en ;
+        cims:belongsToCategory  ra:Package_RemedialActionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:ValueOffsetKind.absolute
+        rdf:type         nc:ValueOffsetKind ;
+        rdfs:comment     "Value of the range constraint is replacing the attribute value referenced by the PropertyReference in a determined operational scenario." ;
+        rdfs:label       "absolute"@en ;
+        cims:stereotype  "enum" .
+
+nc:ValueOffsetKind.incremental
+        rdf:type         nc:ValueOffsetKind ;
+        rdfs:comment     "Value of the range constraint is incrementing the attribute value referenced by the PropertyReference in a determined operational scenario." ;
+        rdfs:label       "incremental"@en ;
+        cims:stereotype  "enum" .
+
+nc:ValueOffsetKind.incrementalPercentage
+        rdf:type         nc:ValueOffsetKind ;
+        rdfs:comment     "Value of the range constraint is incrementing in percentage the attribute value referenced by the PropertyReference in a determined operational scenario. " ;
+        rdfs:label       "incrementalPercentage"@en ;
+        cims:stereotype  "enum" .
+
+profcim:IRI  rdf:type           rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as rdf:resource in RDFXML.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "IRI"@en ;
+        cims:belongsToCategory  ra:Package_DocRemedialActionProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringFixedLanguage
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited.\nThe primitive is serialized as literal without language support." ;
+        rdfs:label              "StringFixedLanguage"@en ;
+        cims:belongsToCategory  ra:Package_DocRemedialActionProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringIRI  rdf:type     rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as literal without language support.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "StringIRI"@en ;
+        cims:belongsToCategory  ra:Package_DocRemedialActionProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:URL  rdf:type           rdfs:Class ;
+        rdfs:comment            "A Uniform Resource Locator (URL), colloquially termed a web address, is a reference to a web resource that specifies its location on a computer network and a mechanism for retrieving it. A URL is a specific type of Uniform Resource Identifier (URI), although many people use the two terms interchangeably.URLs occur most commonly to reference web pages (http), but are also used for file transfer (ftp), email (mailto), database access (JDBC), and many other applications." ;
+        rdfs:label              "URL"@en ;
+        cims:belongsToCategory  ra:Package_DocRemedialActionProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+ra:Ontology  rdf:type         owl:Ontology ;
+        dcterms:conformsTo    "urn:iso:std:iec:61970-501:draft:ed-2" , "urn:iso:std:iec:61970-301:ed-7:amd1" , "urn:iso:std:iec:61970-401:draft:ed-1" , "file://CIM100_CGMES31v01_501-20v02_NC23v62_MM10v01.eap" , "urn:iso:std:iec:61970-600-2:ed-1" , "file://iec61970cim17v40_iec61968cim13v13a_iec62325cim03v17a.eap" ;
+        dcterms:creator       "ENTSO-E CIM WG NC project "@en ;
+        dcterms:description   "This vocabulary is describing the remedial action profile."@en ;
+        dcterms:identifier    "urn:uuid:57fcfe0e-258c-45f2-b2ed-ff5b6a9859bc" ;
+        dcterms:language      "en-GB" ;
+        dcterms:license       "https://www.apache.org/licenses/LICENSE-2.0"@en ;
+        dcterms:modified      "2024-04-08"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        dcterms:publisher     "ENTSO-E"@en ;
+        dcterms:rightsHolder  "ENTSO-E"@en ;
+        dcterms:title         "Remedial action Vocabulary"@en ;
+        owl:priorVersion      <http://entsoe.eu/ns/CIM/RemedialAction-EU/2.2> ;
+        owl:versionIRI        <https://ap.cim4.eu/RemedialAction/2.3> ;
+        owl:versionInfo       "2.3.0"@en ;
+        dcat:keyword          "RA" ;
+        dcat:theme            "vocabulary"@en .
+
+ra:Package_DocRemedialActionProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains datatypes used only in the RDFS header." ;
+        rdfs:label    "DocRemedialActionProfile"@en .
+
+ra:Package_RemedialActionProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains remedial action profile." ;
+        rdfs:label    "RemedialActionProfile"@en .
+

--- a/r2.3/ap-voc/ttl/RemedialActionSchedule-AP-Voc-RDFS2020.ttl
+++ b/r2.3/ap-voc/ttl/RemedialActionSchedule-AP-Voc-RDFS2020.ttl
@@ -1,0 +1,2328 @@
+@prefix cim:     <https://cim.ucaiug.io/ns#> .
+@prefix cims:    <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/#> .
+@prefix nc:      <https://cim4.eu/ns/nc#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix profcim: <https://cim.ucaiug.io/ns/prof-cim#> .
+@prefix ras:     <https://ap.cim4.eu/RemedialActionSchedule#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+
+cim:ActivePower  rdf:type       rdfs:Class ;
+        rdfs:comment            "Product of RMS value of the voltage and the RMS value of the in-phase component of the current." ;
+        rdfs:label              "ActivePower"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:ActivePower.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePower.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "W" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePower.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Boolean  rdf:type           rdfs:Class ;
+        rdfs:comment            "A type with the value space \"true\" and \"false\"." ;
+        rdfs:label              "Boolean"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Contingency  rdf:type       rdfs:Class ;
+        rdfs:comment            "An event threatening system reliability, consisting of one or more contingency elements." ;
+        rdfs:label              "Contingency"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile .
+
+cim:Currency  rdf:type          rdfs:Class ;
+        rdfs:comment            "Monetary currencies.  ISO 4217 standard including 3-character currency code." ;
+        rdfs:label              "Currency"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:Currency.AED  rdf:type  cim:Currency ;
+        rdfs:comment     "United Arab Emirates dirham." ;
+        rdfs:label       "AED"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AFN  rdf:type  cim:Currency ;
+        rdfs:comment     "Afghan afghani." ;
+        rdfs:label       "AFN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ALL  rdf:type  cim:Currency ;
+        rdfs:comment     "Albanian lek." ;
+        rdfs:label       "ALL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AMD  rdf:type  cim:Currency ;
+        rdfs:comment     "Armenian dram." ;
+        rdfs:label       "AMD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ANG  rdf:type  cim:Currency ;
+        rdfs:comment     "Netherlands Antillean guilder." ;
+        rdfs:label       "ANG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AOA  rdf:type  cim:Currency ;
+        rdfs:comment     "Angolan kwanza." ;
+        rdfs:label       "AOA"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ARS  rdf:type  cim:Currency ;
+        rdfs:comment     "Argentine peso." ;
+        rdfs:label       "ARS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AUD  rdf:type  cim:Currency ;
+        rdfs:comment     "Australian dollar." ;
+        rdfs:label       "AUD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AWG  rdf:type  cim:Currency ;
+        rdfs:comment     "Aruban florin." ;
+        rdfs:label       "AWG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AZN  rdf:type  cim:Currency ;
+        rdfs:comment     "Azerbaijani manat." ;
+        rdfs:label       "AZN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BAM  rdf:type  cim:Currency ;
+        rdfs:comment     "Bosnia and Herzegovina convertible mark." ;
+        rdfs:label       "BAM"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BBD  rdf:type  cim:Currency ;
+        rdfs:comment     "Barbados dollar." ;
+        rdfs:label       "BBD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BDT  rdf:type  cim:Currency ;
+        rdfs:comment     "Bangladeshi taka." ;
+        rdfs:label       "BDT"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BGN  rdf:type  cim:Currency ;
+        rdfs:comment     "Bulgarian lev." ;
+        rdfs:label       "BGN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BHD  rdf:type  cim:Currency ;
+        rdfs:comment     "Bahraini dinar." ;
+        rdfs:label       "BHD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BIF  rdf:type  cim:Currency ;
+        rdfs:comment     "Burundian franc." ;
+        rdfs:label       "BIF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BMD  rdf:type  cim:Currency ;
+        rdfs:comment     "Bermudian dollar (customarily known as Bermuda dollar)." ;
+        rdfs:label       "BMD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BND  rdf:type  cim:Currency ;
+        rdfs:comment     "Brunei dollar." ;
+        rdfs:label       "BND"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BOB  rdf:type  cim:Currency ;
+        rdfs:comment     "Boliviano." ;
+        rdfs:label       "BOB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BOV  rdf:type  cim:Currency ;
+        rdfs:comment     "Bolivian Mvdol (funds code)." ;
+        rdfs:label       "BOV"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BRL  rdf:type  cim:Currency ;
+        rdfs:comment     "Brazilian real." ;
+        rdfs:label       "BRL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BSD  rdf:type  cim:Currency ;
+        rdfs:comment     "Bahamian dollar." ;
+        rdfs:label       "BSD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BTN  rdf:type  cim:Currency ;
+        rdfs:comment     "Bhutanese ngultrum." ;
+        rdfs:label       "BTN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BWP  rdf:type  cim:Currency ;
+        rdfs:comment     "Botswana pula." ;
+        rdfs:label       "BWP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BYR  rdf:type  cim:Currency ;
+        rdfs:comment     "Belarusian ruble." ;
+        rdfs:label       "BYR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BZD  rdf:type  cim:Currency ;
+        rdfs:comment     "Belize dollar." ;
+        rdfs:label       "BZD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CAD  rdf:type  cim:Currency ;
+        rdfs:comment     "Canadian dollar." ;
+        rdfs:label       "CAD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CDF  rdf:type  cim:Currency ;
+        rdfs:comment     "Congolese franc." ;
+        rdfs:label       "CDF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CHF  rdf:type  cim:Currency ;
+        rdfs:comment     "Swiss franc." ;
+        rdfs:label       "CHF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CLF  rdf:type  cim:Currency ;
+        rdfs:comment     "Unidad de Fomento (funds code), Chile." ;
+        rdfs:label       "CLF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CLP  rdf:type  cim:Currency ;
+        rdfs:comment     "Chilean peso." ;
+        rdfs:label       "CLP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CNY  rdf:type  cim:Currency ;
+        rdfs:comment     "Chinese yuan." ;
+        rdfs:label       "CNY"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.COP  rdf:type  cim:Currency ;
+        rdfs:comment     "Colombian peso." ;
+        rdfs:label       "COP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.COU  rdf:type  cim:Currency ;
+        rdfs:comment     "Unidad de Valor Real." ;
+        rdfs:label       "COU"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CRC  rdf:type  cim:Currency ;
+        rdfs:comment     "Costa Rican colon." ;
+        rdfs:label       "CRC"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CUC  rdf:type  cim:Currency ;
+        rdfs:comment     "Cuban convertible peso." ;
+        rdfs:label       "CUC"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CUP  rdf:type  cim:Currency ;
+        rdfs:comment     "Cuban peso." ;
+        rdfs:label       "CUP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CVE  rdf:type  cim:Currency ;
+        rdfs:comment     "Cape Verde escudo." ;
+        rdfs:label       "CVE"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CZK  rdf:type  cim:Currency ;
+        rdfs:comment     "Czech koruna." ;
+        rdfs:label       "CZK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.DJF  rdf:type  cim:Currency ;
+        rdfs:comment     "Djiboutian franc." ;
+        rdfs:label       "DJF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.DKK  rdf:type  cim:Currency ;
+        rdfs:comment     "Danish krone." ;
+        rdfs:label       "DKK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.DOP  rdf:type  cim:Currency ;
+        rdfs:comment     "Dominican peso." ;
+        rdfs:label       "DOP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.DZD  rdf:type  cim:Currency ;
+        rdfs:comment     "Algerian dinar." ;
+        rdfs:label       "DZD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.EEK  rdf:type  cim:Currency ;
+        rdfs:comment     "Estonian kroon." ;
+        rdfs:label       "EEK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.EGP  rdf:type  cim:Currency ;
+        rdfs:comment     "Egyptian pound." ;
+        rdfs:label       "EGP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ERN  rdf:type  cim:Currency ;
+        rdfs:comment     "Eritrean nakfa." ;
+        rdfs:label       "ERN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ETB  rdf:type  cim:Currency ;
+        rdfs:comment     "Ethiopian birr." ;
+        rdfs:label       "ETB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.EUR  rdf:type  cim:Currency ;
+        rdfs:comment     "Euro." ;
+        rdfs:label       "EUR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.FJD  rdf:type  cim:Currency ;
+        rdfs:comment     "Fiji dollar." ;
+        rdfs:label       "FJD"@en ;
+        cims:stereotype  "enum" .
+cim:Currency.FKP  rdf:type  cim:Currency ;
+        rdfs:comment     "Falkland Islands pound." ;
+        rdfs:label       "FKP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GBP  rdf:type  cim:Currency ;
+        rdfs:comment     "Pound sterling." ;
+        rdfs:label       "GBP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GEL  rdf:type  cim:Currency ;
+        rdfs:comment     "Georgian lari." ;
+        rdfs:label       "GEL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GHS  rdf:type  cim:Currency ;
+        rdfs:comment     "Ghanaian cedi." ;
+        rdfs:label       "GHS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GIP  rdf:type  cim:Currency ;
+        rdfs:comment     "Gibraltar pound." ;
+        rdfs:label       "GIP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GMD  rdf:type  cim:Currency ;
+        rdfs:comment     "Gambian dalasi." ;
+        rdfs:label       "GMD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GNF  rdf:type  cim:Currency ;
+        rdfs:comment     "Guinean franc." ;
+        rdfs:label       "GNF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GTQ  rdf:type  cim:Currency ;
+        rdfs:comment     "Guatemalan quetzal." ;
+        rdfs:label       "GTQ"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GYD  rdf:type  cim:Currency ;
+        rdfs:comment     "Guyanese dollar." ;
+        rdfs:label       "GYD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HKD  rdf:type  cim:Currency ;
+        rdfs:comment     "Hong Kong dollar." ;
+        rdfs:label       "HKD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HNL  rdf:type  cim:Currency ;
+        rdfs:comment     "Honduran lempira." ;
+        rdfs:label       "HNL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HRK  rdf:type  cim:Currency ;
+        rdfs:comment     "Croatian kuna." ;
+        rdfs:label       "HRK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HTG  rdf:type  cim:Currency ;
+        rdfs:comment     "Haitian gourde." ;
+        rdfs:label       "HTG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HUF  rdf:type  cim:Currency ;
+        rdfs:comment     "Hungarian forint." ;
+        rdfs:label       "HUF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.IDR  rdf:type  cim:Currency ;
+        rdfs:comment     "Indonesian rupiah." ;
+        rdfs:label       "IDR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ILS  rdf:type  cim:Currency ;
+        rdfs:comment     "Israeli new sheqel." ;
+        rdfs:label       "ILS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.INR  rdf:type  cim:Currency ;
+        rdfs:comment     "Indian rupee." ;
+        rdfs:label       "INR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.IQD  rdf:type  cim:Currency ;
+        rdfs:comment     "Iraqi dinar." ;
+        rdfs:label       "IQD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.IRR  rdf:type  cim:Currency ;
+        rdfs:comment     "Iranian rial." ;
+        rdfs:label       "IRR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ISK  rdf:type  cim:Currency ;
+        rdfs:comment     "Icelandic króna." ;
+        rdfs:label       "ISK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.JMD  rdf:type  cim:Currency ;
+        rdfs:comment     "Jamaican dollar." ;
+        rdfs:label       "JMD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.JOD  rdf:type  cim:Currency ;
+        rdfs:comment     "Jordanian dinar." ;
+        rdfs:label       "JOD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.JPY  rdf:type  cim:Currency ;
+        rdfs:comment     "Japanese yen." ;
+        rdfs:label       "JPY"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KES  rdf:type  cim:Currency ;
+        rdfs:comment     "Kenyan shilling." ;
+        rdfs:label       "KES"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KGS  rdf:type  cim:Currency ;
+        rdfs:comment     "Kyrgyzstani som." ;
+        rdfs:label       "KGS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KHR  rdf:type  cim:Currency ;
+        rdfs:comment     "Cambodian riel." ;
+        rdfs:label       "KHR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KMF  rdf:type  cim:Currency ;
+        rdfs:comment     "Comoro franc." ;
+        rdfs:label       "KMF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KPW  rdf:type  cim:Currency ;
+        rdfs:comment     "North Korean won." ;
+        rdfs:label       "KPW"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KRW  rdf:type  cim:Currency ;
+        rdfs:comment     "South Korean won." ;
+        rdfs:label       "KRW"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KWD  rdf:type  cim:Currency ;
+        rdfs:comment     "Kuwaiti dinar." ;
+        rdfs:label       "KWD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KYD  rdf:type  cim:Currency ;
+        rdfs:comment     "Cayman Islands dollar." ;
+        rdfs:label       "KYD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KZT  rdf:type  cim:Currency ;
+        rdfs:comment     "Kazakhstani tenge." ;
+        rdfs:label       "KZT"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LAK  rdf:type  cim:Currency ;
+        rdfs:comment     "Lao kip." ;
+        rdfs:label       "LAK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LBP  rdf:type  cim:Currency ;
+        rdfs:comment     "Lebanese pound." ;
+        rdfs:label       "LBP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LKR  rdf:type  cim:Currency ;
+        rdfs:comment     "Sri Lanka rupee." ;
+        rdfs:label       "LKR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LRD  rdf:type  cim:Currency ;
+        rdfs:comment     "Liberian dollar." ;
+        rdfs:label       "LRD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LSL  rdf:type  cim:Currency ;
+        rdfs:comment     "Lesotho loti." ;
+        rdfs:label       "LSL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LTL  rdf:type  cim:Currency ;
+        rdfs:comment     "Lithuanian litas." ;
+        rdfs:label       "LTL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LVL  rdf:type  cim:Currency ;
+        rdfs:comment     "Latvian lats." ;
+        rdfs:label       "LVL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LYD  rdf:type  cim:Currency ;
+        rdfs:comment     "Libyan dinar." ;
+        rdfs:label       "LYD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MAD  rdf:type  cim:Currency ;
+        rdfs:comment     "Moroccan dirham." ;
+        rdfs:label       "MAD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MDL  rdf:type  cim:Currency ;
+        rdfs:comment     "Moldovan leu." ;
+        rdfs:label       "MDL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MGA  rdf:type  cim:Currency ;
+        rdfs:comment     "Malagasy ariary." ;
+        rdfs:label       "MGA"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MKD  rdf:type  cim:Currency ;
+        rdfs:comment     "Macedonian denar." ;
+        rdfs:label       "MKD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MMK  rdf:type  cim:Currency ;
+        rdfs:comment     "Myanma kyat." ;
+        rdfs:label       "MMK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MNT  rdf:type  cim:Currency ;
+        rdfs:comment     "Mongolian tugrik." ;
+        rdfs:label       "MNT"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MOP  rdf:type  cim:Currency ;
+        rdfs:comment     "Macanese pataca." ;
+        rdfs:label       "MOP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MRO  rdf:type  cim:Currency ;
+        rdfs:comment     "Mauritanian ouguiya." ;
+        rdfs:label       "MRO"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MUR  rdf:type  cim:Currency ;
+        rdfs:comment     "Mauritian rupee." ;
+        rdfs:label       "MUR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MVR  rdf:type  cim:Currency ;
+        rdfs:comment     "Maldivian rufiyaa." ;
+        rdfs:label       "MVR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MWK  rdf:type  cim:Currency ;
+        rdfs:comment     "Malawian kwacha." ;
+        rdfs:label       "MWK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MXN  rdf:type  cim:Currency ;
+        rdfs:comment     "Mexican peso." ;
+        rdfs:label       "MXN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MYR  rdf:type  cim:Currency ;
+        rdfs:comment     "Malaysian ringgit." ;
+        rdfs:label       "MYR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MZN  rdf:type  cim:Currency ;
+        rdfs:comment     "Mozambican metical." ;
+        rdfs:label       "MZN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NAD  rdf:type  cim:Currency ;
+        rdfs:comment     "Namibian dollar." ;
+        rdfs:label       "NAD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NGN  rdf:type  cim:Currency ;
+        rdfs:comment     "Nigerian naira." ;
+        rdfs:label       "NGN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NIO  rdf:type  cim:Currency ;
+        rdfs:comment     "Cordoba oro." ;
+        rdfs:label       "NIO"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NOK  rdf:type  cim:Currency ;
+        rdfs:comment     "Norwegian krone." ;
+        rdfs:label       "NOK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NPR  rdf:type  cim:Currency ;
+        rdfs:comment     "Nepalese rupee." ;
+        rdfs:label       "NPR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NZD  rdf:type  cim:Currency ;
+        rdfs:comment     "New Zealand dollar." ;
+        rdfs:label       "NZD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.OMR  rdf:type  cim:Currency ;
+        rdfs:comment     "Omani rial." ;
+        rdfs:label       "OMR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PAB  rdf:type  cim:Currency ;
+        rdfs:comment     "Panamanian balboa." ;
+        rdfs:label       "PAB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PEN  rdf:type  cim:Currency ;
+        rdfs:comment     "Peruvian nuevo sol." ;
+        rdfs:label       "PEN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PGK  rdf:type  cim:Currency ;
+        rdfs:comment     "Papua New Guinean kina." ;
+        rdfs:label       "PGK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PHP  rdf:type  cim:Currency ;
+        rdfs:comment     "Philippine peso." ;
+        rdfs:label       "PHP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PKR  rdf:type  cim:Currency ;
+        rdfs:comment     "Pakistani rupee." ;
+        rdfs:label       "PKR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PLN  rdf:type  cim:Currency ;
+        rdfs:comment     "Polish zloty." ;
+        rdfs:label       "PLN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PYG  rdf:type  cim:Currency ;
+        rdfs:comment     "Paraguayan guaraní." ;
+        rdfs:label       "PYG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.QAR  rdf:type  cim:Currency ;
+        rdfs:comment     "Qatari rial." ;
+        rdfs:label       "QAR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.RON  rdf:type  cim:Currency ;
+        rdfs:comment     "Romanian new leu." ;
+        rdfs:label       "RON"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.RSD  rdf:type  cim:Currency ;
+        rdfs:comment     "Serbian dinar." ;
+        rdfs:label       "RSD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.RUB  rdf:type  cim:Currency ;
+        rdfs:comment     "Russian rouble." ;
+        rdfs:label       "RUB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.RWF  rdf:type  cim:Currency ;
+        rdfs:comment     "Rwandan franc." ;
+        rdfs:label       "RWF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SAR  rdf:type  cim:Currency ;
+        rdfs:comment     "Saudi riyal." ;
+        rdfs:label       "SAR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SBD  rdf:type  cim:Currency ;
+        rdfs:comment     "Solomon Islands dollar." ;
+        rdfs:label       "SBD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SCR  rdf:type  cim:Currency ;
+        rdfs:comment     "Seychelles rupee." ;
+        rdfs:label       "SCR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SDG  rdf:type  cim:Currency ;
+        rdfs:comment     "Sudanese pound." ;
+        rdfs:label       "SDG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SEK  rdf:type  cim:Currency ;
+        rdfs:comment     "Swedish krona/kronor." ;
+        rdfs:label       "SEK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SGD  rdf:type  cim:Currency ;
+        rdfs:comment     "Singapore dollar." ;
+        rdfs:label       "SGD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SHP  rdf:type  cim:Currency ;
+        rdfs:comment     "Saint Helena pound." ;
+        rdfs:label       "SHP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SLL  rdf:type  cim:Currency ;
+        rdfs:comment     "Sierra Leonean leone." ;
+        rdfs:label       "SLL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SOS  rdf:type  cim:Currency ;
+        rdfs:comment     "Somali shilling." ;
+        rdfs:label       "SOS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SRD  rdf:type  cim:Currency ;
+        rdfs:comment     "Surinamese dollar." ;
+        rdfs:label       "SRD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.STD  rdf:type  cim:Currency ;
+        rdfs:comment     "São Tomé and Príncipe dobra." ;
+        rdfs:label       "STD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SYP  rdf:type  cim:Currency ;
+        rdfs:comment     "Syrian pound." ;
+        rdfs:label       "SYP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SZL  rdf:type  cim:Currency ;
+        rdfs:comment     "Lilangeni." ;
+        rdfs:label       "SZL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.THB  rdf:type  cim:Currency ;
+        rdfs:comment     "Thai baht." ;
+        rdfs:label       "THB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TJS  rdf:type  cim:Currency ;
+        rdfs:comment     "Tajikistani somoni." ;
+        rdfs:label       "TJS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TMT  rdf:type  cim:Currency ;
+        rdfs:comment     "Turkmenistani manat." ;
+        rdfs:label       "TMT"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TND  rdf:type  cim:Currency ;
+        rdfs:comment     "Tunisian dinar." ;
+        rdfs:label       "TND"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TOP  rdf:type  cim:Currency ;
+        rdfs:comment     "Tongan pa'anga." ;
+        rdfs:label       "TOP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TRY  rdf:type  cim:Currency ;
+        rdfs:comment     "Turkish lira." ;
+        rdfs:label       "TRY"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TTD  rdf:type  cim:Currency ;
+        rdfs:comment     "Trinidad and Tobago dollar." ;
+        rdfs:label       "TTD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TWD  rdf:type  cim:Currency ;
+        rdfs:comment     "New Taiwan dollar." ;
+        rdfs:label       "TWD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TZS  rdf:type  cim:Currency ;
+        rdfs:comment     "Tanzanian shilling." ;
+        rdfs:label       "TZS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.UAH  rdf:type  cim:Currency ;
+        rdfs:comment     "Ukrainian hryvnia." ;
+        rdfs:label       "UAH"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.UGX  rdf:type  cim:Currency ;
+        rdfs:comment     "Ugandan shilling." ;
+        rdfs:label       "UGX"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.USD  rdf:type  cim:Currency ;
+        rdfs:comment     "United States dollar." ;
+        rdfs:label       "USD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.UYU  rdf:type  cim:Currency ;
+        rdfs:comment     "Uruguayan peso." ;
+        rdfs:label       "UYU"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.UZS  rdf:type  cim:Currency ;
+        rdfs:comment     "Uzbekistan som." ;
+        rdfs:label       "UZS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.VEF  rdf:type  cim:Currency ;
+        rdfs:comment     "Venezuelan bolívar fuerte." ;
+        rdfs:label       "VEF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.VND  rdf:type  cim:Currency ;
+        rdfs:comment     "Vietnamese Dong." ;
+        rdfs:label       "VND"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.VUV  rdf:type  cim:Currency ;
+        rdfs:comment     "Vanuatu vatu." ;
+        rdfs:label       "VUV"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.WST  rdf:type  cim:Currency ;
+        rdfs:comment     "Samoan tala." ;
+        rdfs:label       "WST"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.XAF  rdf:type  cim:Currency ;
+        rdfs:comment     "CFA franc BEAC." ;
+        rdfs:label       "XAF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.XCD  rdf:type  cim:Currency ;
+        rdfs:comment     "East Caribbean dollar." ;
+        rdfs:label       "XCD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.XOF  rdf:type  cim:Currency ;
+        rdfs:comment     "CFA Franc BCEAO." ;
+        rdfs:label       "XOF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.XPF  rdf:type  cim:Currency ;
+        rdfs:comment     "CFP franc." ;
+        rdfs:label       "XPF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.YER  rdf:type  cim:Currency ;
+        rdfs:comment     "Yemeni rial." ;
+        rdfs:label       "YER"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ZAR  rdf:type  cim:Currency ;
+        rdfs:comment     "South African rand." ;
+        rdfs:label       "ZAR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ZMK  rdf:type  cim:Currency ;
+        rdfs:comment     "Zambian kwacha." ;
+        rdfs:label       "ZMK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ZWL  rdf:type  cim:Currency ;
+        rdfs:comment     "Zimbabwe dollar." ;
+        rdfs:label       "ZWL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Date  rdf:type              rdfs:Class ;
+        rdfs:comment            "Date as \"yyyy-mm-dd\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddZ\". A local timezone relative UTC is specified as \"yyyy-mm-dd(+/-)hh:mm\"." ;
+        rdfs:label              "Date"@en ;
+        cims:belongsToCategory  ras:Package_DocRemedialActionScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:DateTime  rdf:type          rdfs:Class ;
+        rdfs:comment            "Date and time as \"yyyy-mm-ddThh:mm:ss.sss\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddThh:mm:ss.sssZ\". A local timezone relative UTC is specified as \"yyyy-mm-ddThh:mm:ss.sss-hh:mm\". The second component (shown here as \"ss.sss\") could have any number of digits in its fractional part to allow any kind of precision beyond seconds." ;
+        rdfs:label              "DateTime"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Decimal  rdf:type           rdfs:Class ;
+        rdfs:comment            "Decimal is the base-10 notational system for representing real numbers." ;
+        rdfs:label              "Decimal"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Duration  rdf:type          rdfs:Class ;
+        rdfs:comment            "Duration as \"PnYnMnDTnHnMnS\" which conforms to ISO 8601, where nY expresses a number of years, nM a number of months, nD a number of days. The letter T separates the date expression from the time expression and, after it, nH identifies a number of hours, nM a number of minutes and nS a number of seconds. The number of seconds could be expressed as a decimal number, but all other numbers are integers." ;
+        rdfs:label              "Duration"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Float  rdf:type             rdfs:Class ;
+        rdfs:comment            "A floating point number. The range is unspecified and not limited." ;
+        rdfs:label              "Float"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:IdentifiedObject  rdf:type  rdfs:Class ;
+        rdfs:comment            "This is a root class to provide common identification for all classes needing identification and naming attributes." ;
+        rdfs:label              "IdentifiedObject"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile .
+
+cim:IdentifiedObject.description
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The description is a free human readable text describing or naming the object. It may be non unique and may not correlate to a naming hierarchy." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "description"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.name
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The name is any free human readable and possibly non unique text naming the object." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "name"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Integer  rdf:type           rdfs:Class ;
+        rdfs:comment            "An integer number. The range is unspecified and not limited." ;
+        rdfs:label              "Integer"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:ReactivePower  rdf:type     rdfs:Class ;
+        rdfs:comment            "Product of RMS value of the voltage and the RMS value of the quadrature component of the current." ;
+        rdfs:label              "ReactivePower"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:ReactivePower.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ReactivePower ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ReactivePower.unit
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ReactivePower ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "VAr" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ReactivePower.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ReactivePower ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:RealEnergy  rdf:type        rdfs:Class ;
+        rdfs:comment            "Real electrical energy." ;
+        rdfs:label              "RealEnergy"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:RealEnergy.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:RealEnergy ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:RealEnergy.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:RealEnergy ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "Wh" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:RealEnergy.value  rdf:type  rdf:Property ;
+        rdfs:domain        cim:RealEnergy ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Seconds  rdf:type           rdfs:Class ;
+        rdfs:comment            "Time, in seconds." ;
+        rdfs:label              "Seconds"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Seconds.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:Seconds ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Seconds.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Seconds ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "s" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Seconds.value  rdf:type  rdf:Property ;
+        rdfs:comment       "Time, in seconds" ;
+        rdfs:domain        cim:Seconds ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:String  rdf:type            rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited." ;
+        rdfs:label              "String"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:UnitMultiplier  rdf:type    rdfs:Class ;
+        rdfs:comment            "The unit multipliers defined for the CIM.  When applied to unit symbols, the unit symbol is treated as a derived unit. Regardless of the contents of the unit symbol text, the unit symbol shall be treated as if it were a single-character unit symbol. Unit symbols should not contain multipliers, and it should be left to the multiplier to define the multiple for an entire data type. \n\nFor example, if a unit symbol is \"m2Pers\" and the multiplier is \"k\", then the value is k(m**2/s), and the multiplier applies to the entire final value, not to any individual part of the value. This can be conceptualized by substituting a derived unit symbol for the unit type. If one imagines that the symbol \"Þ\" represents the derived unit \"m2Pers\", then applying the multiplier \"k\" can be conceptualized simply as \"kÞ\".\n\nFor example, the SI unit for mass is \"kg\" and not \"g\".  If the unit symbol is defined as \"kg\", then the multiplier is applied to \"kg\" as a whole and does not replace the \"k\" in front of the \"g\". In this case, the multiplier of \"m\" would be used with the unit symbol of \"kg\" to represent one gram.  As a text string, this violates the instructions in IEC 80000-1. However, because the unit symbol in CIM is treated as a derived unit instead of as an SI unit, it makes more sense to conceptualize the \"kg\" as if it were replaced by one of the proposed replacements for the SI mass symbol. If one imagines that the \"kg\" were replaced by a symbol \"Þ\", then it is easier to conceptualize the multiplier \"m\" as creating the proper unit \"mÞ\", and not the forbidden unit \"mkg\"." ;
+        rdfs:label              "UnitMultiplier"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitMultiplier.M  rdf:type  cim:UnitMultiplier ;
+        rdfs:comment     "Mega 10**6." ;
+        rdfs:label       "M"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitMultiplier.none
+        rdf:type         cim:UnitMultiplier ;
+        rdfs:comment     "No multiplier or equivalently multiply by 1." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol  rdf:type        rdfs:Class ;
+        rdfs:comment            "The derived units defined for usage in the CIM. In some cases, the derived unit is equal to an SI unit. Whenever possible, the standard derived symbol is used instead of the formula for the derived unit. For example, the unit symbol Farad is defined as \"F\" instead of \"CPerV\". In cases where a standard symbol does not exist for a derived unit, the formula for the unit is used as the unit symbol. For example, density does not have a standard symbol and so it is represented as \"kgPerm3\". With the exception of the \"kg\", which is an SI unit, the unit symbols do not contain multipliers and therefore represent the base derived unit to which a multiplier can be applied as a whole. \nEvery unit symbol is treated as an unparseable text as if it were a single-letter symbol. The meaning of each unit symbol is defined by the accompanying descriptive text and not by the text contents of the unit symbol.\nTo allow the widest possible range of serializations without requiring special character handling, several substitutions are made which deviate from the format described in IEC 80000-1. The division symbol \"/\" is replaced by the letters \"Per\". Exponents are written in plain text after the unit as \"m3\" instead of being formatted as \"m\" with a superscript of 3  or introducing a symbol as in \"m^3\". The degree symbol \"°\" is replaced with the letters \"deg\". Any clarification of the meaning for a substitution is included in the description for the unit symbol.\nNon-SI units are included in list of unit symbols to allow sources of data to be correctly labelled with their non-SI units (for example, a GPS sensor that is reporting numbers that represent feet instead of meters). This allows software to use the unit symbol information correctly convert and scale the raw data of those sources into SI-based units. \nThe integer values are used for harmonization with IEC 61850." ;
+        rdfs:label              "UnitSymbol"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitSymbol.VAr  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Reactive power in volt amperes reactive. The “reactive” or “imaginary” component of electrical power (VIsin(phi)). (See also real power and apparent power).\nNote: Different meter designs use different methods to arrive at their results. Some meters may compute reactive power as an arithmetic value, while others compute the value vectorially. The data consumer should determine the method in use and the suitability of the measurement for the intended purpose." ;
+        rdfs:label       "VAr"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.W  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Real power in watts (J/s). Electrical power may have real and reactive components. The real portion of electrical power (I&#178;R or VIcos(phi)), is expressed in Watts. See also apparent power and reactive power." ;
+        rdfs:label       "W"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.Wh  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Real energy in watt hours." ;
+        rdfs:label       "Wh"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.s  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Time in seconds." ;
+        rdfs:label       "s"@en ;
+        cims:stereotype  "enum" .
+
+nc:AvailabilityRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Availability remedial action is a remedial action that cancels or reschedules an availability schedule." ;
+        rdfs:label              "AvailabilityRemedialAction"@en ;
+        rdfs:subClassOf         nc:RemedialAction ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:AvailabilityRemedialAction.AvailabilitySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Availability schedule that is part of the remedial action." ;
+        rdfs:domain           nc:AvailabilityRemedialAction ;
+        rdfs:label            "AvailabilitySchedule"@en ;
+        rdfs:range            nc:AvailabilitySchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AvailabilitySchedule.RemedialAction ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilitySchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A given (un)availability schedule with a given status and cause that include multiple equipment that need to follow the same scheduling periods." ;
+        rdfs:label              "AvailabilitySchedule"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AvailabilitySchedule.RemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action that is cancelling this availability schedule." ;
+        rdfs:domain           nc:AvailabilitySchedule ;
+        rdfs:label            "RemedialAction"@en ;
+        rdfs:range            nc:AvailabilityRemedialAction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AvailabilityRemedialAction.AvailabilitySchedule ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilitySchedule.isCancelled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Defines the cancelling of the availability schedule. True means that is cancelling, False means that it is not cancelling." ;
+        rdfs:domain        nc:AvailabilitySchedule ;
+        rdfs:label         "isCancelled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AvailabilitySchedule.priority
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Value 0 means ignore priority. 1 means the highest priority, 2 is the second highest priority." ;
+        rdfs:domain        nc:AvailabilitySchedule ;
+        rdfs:label         "priority"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseIrregularTimeSeries
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Time series that has irregular points in time." ;
+        rdfs:label              "BaseIrregularTimeSeries"@en ;
+        rdfs:subClassOf         nc:BaseTimeSeries ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:BaseTimeSeries  rdf:type     rdfs:Class ;
+        rdfs:comment            "Time series of values at points in time." ;
+        rdfs:label              "BaseTimeSeries"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:BaseTimeSeries.interpolationKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of interpolation done between time point." ;
+        rdfs:domain        nc:BaseTimeSeries ;
+        rdfs:label         "interpolationKind"@en ;
+        rdfs:range         nc:TimeSeriesInterpolationKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Contingency.CurativeRemedialActionSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Curative remedial action schedule linked to this contingency." ;
+        rdfs:domain           cim:Contingency ;
+        rdfs:label            "CurativeRemedialActionSchedule"@en ;
+        rdfs:range            nc:RemedialActionSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialActionSchedule.Contingency ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:CostSettledKind  rdf:type    rdfs:Class ;
+        rdfs:comment            "Kind describing how settled the cost is in regards to changes." ;
+        rdfs:label              "CostSettledKind"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:CostSettledKind.final
+        rdf:type         nc:CostSettledKind ;
+        rdfs:comment     "Final cost. For instance, the cost is not expected to be changed on a later stage." ;
+        rdfs:label       "final"@en ;
+        cims:stereotype  "enum" .
+
+nc:CostSettledKind.indicative
+        rdf:type         nc:CostSettledKind ;
+        rdfs:comment     "Indicative cost." ;
+        rdfs:label       "indicative"@en ;
+        cims:stereotype  "enum" .
+
+nc:CostSettledKind.provisional
+        rdf:type         nc:CostSettledKind ;
+        rdfs:comment     "Provisional cost." ;
+        rdfs:label       "provisional"@en ;
+        cims:stereotype  "enum" .
+
+nc:CountertradeScheduleAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Countertrade schedule action is an action to rearrange power schedules based on a Generation and Load Shift Key (GLSK) strategy." ;
+        rdfs:label              "CountertradeScheduleAction"@en ;
+        rdfs:subClassOf         nc:PowerScheduleAction ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EventSchedule  rdf:type      rdfs:Class ;
+        rdfs:comment            "Time series represent irregular event described by event points in time." ;
+        rdfs:label              "EventSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EventSchedule.EventTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Value for the point in time." ;
+        rdfs:domain           nc:EventSchedule ;
+        rdfs:label            "EventTimePoint"@en ;
+        rdfs:range            nc:EventTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EventTimePoint.EventSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:EventSchedule.RemedialActionSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action schedule is the event that is validity for the given time series." ;
+        rdfs:domain           nc:EventSchedule ;
+        rdfs:label            "RemedialActionSchedule"@en ;
+        rdfs:range            nc:RemedialActionSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialActionSchedule.EventSchedule ;
+        cims:multiplicity     cims:M:0..1 .
+
+nc:EventTimePoint  rdf:type     rdfs:Class ;
+        rdfs:comment            "Event valid for a given point in time." ;
+        rdfs:label              "EventTimePoint"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EventTimePoint.EventSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Time series the time point values belongs to." ;
+        rdfs:domain           nc:EventTimePoint ;
+        rdfs:label            "EventSchedule"@en ;
+        rdfs:range            nc:EventSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EventSchedule.EventTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:EventTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:EventTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EventTimePoint.isActive
+        rdf:type           rdf:Property ;
+        rdfs:comment       "True, if the event is occurring (Active) at this time point. Otherwise false." ;
+        rdfs:domain        nc:EventTimePoint ;
+        rdfs:label         "isActive"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GenericValueSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Time series represent irregular generic value at given points in time. The type of value is given by the reference association.  " ;
+        rdfs:label              "GenericValueSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:GenericValueSchedule.GenericValueTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Value for the point in time." ;
+        rdfs:domain           nc:GenericValueSchedule ;
+        rdfs:label            "GenericValueTimePoint"@en ;
+        rdfs:range            nc:GenericValueTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GenericValueTimePoint.GenericValueSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:GenericValueSchedule.RemedialActionSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action schedule which has generic value schedules." ;
+        rdfs:domain           nc:GenericValueSchedule ;
+        rdfs:label            "RemedialActionSchedule"@en ;
+        rdfs:range            nc:RemedialActionSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialActionSchedule.GenericValueSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:GenericValueTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Generic value for a given point in time." ;
+        rdfs:label              "GenericValueTimePoint"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:GenericValueTimePoint.GenericValueSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Time series the time point values belongs to." ;
+        rdfs:domain           nc:GenericValueTimePoint ;
+        rdfs:label            "GenericValueSchedule"@en ;
+        rdfs:range            nc:GenericValueSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GenericValueSchedule.GenericValueTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:GenericValueTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:GenericValueTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GenericValueTimePoint.value
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The value at the time. The meaning of the value is defined by the derived type of the associated schedule. The value can be integer, float or boolean. In case of boolean 1 equals true and 0 equals false." ;
+        rdfs:domain        nc:GenericValueTimePoint ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GridStateAlteration
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Grid state alteration is a change of values describing state (operating point) of one element in the grid model compared to the base case." ;
+        rdfs:label              "GridStateAlteration"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:GridStateAlteration.GridStateIntensitySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The intensity associated with a given GridStateAlterationSchedule." ;
+        rdfs:domain           nc:GridStateAlteration ;
+        rdfs:label            "GridStateIntensitySchedule"@en ;
+        rdfs:range            nc:GridStateIntensitySchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GridStateIntensitySchedule.GridStateAlteration ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:GridStateIntensitySchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Defines the intensity applied for a given grid state alteration. It is primarily used in exchanges related to the remedial action schedule. The value provided by the schedule replaces the value of the attribute to which the schedule refers to." ;
+        rdfs:label              "GridStateIntensitySchedule"@en ;
+        rdfs:subClassOf         nc:GenericValueSchedule ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:GridStateIntensitySchedule.GridStateAlteration
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The grid state alteration which has intensity." ;
+        rdfs:domain           nc:GridStateIntensitySchedule ;
+        rdfs:label            "GridStateAlteration"@en ;
+        rdfs:range            nc:GridStateAlteration ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GridStateAlteration.GridStateIntensitySchedule ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:GridStateIntensitySchedule.valueKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The kind of value1 and value2 of the associated IrregularIntervalSchedule." ;
+        rdfs:domain        nc:GridStateIntensitySchedule ;
+        rdfs:label         "valueKind"@en ;
+        rdfs:range         nc:ValueOffsetKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidSchedule  rdf:type   rdfs:Class ;
+        rdfs:comment            "Power bid or offer related to a redispatch or countertrading measures. In the case of market place for economic efficiency of the bids and offers, this is equivalent to BidTimeSeries class in 62325 package." ;
+        rdfs:label              "PowerBidSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:PowerBidSchedule.PowerSchedulelAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The power schedule action pointed by the power bid schedule." ;
+        rdfs:domain           nc:PowerBidSchedule ;
+        rdfs:label            "PowerSchedulelAction"@en ;
+        rdfs:range            nc:PowerScheduleAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerScheduleAction.PowerBidSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerSchedule  rdf:type      rdfs:Class ;
+        rdfs:comment            "Time series represent irregular power, active and reactive, values at given points in time." ;
+        rdfs:label              "PowerSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerSchedule.PowerScheduleAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power schedule action which belongs to the power schedule." ;
+        rdfs:domain           nc:PowerSchedule ;
+        rdfs:label            "PowerScheduleAction"@en ;
+        rdfs:range            nc:PowerScheduleAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerScheduleAction.PowerSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerSchedule.PowerTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Value for the point in time." ;
+        rdfs:domain           nc:PowerSchedule ;
+        rdfs:label            "PowerTimePoint"@en ;
+        rdfs:range            nc:PowerTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerTimePoint.PowerSchedule ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:PowerScheduleAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Power schedule action is an action to rearrange power schedules." ;
+        rdfs:label              "PowerScheduleAction"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:PowerScheduleAction.PowerBidSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The power bid schedule which contains the power schedule action." ;
+        rdfs:domain           nc:PowerScheduleAction ;
+        rdfs:label            "PowerBidSchedule"@en ;
+        rdfs:range            nc:PowerBidSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerBidSchedule.PowerSchedulelAction ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerScheduleAction.PowerSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power schedule which contains the power schedule action." ;
+        rdfs:domain           nc:PowerScheduleAction ;
+        rdfs:label            "PowerSchedule"@en ;
+        rdfs:range            nc:PowerSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerSchedule.PowerScheduleAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerScheduleAction.RemedialActionSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action schedule which power schedule actions." ;
+        rdfs:domain           nc:PowerScheduleAction ;
+        rdfs:label            "RemedialActionSchedule"@en ;
+        rdfs:range            nc:RemedialActionSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialActionSchedule.PowerScheduleAction ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerScheduleAction.currency
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Currency the energy price is given in." ;
+        rdfs:domain        nc:PowerScheduleAction ;
+        rdfs:label         "currency"@en ;
+        rdfs:range         cim:Currency ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerScheduleAction.energyPrice
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Energy price for the power schedule action." ;
+        rdfs:domain        nc:PowerScheduleAction ;
+        rdfs:label         "energyPrice"@en ;
+        cims:dataType      cim:Decimal ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerTimePoint  rdf:type     rdfs:Class ;
+        rdfs:comment            "Power, active and reactive, value at a given point in time." ;
+        rdfs:label              "PowerTimePoint"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerTimePoint.PowerSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Time series the time point values belongs to." ;
+        rdfs:domain           nc:PowerTimePoint ;
+        rdfs:label            "PowerSchedule"@en ;
+        rdfs:range            nc:PowerSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerSchedule.PowerTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerTimePoint.activatedP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Active power activated as part of redispatch. Negative number means that the value is scheduling down. Positive number means that the value is scheduling up." ;
+        rdfs:domain        nc:PowerTimePoint ;
+        rdfs:label         "activatedP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerTimePoint.activatedPrice
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Price for the activated active power per unit e.g. per MW." ;
+        rdfs:domain        nc:PowerTimePoint ;
+        rdfs:label         "activatedPrice"@en ;
+        cims:dataType      cim:Decimal ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:PowerTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerTimePoint.p  rdf:type  rdf:Property ;
+        rdfs:comment       "Active power injection. Load sign convention is used, i.e. positive sign means flow out from a node." ;
+        rdfs:domain        nc:PowerTimePoint ;
+        rdfs:label         "p"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerTimePoint.price
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Price for the scheduled active power per unit of active power. e.g. per MW." ;
+        rdfs:domain        nc:PowerTimePoint ;
+        rdfs:label         "price"@en ;
+        cims:dataType      cim:Decimal ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerTimePoint.q  rdf:type  rdf:Property ;
+        rdfs:comment       "Reactive power injection. Load sign convention is used, i.e. positive sign means flow out from a node." ;
+        rdfs:domain        nc:PowerTimePoint ;
+        rdfs:label         "q"@en ;
+        cims:dataType      cim:ReactivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ProposingRemedialActionScheduleShare
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Proposing entity (System Operator) with a proper cost share for a given remedial action schedule." ;
+        rdfs:label              "ProposingRemedialActionScheduleShare"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ProposingRemedialActionScheduleShare.ProposingEntity
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Proposing entity making the proposing remedial action schedule share." ;
+        rdfs:domain           nc:ProposingRemedialActionScheduleShare ;
+        rdfs:label            "ProposingEntity"@en ;
+        rdfs:range            nc:SystemOperator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SystemOperator.ProposingRemedialActionScheduleShare ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:ProposingRemedialActionScheduleShare.RemedialActionSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action schedule proposed by the proposing entity." ;
+        rdfs:domain           nc:ProposingRemedialActionScheduleShare ;
+        rdfs:label            "RemedialActionSchedule"@en ;
+        rdfs:range            nc:RemedialActionSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialActionSchedule.ProposingRemedialActionScheduleShare ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:ProposingRemedialActionScheduleShare.costSharingFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Sharing factor of the cost of the remedial action as a  fraction of the total cost, i.e. system operator's cost = cost x (costSharingFactor / sum of all costSharingFactor)." ;
+        rdfs:domain        nc:ProposingRemedialActionScheduleShare ;
+        rdfs:label         "costSharingFactor"@en ;
+        cims:dataType      cim:Decimal ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ProposingRemedialActionScheduleShare.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:ProposingRemedialActionScheduleShare ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RedispatchScheduleAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Redispatch schedule action is an action to rearrange power schedules for a scheduled resource to obtain a feasible and secure operational state of the power electricity system." ;
+        rdfs:label              "RedispatchScheduleAction"@en ;
+        rdfs:subClassOf         nc:PowerScheduleAction ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RedispatchScheduleAction.ScheduleResource
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The schedule resource that has this redispatch action." ;
+        rdfs:domain           nc:RedispatchScheduleAction ;
+        rdfs:label            "ScheduleResource"@en ;
+        rdfs:range            nc:ScheduleResource ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ScheduleResource.RedispatchAction ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:Region  rdf:type             rdfs:Class ;
+        rdfs:comment            "A region where the system operator belongs to." ;
+        rdfs:label              "Region"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:Region.RemedialActionSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The remedial action schedule relevant for this region." ;
+        rdfs:domain           nc:Region ;
+        rdfs:label            "RemedialActionSchedule"@en ;
+        rdfs:range            nc:RemedialActionSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialActionSchedule.AssignedRegion ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialAction  rdf:type     rdfs:Class ;
+        rdfs:comment            "Remedial action describes one or more actions that can be performed on a given power system model situation to eliminate one or more identified breaches of constraints. The remedial action can be costly, and have a cost characteristic, or non costly. " ;
+        rdfs:label              "RemedialAction"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:RemedialAction.RemedialActionSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The remedial action schedule associated with a remedial action, i.e. the assigning a schedule to a remedial action." ;
+        rdfs:domain           nc:RemedialAction ;
+        rdfs:label            "RemedialActionSchedule"@en ;
+        rdfs:range            nc:RemedialActionSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialActionSchedule.RemedialAction ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionCost
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Remedial action cost is the total cost itemised cost by category and type for the remedial action." ;
+        rdfs:label              "RemedialActionCost"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RemedialActionCost.RemedialActionSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action schedule for which this remedial action cost relates to." ;
+        rdfs:domain           nc:RemedialActionCost ;
+        rdfs:label            "RemedialActionSchedule"@en ;
+        rdfs:range            nc:RemedialActionSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialActionSchedule.RemedialActionCost ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionCost.costAllocationTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Cost allocation time is the time the cost shall be allocated." ;
+        rdfs:domain        nc:RemedialActionCost ;
+        rdfs:label         "costAllocationTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionCost.kind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Remedial action cost category related to the confirmation of the cost in regards to changes." ;
+        rdfs:domain        nc:RemedialActionCost ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         nc:CostSettledKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionCost.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:RemedialActionCost ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionCost.operationalCost
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Operational cost is the total cost directly related to operate the unit according to the remedial action, e.g. fuel cost." ;
+        rdfs:domain        nc:RemedialActionCost ;
+        rdfs:label         "operationalCost"@en ;
+        cims:dataType      cim:Decimal ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionCost.opportunityCost
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Opportunity cost is the total cost of potential earning that is missed due to performing the remedial action." ;
+        rdfs:domain        nc:RemedialActionCost ;
+        rdfs:label         "opportunityCost"@en ;
+        cims:dataType      cim:Decimal ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionCost.otherCost
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Other cost is the total cost that cannot be directly allocated to any of the other items." ;
+        rdfs:domain        nc:RemedialActionCost ;
+        rdfs:label         "otherCost"@en ;
+        cims:dataType      cim:Decimal ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionCost.processingFee
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Processing fee is the total cost for processing the remedial action." ;
+        rdfs:domain        nc:RemedialActionCost ;
+        rdfs:label         "processingFee"@en ;
+        cims:dataType      cim:Decimal ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionCost.savedFuelCost
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Saved fuel cost is the total saving due to not consuming the expected fuel as part of the remedial action." ;
+        rdfs:domain        nc:RemedialActionCost ;
+        rdfs:label         "savedFuelCost"@en ;
+        cims:dataType      cim:Decimal ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionCost.shutdownCost
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Shutdown cost is the total cost for shutting down a unit as part of the remedial action." ;
+        rdfs:domain        nc:RemedialActionCost ;
+        rdfs:label         "shutdownCost"@en ;
+        cims:dataType      cim:Decimal ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionCost.startupCost
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Start-up cost is the total cost for activating the remedial action, e.g. if a generator needs to be started before it can perform the remedial action." ;
+        rdfs:domain        nc:RemedialActionCost ;
+        rdfs:label         "startupCost"@en ;
+        cims:dataType      cim:Decimal ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A schedule for a determined remedial action." ;
+        rdfs:label              "RemedialActionSchedule"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RemedialActionSchedule.AssignedRegion
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The assigned region for this remedial action schedule." ;
+        rdfs:domain           nc:RemedialActionSchedule ;
+        rdfs:label            "AssignedRegion"@en ;
+        rdfs:range            nc:Region ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Region.RemedialActionSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionSchedule.Contingency
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The contingency for a curative remedial action schedule." ;
+        rdfs:domain           nc:RemedialActionSchedule ;
+        rdfs:label            "Contingency"@en ;
+        rdfs:range            cim:Contingency ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Contingency.CurativeRemedialActionSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionSchedule.EventSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Event schedule that describes the validity of the remedial action schedule." ;
+        rdfs:domain           nc:RemedialActionSchedule ;
+        rdfs:label            "EventSchedule"@en ;
+        rdfs:range            nc:EventSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EventSchedule.RemedialActionSchedule ;
+        cims:multiplicity     cims:M:0..1 .
+
+nc:RemedialActionSchedule.GenericValueSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Generic value schedule which belongs to a remedial action schedule." ;
+        rdfs:domain           nc:RemedialActionSchedule ;
+        rdfs:label            "GenericValueSchedule"@en ;
+        rdfs:range            nc:GenericValueSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GenericValueSchedule.RemedialActionSchedule ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionSchedule.PowerScheduleAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power schedule action which belongs to a remedial action schedule." ;
+        rdfs:domain           nc:RemedialActionSchedule ;
+        rdfs:label            "PowerScheduleAction"@en ;
+        rdfs:range            nc:PowerScheduleAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerScheduleAction.RemedialActionSchedule ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionSchedule.ProposingEntity
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The security coordinator that is proposing this remedial action schedule." ;
+        rdfs:domain           nc:RemedialActionSchedule ;
+        rdfs:label            "ProposingEntity"@en ;
+        rdfs:range            nc:SecurityCoordinator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SecurityCoordinator.RemedialActionSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionSchedule.ProposingRemedialActionScheduleShare
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The entity with its associated share that are making the proposal of the remedial action schedule" ;
+        rdfs:domain           nc:RemedialActionSchedule ;
+        rdfs:label            "ProposingRemedialActionScheduleShare"@en ;
+        rdfs:range            nc:ProposingRemedialActionScheduleShare ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ProposingRemedialActionScheduleShare.RemedialActionSchedule ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionSchedule.RemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The remedial action that has a remedial action schedule associated." ;
+        rdfs:domain           nc:RemedialActionSchedule ;
+        rdfs:label            "RemedialAction"@en ;
+        rdfs:range            nc:RemedialAction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialAction.RemedialActionSchedule ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionSchedule.RemedialActionCost
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action cost related to this remedial schedule." ;
+        rdfs:domain           nc:RemedialActionSchedule ;
+        rdfs:label            "RemedialActionCost"@en ;
+        rdfs:range            nc:RemedialActionCost ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialActionCost.RemedialActionSchedule ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionSchedule.RemedialActionScheduleAcceptance
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The remedial action schedule acceptance related to a remedial action schedule." ;
+        rdfs:domain           nc:RemedialActionSchedule ;
+        rdfs:label            "RemedialActionScheduleAcceptance"@en ;
+        rdfs:range            nc:RemedialActionScheduleAcceptance ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialActionScheduleAcceptance.RemedialActionSchedule ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionSchedule.RemedialActionScheduleGroup
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action schedule group in which the remedial action schedule is allocated." ;
+        rdfs:domain           nc:RemedialActionSchedule ;
+        rdfs:label            "RemedialActionScheduleGroup"@en ;
+        rdfs:range            nc:RemedialActionScheduleGroup ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialActionScheduleGroup.RemedialActionSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionSchedule.statusKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Indicates the status kind for the remedial action schedule." ;
+        rdfs:domain        nc:RemedialActionSchedule ;
+        rdfs:label         "statusKind"@en ;
+        rdfs:range         nc:RemedialActionScheduleStatusKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionSchedule.statusReason
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Description of reasoning for the status. For instance, in case of rejected remedial action, the reason for this rejection is described here." ;
+        rdfs:domain        nc:RemedialActionSchedule ;
+        rdfs:label         "statusReason"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionSchedule.totalCostCurrency
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The currency of the total cost." ;
+        rdfs:domain        nc:RemedialActionSchedule ;
+        rdfs:label         "totalCostCurrency"@en ;
+        rdfs:range         cim:Currency ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionScheduleAcceptance
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "It identifies if the remedial action schedule is accepted for a given system operator." ;
+        rdfs:label              "RemedialActionScheduleAcceptance"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RemedialActionScheduleAcceptance.RemedialActionSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "A remedial action schedule for which a remedial action schedule acceptance is reported." ;
+        rdfs:domain           nc:RemedialActionScheduleAcceptance ;
+        rdfs:label            "RemedialActionSchedule"@en ;
+        rdfs:range            nc:RemedialActionSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialActionSchedule.RemedialActionScheduleAcceptance ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionScheduleAcceptance.SystemOperator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "A system operator for which a remedial action schedule acceptances are reported." ;
+        rdfs:domain           nc:RemedialActionScheduleAcceptance ;
+        rdfs:label            "SystemOperator"@en ;
+        rdfs:range            nc:SystemOperator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SystemOperator.RemedialActionScheduleAcceptance ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionScheduleAcceptance.kind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The kind of the remedial action acceptance." ;
+        rdfs:domain        nc:RemedialActionScheduleAcceptance ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         nc:RemedialActionScheduleAcceptanceKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionScheduleAcceptance.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:RemedialActionScheduleAcceptance ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionScheduleAcceptanceKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The kind of acceptance for a remedial action schedule." ;
+        rdfs:label              "RemedialActionScheduleAcceptanceKind"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:RemedialActionScheduleAcceptanceKind.accepted
+        rdf:type         nc:RemedialActionScheduleAcceptanceKind ;
+        rdfs:comment     "The acceptance of remedial action schedule is concluded and accepted." ;
+        rdfs:label       "accepted"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionScheduleAcceptanceKind.refused
+        rdf:type         nc:RemedialActionScheduleAcceptanceKind ;
+        rdfs:comment     "The acceptance of the remedial action schedule is concluded and refused." ;
+        rdfs:label       "refused"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionScheduleAcceptanceKind.timeout
+        rdf:type         nc:RemedialActionScheduleAcceptanceKind ;
+        rdfs:comment     "The acceptance of the remedial action schedule was not completed due to timeout." ;
+        rdfs:label       "timeout"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionScheduleAcceptanceKind.waiting
+        rdf:type         nc:RemedialActionScheduleAcceptanceKind ;
+        rdfs:comment     "The acceptance of the remedial action schedule is waiting (in progress)." ;
+        rdfs:label       "waiting"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionScheduleGroup
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Remedial action schedule group collects two or more remedial action schedules together. The remedial action schedule group needs to be set up for the same remedial action or proposing alternative remedial action by including a reference to another remedial action." ;
+        rdfs:label              "RemedialActionScheduleGroup"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RemedialActionScheduleGroup.RemedialActionSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action schedule included in the remedial action schedule group." ;
+        rdfs:domain           nc:RemedialActionScheduleGroup ;
+        rdfs:label            "RemedialActionSchedule"@en ;
+        rdfs:range            nc:RemedialActionSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialActionSchedule.RemedialActionScheduleGroup ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionScheduleStatusKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Remedial action schedule status kinds." ;
+        rdfs:label              "RemedialActionScheduleStatusKind"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:RemedialActionScheduleStatusKind.activated
+        rdf:type         nc:RemedialActionScheduleStatusKind ;
+        rdfs:comment     "Activated remedial action schedule." ;
+        rdfs:label       "activated"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionScheduleStatusKind.agreed
+        rdf:type         nc:RemedialActionScheduleStatusKind ;
+        rdfs:comment     "Agreed remedial action schedule." ;
+        rdfs:label       "agreed"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionScheduleStatusKind.agreementValidated
+        rdf:type         nc:RemedialActionScheduleStatusKind ;
+        rdfs:comment     "The agreement is validated for the remedial action schedule." ;
+        rdfs:label       "agreementValidated"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionScheduleStatusKind.implemented
+        rdf:type         nc:RemedialActionScheduleStatusKind ;
+        rdfs:comment     "An ordered remedial action is implemented." ;
+        rdfs:label       "implemented"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionScheduleStatusKind.notUsed
+        rdf:type         nc:RemedialActionScheduleStatusKind ;
+        rdfs:comment     "Not used remedial action schedule." ;
+        rdfs:label       "notUsed"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionScheduleStatusKind.ordered
+        rdf:type         nc:RemedialActionScheduleStatusKind ;
+        rdfs:comment     "Ordered remedial action schedule." ;
+        rdfs:label       "ordered"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionScheduleStatusKind.previouslyAgreed
+        rdf:type         nc:RemedialActionScheduleStatusKind ;
+        rdfs:comment     "Previously agreed remedial action schedule." ;
+        rdfs:label       "previouslyAgreed"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionScheduleStatusKind.proposed
+        rdf:type         nc:RemedialActionScheduleStatusKind ;
+        rdfs:comment     "Proposed remedial action schedule." ;
+        rdfs:label       "proposed"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionScheduleStatusKind.rejected
+        rdf:type         nc:RemedialActionScheduleStatusKind ;
+        rdfs:comment     "Rejected remedial action schedule." ;
+        rdfs:label       "rejected"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionScheduleStatusKind.rejectionValidated
+        rdf:type         nc:RemedialActionScheduleStatusKind ;
+        rdfs:comment     "The rejection is validated for the remedial action schedule." ;
+        rdfs:label       "rejectionValidated"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialActionSchemeSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The schedule for a remedial action scheme." ;
+        rdfs:label              "RemedialActionSchemeSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RemedialActionSchemeSchedule.ArmedRemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Armed remedial action for a remedial action scheme." ;
+        rdfs:domain           nc:RemedialActionSchemeSchedule ;
+        rdfs:label            "ArmedRemedialAction"@en ;
+        rdfs:range            nc:SchemeRemedialAction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SchemeRemedialAction.RemedialActionSchemeSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ScheduleResource  rdf:type   rdfs:Class ;
+        rdfs:comment            "A schedule resource is a market-based method for handling participation of small units, particularly located on the lower voltage level that is controlled by a Distributed System Operator (DSO). It is a collection of units that can operate in the market by providing bids, offers and a resulting committed operational schedule for the collection." ;
+        rdfs:label              "ScheduleResource"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:ScheduleResource.RedispatchAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The redispatch action that relates to this schedule resource." ;
+        rdfs:domain           nc:ScheduleResource ;
+        rdfs:label            "RedispatchAction"@en ;
+        rdfs:range            nc:RedispatchScheduleAction ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RedispatchScheduleAction.ScheduleResource ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SchemeRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Scheme remedial action is remedial action that involves a scheme that can include conditional logic and stages of grid alteration. The primary remedial action is the arming of these schemes, that will then perform curative remedial action when the condition is met. System Integrity Protection Scheme (SIPS) and Special Protection Scheme (SPS) are example of this. " ;
+        rdfs:label              "SchemeRemedialAction"@en ;
+        rdfs:subClassOf         nc:RemedialAction ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SchemeRemedialAction.RemedialActionSchemeSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action scheme schedule that has this armed remedial action." ;
+        rdfs:domain           nc:SchemeRemedialAction ;
+        rdfs:label            "RemedialActionSchemeSchedule"@en ;
+        rdfs:range            nc:RemedialActionSchemeSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialActionSchemeSchedule.ArmedRemedialAction ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:SecurityCoordinator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A role that coordinates the relevant remedial actions and their optimisation to ensure efficient use to achieve required operational security of the power system." ;
+        rdfs:label              "SecurityCoordinator"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:SecurityCoordinator.RemedialActionSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action schedule for this security coordinator." ;
+        rdfs:domain           nc:SecurityCoordinator ;
+        rdfs:label            "RemedialActionSchedule"@en ;
+        rdfs:range            nc:RemedialActionSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialActionSchedule.ProposingEntity ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SystemOperator  rdf:type     rdfs:Class ;
+        rdfs:comment            "System operator." ;
+        rdfs:label              "SystemOperator"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:SystemOperator.ProposingRemedialActionScheduleShare
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Proposing remedial action schedule share which is made by the proposing entity." ;
+        rdfs:domain           nc:SystemOperator ;
+        rdfs:label            "ProposingRemedialActionScheduleShare"@en ;
+        rdfs:range            nc:ProposingRemedialActionScheduleShare ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ProposingRemedialActionScheduleShare.ProposingEntity ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SystemOperator.RemedialActionScheduleAcceptance
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action schedule acceptance related to a system operator." ;
+        rdfs:domain           nc:SystemOperator ;
+        rdfs:label            "RemedialActionScheduleAcceptance"@en ;
+        rdfs:range            nc:RemedialActionScheduleAcceptance ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialActionScheduleAcceptance.SystemOperator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:TimeSeriesInterpolationKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kinds of interpolation of values between two time point. " ;
+        rdfs:label              "TimeSeriesInterpolationKind"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:TimeSeriesInterpolationKind.next
+        rdf:type         nc:TimeSeriesInterpolationKind ;
+        rdfs:comment     "The value between two time points is set to next value." ;
+        rdfs:label       "next"@en ;
+        cims:stereotype  "enum" .
+
+nc:TimeSeriesInterpolationKind.none
+        rdf:type         nc:TimeSeriesInterpolationKind ;
+        rdfs:comment     "No interpolation is applied." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+nc:ValueOffsetKind  rdf:type    rdfs:Class ;
+        rdfs:comment            "The kind of the value offset." ;
+        rdfs:label              "ValueOffsetKind"@en ;
+        cims:belongsToCategory  ras:Package_RemedialActionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:ValueOffsetKind.absolute
+        rdf:type         nc:ValueOffsetKind ;
+        rdfs:comment     "Value of the range constraint is replacing the attribute value referenced by the PropertyReference in a determined operational scenario." ;
+        rdfs:label       "absolute"@en ;
+        cims:stereotype  "enum" .
+
+nc:ValueOffsetKind.incremental
+        rdf:type         nc:ValueOffsetKind ;
+        rdfs:comment     "Value of the range constraint is incrementing the attribute value referenced by the PropertyReference in a determined operational scenario." ;
+        rdfs:label       "incremental"@en ;
+        cims:stereotype  "enum" .
+
+nc:ValueOffsetKind.incrementalPercentage
+        rdf:type         nc:ValueOffsetKind ;
+        rdfs:comment     "Value of the range constraint is incrementing in percentage the attribute value referenced by the PropertyReference in a determined operational scenario. " ;
+        rdfs:label       "incrementalPercentage"@en ;
+        cims:stereotype  "enum" .
+
+profcim:IRI  rdf:type           rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as rdf:resource in RDFXML.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "IRI"@en ;
+        cims:belongsToCategory  ras:Package_DocRemedialActionScheduleProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringFixedLanguage
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited.\nThe primitive is serialized as literal without language support." ;
+        rdfs:label              "StringFixedLanguage"@en ;
+        cims:belongsToCategory  ras:Package_DocRemedialActionScheduleProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringIRI  rdf:type     rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as literal without language support.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "StringIRI"@en ;
+        cims:belongsToCategory  ras:Package_DocRemedialActionScheduleProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:URL  rdf:type           rdfs:Class ;
+        rdfs:comment            "A Uniform Resource Locator (URL), colloquially termed a web address, is a reference to a web resource that specifies its location on a computer network and a mechanism for retrieving it. A URL is a specific type of Uniform Resource Identifier (URI), although many people use the two terms interchangeably.URLs occur most commonly to reference web pages (http), but are also used for file transfer (ftp), email (mailto), database access (JDBC), and many other applications." ;
+        rdfs:label              "URL"@en ;
+        cims:belongsToCategory  ras:Package_DocRemedialActionScheduleProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+ras:Ontology  rdf:type        owl:Ontology ;
+        dcterms:conformsTo    "urn:iso:std:iec:61970-501:draft:ed-2" , "file://CIM100_CGMES31v01_501-20v02_NC23v62_MM10v01.eap" , "urn:iso:std:iec:61970-600-2:ed-1" , "urn:iso:std:iec:61970-301:ed-7:amd1" , "urn:iso:std:iec:61970-401:draft:ed-1" , "file://iec61970cim17v40_iec61968cim13v13a_iec62325cim03v17a.eap" ;
+        dcterms:creator       "ENTSO-E CIM WG NC project "@en ;
+        dcterms:description   "This vocabulary is describing the remedial action schedule profile."@en ;
+        dcterms:identifier    "urn:uuid:6e90c546-3c6c-471b-8040-e05037081c59" ;
+        dcterms:language      "en-GB" ;
+        dcterms:license       "https://www.apache.org/licenses/LICENSE-2.0"@en ;
+        dcterms:modified      "2024-03-20"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        dcterms:publisher     "ENTSO-E"@en ;
+        dcterms:rightsHolder  "ENTSO-E"@en ;
+        dcterms:title         "Remedial Action Schedule Vocabulary"@en ;
+        owl:priorVersion      <http://entsoe.eu/ns/CIM/RemedialActionSchedule-EU/2.2> ;
+        owl:versionIRI        <https://ap.cim4.eu/RemedialActionSchedule/2.3> ;
+        owl:versionInfo       "2.3.0"@en ;
+        dcat:keyword          "RAS" ;
+        dcat:theme            "vocabulary"@en .
+
+ras:Package_DocRemedialActionScheduleProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains datatypes used only in the RDFS header." ;
+        rdfs:label    "DocRemedialActionScheduleProfile"@en .
+
+ras:Package_RemedialActionScheduleProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains remedial action schedule profile." ;
+        rdfs:label    "RemedialActionScheduleProfile"@en .
+

--- a/r2.3/ap-voc/ttl/SecurityAnalysisResult-AP-Voc-RDFS2020.ttl
+++ b/r2.3/ap-voc/ttl/SecurityAnalysisResult-AP-Voc-RDFS2020.ttl
@@ -1,0 +1,605 @@
+@prefix cim:     <https://cim.ucaiug.io/ns#> .
+@prefix cims:    <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/#> .
+@prefix nc:      <https://cim4.eu/ns/nc#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix profcim: <https://cim.ucaiug.io/ns/prof-cim#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sar:     <https://ap.cim4.eu/SecurityAnalysisResult#> .
+
+cim:ACDCTerminal  rdf:type      rdfs:Class ;
+        rdfs:comment            "An electrical connection point (AC or DC) to a piece of conducting equipment. Terminals are connected at physical connection points called connectivity nodes." ;
+        rdfs:label              "ACDCTerminal"@en ;
+        cims:belongsToCategory  sar:Package_SecurityAnalysisResultProfile .
+
+cim:ActivePower  rdf:type       rdfs:Class ;
+        rdfs:comment            "Product of RMS value of the voltage and the RMS value of the in-phase component of the current." ;
+        rdfs:label              "ActivePower"@en ;
+        cims:belongsToCategory  sar:Package_SecurityAnalysisResultProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:ActivePower.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePower.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "W" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePower.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:AngleDegrees  rdf:type      rdfs:Class ;
+        rdfs:comment            "Measurement of angle in degrees." ;
+        rdfs:label              "AngleDegrees"@en ;
+        cims:belongsToCategory  sar:Package_SecurityAnalysisResultProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:AngleDegrees.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:AngleDegrees ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:AngleDegrees.unit
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:AngleDegrees ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "deg" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:AngleDegrees.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:AngleDegrees ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ApparentPower  rdf:type     rdfs:Class ;
+        rdfs:comment            "Product of the RMS value of the voltage and the RMS value of the current." ;
+        rdfs:label              "ApparentPower"@en ;
+        cims:belongsToCategory  sar:Package_SecurityAnalysisResultProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:ApparentPower.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ApparentPower ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ApparentPower.unit
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ApparentPower ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "VA" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ApparentPower.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ApparentPower ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Boolean  rdf:type           rdfs:Class ;
+        rdfs:comment            "A type with the value space \"true\" and \"false\"." ;
+        rdfs:label              "Boolean"@en ;
+        cims:belongsToCategory  sar:Package_SecurityAnalysisResultProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Contingency  rdf:type       rdfs:Class ;
+        rdfs:comment            "An event threatening system reliability, consisting of one or more contingency elements." ;
+        rdfs:label              "Contingency"@en ;
+        cims:belongsToCategory  sar:Package_SecurityAnalysisResultProfile .
+
+cim:CurrentFlow  rdf:type       rdfs:Class ;
+        rdfs:comment            "Electrical current with sign convention: positive flow is out of the conducting equipment into the connectivity node. Can be both AC and DC." ;
+        rdfs:label              "CurrentFlow"@en ;
+        cims:belongsToCategory  sar:Package_SecurityAnalysisResultProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:CurrentFlow.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:CurrentFlow ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:CurrentFlow.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:CurrentFlow ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "A" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:CurrentFlow.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:CurrentFlow ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Date  rdf:type              rdfs:Class ;
+        rdfs:comment            "Date as \"yyyy-mm-dd\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddZ\". A local timezone relative UTC is specified as \"yyyy-mm-dd(+/-)hh:mm\"." ;
+        rdfs:label              "Date"@en ;
+        cims:belongsToCategory  sar:Package_DocSecurityAnalysisResultProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:DateTime  rdf:type          rdfs:Class ;
+        rdfs:comment            "Date and time as \"yyyy-mm-ddThh:mm:ss.sss\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddThh:mm:ss.sssZ\". A local timezone relative UTC is specified as \"yyyy-mm-ddThh:mm:ss.sss-hh:mm\". The second component (shown here as \"ss.sss\") could have any number of digits in its fractional part to allow any kind of precision beyond seconds." ;
+        rdfs:label              "DateTime"@en ;
+        cims:belongsToCategory  sar:Package_SecurityAnalysisResultProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Float  rdf:type             rdfs:Class ;
+        rdfs:comment            "A floating point number. The range is unspecified and not limited." ;
+        rdfs:label              "Float"@en ;
+        cims:belongsToCategory  sar:Package_SecurityAnalysisResultProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:OperationalLimit  rdf:type  rdfs:Class ;
+        rdfs:comment            "A value and normal value associated with a specific kind of limit. \nThe sub class value and normalValue attributes vary inversely to the associated OperationalLimitType.acceptableDuration (acceptableDuration for short).  \nIf a particular piece of equipment has multiple operational limits of the same kind (apparent power, current, etc.), the limit with the greatest acceptableDuration shall have the smallest limit value and the limit with the smallest acceptableDuration shall have the largest limit value.  Note: A large current can only be allowed to flow through a piece of equipment for a short duration without causing damage, but a lesser current can be allowed to flow for a longer duration. " ;
+        rdfs:label              "OperationalLimit"@en ;
+        cims:belongsToCategory  sar:Package_SecurityAnalysisResultProfile .
+
+cim:PerCent  rdf:type           rdfs:Class ;
+        rdfs:comment            "Percentage on a defined base.   For example, specify as 100 to indicate at the defined base." ;
+        rdfs:label              "PerCent"@en ;
+        cims:belongsToCategory  sar:Package_SecurityAnalysisResultProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:PerCent.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent.value  rdf:type  rdf:Property ;
+        rdfs:comment       "Normally 0 to 100 on a defined base." ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ReactivePower  rdf:type     rdfs:Class ;
+        rdfs:comment            "Product of RMS value of the voltage and the RMS value of the quadrature component of the current." ;
+        rdfs:label              "ReactivePower"@en ;
+        cims:belongsToCategory  sar:Package_SecurityAnalysisResultProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:ReactivePower.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ReactivePower ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ReactivePower.unit
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ReactivePower ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "VAr" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ReactivePower.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ReactivePower ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:String  rdf:type            rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited." ;
+        rdfs:label              "String"@en ;
+        cims:belongsToCategory  sar:Package_SecurityAnalysisResultProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:UnitMultiplier  rdf:type    rdfs:Class ;
+        rdfs:comment            "The unit multipliers defined for the CIM.  When applied to unit symbols, the unit symbol is treated as a derived unit. Regardless of the contents of the unit symbol text, the unit symbol shall be treated as if it were a single-character unit symbol. Unit symbols should not contain multipliers, and it should be left to the multiplier to define the multiple for an entire data type. \n\nFor example, if a unit symbol is \"m2Pers\" and the multiplier is \"k\", then the value is k(m**2/s), and the multiplier applies to the entire final value, not to any individual part of the value. This can be conceptualized by substituting a derived unit symbol for the unit type. If one imagines that the symbol \"Þ\" represents the derived unit \"m2Pers\", then applying the multiplier \"k\" can be conceptualized simply as \"kÞ\".\n\nFor example, the SI unit for mass is \"kg\" and not \"g\".  If the unit symbol is defined as \"kg\", then the multiplier is applied to \"kg\" as a whole and does not replace the \"k\" in front of the \"g\". In this case, the multiplier of \"m\" would be used with the unit symbol of \"kg\" to represent one gram.  As a text string, this violates the instructions in IEC 80000-1. However, because the unit symbol in CIM is treated as a derived unit instead of as an SI unit, it makes more sense to conceptualize the \"kg\" as if it were replaced by one of the proposed replacements for the SI mass symbol. If one imagines that the \"kg\" were replaced by a symbol \"Þ\", then it is easier to conceptualize the multiplier \"m\" as creating the proper unit \"mÞ\", and not the forbidden unit \"mkg\"." ;
+        rdfs:label              "UnitMultiplier"@en ;
+        cims:belongsToCategory  sar:Package_SecurityAnalysisResultProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitMultiplier.M  rdf:type  cim:UnitMultiplier ;
+        rdfs:comment     "Mega 10**6." ;
+        rdfs:label       "M"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitMultiplier.k  rdf:type  cim:UnitMultiplier ;
+        rdfs:comment     "Kilo 10**3." ;
+        rdfs:label       "k"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitMultiplier.none
+        rdf:type         cim:UnitMultiplier ;
+        rdfs:comment     "No multiplier or equivalently multiply by 1." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol  rdf:type        rdfs:Class ;
+        rdfs:comment            "The derived units defined for usage in the CIM. In some cases, the derived unit is equal to an SI unit. Whenever possible, the standard derived symbol is used instead of the formula for the derived unit. For example, the unit symbol Farad is defined as \"F\" instead of \"CPerV\". In cases where a standard symbol does not exist for a derived unit, the formula for the unit is used as the unit symbol. For example, density does not have a standard symbol and so it is represented as \"kgPerm3\". With the exception of the \"kg\", which is an SI unit, the unit symbols do not contain multipliers and therefore represent the base derived unit to which a multiplier can be applied as a whole. \nEvery unit symbol is treated as an unparseable text as if it were a single-letter symbol. The meaning of each unit symbol is defined by the accompanying descriptive text and not by the text contents of the unit symbol.\nTo allow the widest possible range of serializations without requiring special character handling, several substitutions are made which deviate from the format described in IEC 80000-1. The division symbol \"/\" is replaced by the letters \"Per\". Exponents are written in plain text after the unit as \"m3\" instead of being formatted as \"m\" with a superscript of 3  or introducing a symbol as in \"m^3\". The degree symbol \"°\" is replaced with the letters \"deg\". Any clarification of the meaning for a substitution is included in the description for the unit symbol.\nNon-SI units are included in list of unit symbols to allow sources of data to be correctly labelled with their non-SI units (for example, a GPS sensor that is reporting numbers that represent feet instead of meters). This allows software to use the unit symbol information correctly convert and scale the raw data of those sources into SI-based units. \nThe integer values are used for harmonization with IEC 61850." ;
+        rdfs:label              "UnitSymbol"@en ;
+        cims:belongsToCategory  sar:Package_SecurityAnalysisResultProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitSymbol.A  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Current in amperes." ;
+        rdfs:label       "A"@en ;
+        cims:stereotype  "enum" .
+cim:UnitSymbol.V  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Electric potential in volts (W/A)." ;
+        rdfs:label       "V"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.VA  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Apparent power in volt amperes. See also real power and reactive power." ;
+        rdfs:label       "VA"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.VAr  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Reactive power in volt amperes reactive. The “reactive” or “imaginary” component of electrical power (VIsin(phi)). (See also real power and apparent power).\nNote: Different meter designs use different methods to arrive at their results. Some meters may compute reactive power as an arithmetic value, while others compute the value vectorially. The data consumer should determine the method in use and the suitability of the measurement for the intended purpose." ;
+        rdfs:label       "VAr"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.W  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Real power in watts (J/s). Electrical power may have real and reactive components. The real portion of electrical power (I&#178;R or VIcos(phi)), is expressed in Watts. See also apparent power and reactive power." ;
+        rdfs:label       "W"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.deg  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Plane angle in degrees." ;
+        rdfs:label       "deg"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.none  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Dimension less quantity, e.g. count, per unit, etc." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+cim:Voltage  rdf:type           rdfs:Class ;
+        rdfs:comment            "Electrical voltage, can be both AC and DC." ;
+        rdfs:label              "Voltage"@en ;
+        cims:belongsToCategory  sar:Package_SecurityAnalysisResultProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Voltage.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:Voltage ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "k" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Voltage.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Voltage ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "V" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Voltage.value  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Voltage ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ACDCTerminal.PowerFlowResult
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power result associated with the ACDC terminal." ;
+        rdfs:domain           cim:ACDCTerminal ;
+        rdfs:label            "PowerFlowResult"@en ;
+        rdfs:range            nc:PowerFlowResult ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerFlowResult.ACDCTerminal ;
+        cims:multiplicity     cims:M:0..n .
+
+nc:BaseCasePowerFlowResult
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Base case power flow result for a given terminal." ;
+        rdfs:label              "BaseCasePowerFlowResult"@en ;
+        rdfs:subClassOf         nc:PowerFlowResult ;
+        cims:belongsToCategory  sar:Package_SecurityAnalysisResultProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:Contingency.ContingencyPowerFlowResult
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The power flow result that is associated with a contingency." ;
+        rdfs:domain           cim:Contingency ;
+        rdfs:label            "ContingencyPowerFlowResult"@en ;
+        rdfs:range            nc:ContingencyPowerFlowResult ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ContingencyPowerFlowResult.Contingency ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ContingencyPowerFlowResult
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Contingency power flow result on a given terminal for a given contingency." ;
+        rdfs:label              "ContingencyPowerFlowResult"@en ;
+        rdfs:subClassOf         nc:PowerFlowResult ;
+        cims:belongsToCategory  sar:Package_SecurityAnalysisResultProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ContingencyPowerFlowResult.Contingency
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The contingency that has this power flow result." ;
+        rdfs:domain           nc:ContingencyPowerFlowResult ;
+        rdfs:label            "Contingency"@en ;
+        rdfs:range            cim:Contingency ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Contingency.ContingencyPowerFlowResult ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:OperationalLimit.PowerFlowResult
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The limit violation associated with an operational limit." ;
+        rdfs:domain           cim:OperationalLimit ;
+        rdfs:label            "PowerFlowResult"@en ;
+        rdfs:range            nc:PowerFlowResult ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerFlowResult.OperationalLimit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerFlowResult  rdf:type    rdfs:Class ;
+        rdfs:comment            "Power flow result including any operational limit violation." ;
+        rdfs:label              "PowerFlowResult"@en ;
+        cims:belongsToCategory  sar:Package_SecurityAnalysisResultProfile ;
+        cims:stereotype         "NC" .
+
+nc:PowerFlowResult.ACDCTerminal
+        rdf:type              rdf:Property ;
+        rdfs:comment          "ACDC terminal where the powerflow result is located." ;
+        rdfs:domain           nc:PowerFlowResult ;
+        rdfs:label            "ACDCTerminal"@en ;
+        rdfs:range            cim:ACDCTerminal ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ACDCTerminal.PowerFlowResult ;
+        cims:multiplicity     cims:M:1 .
+
+nc:PowerFlowResult.OperationalLimit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The operational limit that has this limit violation." ;
+        rdfs:domain           nc:PowerFlowResult ;
+        rdfs:label            "OperationalLimit"@en ;
+        rdfs:range            cim:OperationalLimit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:OperationalLimit.PowerFlowResult ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerFlowResult.ReportedByRegion
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The region which reports this limit violation." ;
+        rdfs:domain           nc:PowerFlowResult ;
+        rdfs:label            "ReportedByRegion"@en ;
+        rdfs:range            nc:Region ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Region.LimitViolation ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerFlowResult.absoluteValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Absolute value from a power flow calculation on a given terminal related to a given operational limit. For instance, if the operational limit is 1000 A and the current flow is 1100 A the absoluteValue is reported as 1100 A." ;
+        rdfs:domain        nc:PowerFlowResult ;
+        rdfs:label         "absoluteValue"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerFlowResult.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The date and time of the scenario time that was studied and at which the limit violation occurred." ;
+        rdfs:domain        nc:PowerFlowResult ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerFlowResult.isViolation
+        rdf:type           rdf:Property ;
+        rdfs:comment       "True if the power flow result is violating the associated operational limit. False if it is not violating the associated operational limits." ;
+        rdfs:domain        nc:PowerFlowResult ;
+        rdfs:label         "isViolation"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerFlowResult.value
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The value of the limit violation in percent related to the value of the operational limit that is violated. For instance, if the operational limit is 1000 A and the current flow is 1100 A the value is reported as 110 %.  " ;
+        rdfs:domain        nc:PowerFlowResult ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerFlowResult.valueA
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Current from a power flow calculation on a given terminal.\nLoad sign convention is used, i.e. positive sign means flow out from a TopologicalNode (bus) into the conducting equipment." ;
+        rdfs:domain        nc:PowerFlowResult ;
+        rdfs:label         "valueA"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerFlowResult.valueAngle
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Voltage angle value from a power flow calculation on a given terminal." ;
+        rdfs:domain        nc:PowerFlowResult ;
+        rdfs:label         "valueAngle"@en ;
+        cims:dataType      cim:AngleDegrees ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerFlowResult.valueV
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Voltage value from a power flow calculation on a given terminal. The attribute shall be a positive value." ;
+        rdfs:domain        nc:PowerFlowResult ;
+        rdfs:label         "valueV"@en ;
+        cims:dataType      cim:Voltage ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerFlowResult.valueVA
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Apparent power value from a power flow calculation on a given terminal." ;
+        rdfs:domain        nc:PowerFlowResult ;
+        rdfs:label         "valueVA"@en ;
+        cims:dataType      cim:ApparentPower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerFlowResult.valueVAR
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Reactive power value from a power flow calculation on a given terminal.\nLoad sign convention is used, i.e. positive sign means flow out from a TopologicalNode (bus) into the conducting equipment." ;
+        rdfs:domain        nc:PowerFlowResult ;
+        rdfs:label         "valueVAR"@en ;
+        cims:dataType      cim:ReactivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerFlowResult.valueW
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Active power value from a power flow calculation on a given terminal. \nLoad sign convention is used, i.e. positive sign means flow out from a TopologicalNode (bus) into the conducting equipment." ;
+        rdfs:domain        nc:PowerFlowResult ;
+        rdfs:label         "valueW"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Region  rdf:type             rdfs:Class ;
+        rdfs:comment            "A region where the system operator belongs to." ;
+        rdfs:label              "Region"@en ;
+        cims:belongsToCategory  sar:Package_SecurityAnalysisResultProfile ;
+        cims:stereotype         "NC" .
+
+nc:Region.LimitViolation
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The limit violation reported by a region." ;
+        rdfs:domain           nc:Region ;
+        rdfs:label            "LimitViolation"@en ;
+        rdfs:range            nc:PowerFlowResult ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerFlowResult.ReportedByRegion ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+profcim:IRI  rdf:type           rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as rdf:resource in RDFXML.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "IRI"@en ;
+        cims:belongsToCategory  sar:Package_DocSecurityAnalysisResultProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringFixedLanguage
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited.\nThe primitive is serialized as literal without language support." ;
+        rdfs:label              "StringFixedLanguage"@en ;
+        cims:belongsToCategory  sar:Package_DocSecurityAnalysisResultProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringIRI  rdf:type     rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as literal without language support.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "StringIRI"@en ;
+        cims:belongsToCategory  sar:Package_DocSecurityAnalysisResultProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:URL  rdf:type           rdfs:Class ;
+        rdfs:comment            "A Uniform Resource Locator (URL), colloquially termed a web address, is a reference to a web resource that specifies its location on a computer network and a mechanism for retrieving it. A URL is a specific type of Uniform Resource Identifier (URI), although many people use the two terms interchangeably.URLs occur most commonly to reference web pages (http), but are also used for file transfer (ftp), email (mailto), database access (JDBC), and many other applications." ;
+        rdfs:label              "URL"@en ;
+        cims:belongsToCategory  sar:Package_DocSecurityAnalysisResultProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+sar:Ontology  rdf:type        owl:Ontology ;
+        dcterms:conformsTo    "file://iec61970cim17v40_iec61968cim13v13a_iec62325cim03v17a.eap" , "urn:iso:std:iec:61970-401:draft:ed-1" , "urn:iso:std:iec:61970-501:draft:ed-2" , "urn:iso:std:iec:61970-301:ed-7:amd1" , "urn:iso:std:iec:61970-600-2:ed-1" , "file://CIM100_CGMES31v01_501-20v02_NC23v62_MM10v01.eap" ;
+        dcterms:creator       "ENTSO-E CIM WG NC project"@en ;
+        dcterms:description   "This vocabulary is describing the security analysis result profile."@en ;
+        dcterms:identifier    "urn:uuid:7d53a1b2-0dcc-4556-b868-6ed099bd9ac9" ;
+        dcterms:language      "en-GB" ;
+        dcterms:license       "https://www.apache.org/licenses/LICENSE-2.0"@en ;
+        dcterms:modified      "2024-03-20"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        dcterms:publisher     "ENTSO-E"@en ;
+        dcterms:rightsHolder  "ENTSO-E"@en ;
+        dcterms:title         "Security Analysis Result Vocabulary"@en ;
+        owl:priorVersion      <http://entsoe.eu/ns/CIM/SecurityAnalysisResult-EU/2.2> ;
+        owl:versionIRI        <https://ap.cim4.eu/SecurityAnalysisResult/2.3> ;
+        owl:versionInfo       "2.3.0"@en ;
+        dcat:keyword          "SAR" ;
+        dcat:theme            "vocabulary"@en .
+
+sar:Package_DocSecurityAnalysisResultProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains datatypes used only in the RDFS header." ;
+        rdfs:label    "DocSecurityAnalysisResultProfile"@en .
+
+sar:Package_SecurityAnalysisResultProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains the security analysis result profile.\nThis profile is not intended to replace the Topology (TP) and State Variables (SV) profiles. Its intention is to exchange power flow result that is relevant for security optimization, either through violation or through a loading threshold. Systems should not use this profile for dumping a full database. The modeling is optimized to have the minimum size in addition to a well defined value definition (e.g. active power, apparent power,etc.).\nRecommendation: If the terminals are connected with zero impedance, it is recommended to export only one terminal with a voltage (e.g. the terminal of a BusbarSection).\nThe connection between Contingency and Remedial Action is given by the Remedial Action Profile. The connection between AssessedElement and PowerFlowResult is given by the OperationalLimit." ;
+        rdfs:label    "SecurityAnalysisResultProfile"@en .
+

--- a/r2.3/ap-voc/ttl/SensitivityMatrix-AP-Voc-RDFS2020.ttl
+++ b/r2.3/ap-voc/ttl/SensitivityMatrix-AP-Voc-RDFS2020.ttl
@@ -1,0 +1,431 @@
+@prefix cim:     <https://cim.ucaiug.io/ns#> .
+@prefix cims:    <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/#> .
+@prefix nc:      <https://cim4.eu/ns/nc#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix profcim: <https://cim.ucaiug.io/ns/prof-cim#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sm:      <https://ap.cim4.eu/SensitivityMatrix#> .
+
+cim:Contingency  rdf:type       rdfs:Class ;
+        rdfs:comment            "An event threatening system reliability, consisting of one or more contingency elements." ;
+        rdfs:label              "Contingency"@en ;
+        cims:belongsToCategory  sm:Package_SensitivityMatrixProfile .
+
+cim:Date  rdf:type              rdfs:Class ;
+        rdfs:comment            "Date as \"yyyy-mm-dd\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddZ\". A local timezone relative UTC is specified as \"yyyy-mm-dd(+/-)hh:mm\"." ;
+        rdfs:label              "Date"@en ;
+        cims:belongsToCategory  sm:Package_DocSensitivityMatrixProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:DateTime  rdf:type          rdfs:Class ;
+        rdfs:comment            "Date and time as \"yyyy-mm-ddThh:mm:ss.sss\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddThh:mm:ss.sssZ\". A local timezone relative UTC is specified as \"yyyy-mm-ddThh:mm:ss.sss-hh:mm\". The second component (shown here as \"ss.sss\") could have any number of digits in its fractional part to allow any kind of precision beyond seconds." ;
+        rdfs:label              "DateTime"@en ;
+        cims:belongsToCategory  sm:Package_DocSensitivityMatrixProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Float  rdf:type             rdfs:Class ;
+        rdfs:comment            "A floating point number. The range is unspecified and not limited." ;
+        rdfs:label              "Float"@en ;
+        cims:belongsToCategory  sm:Package_SensitivityMatrixProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:IdentifiedObject  rdf:type  rdfs:Class ;
+        rdfs:comment            "This is a root class to provide common identification for all classes needing identification and naming attributes." ;
+        rdfs:label              "IdentifiedObject"@en ;
+        cims:belongsToCategory  sm:Package_SensitivityMatrixProfile .
+
+cim:IdentifiedObject.description
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The description is a free human readable text describing or naming the object. It may be non unique and may not correlate to a naming hierarchy." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "description"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.name
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The name is any free human readable and possibly non unique text naming the object." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "name"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:String  rdf:type            rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited." ;
+        rdfs:label              "String"@en ;
+        cims:belongsToCategory  sm:Package_SensitivityMatrixProfile ;
+        cims:stereotype         "Primitive" .
+
+nc:AssessedElement  rdf:type    rdfs:Class ;
+        rdfs:comment            "Assessed element is a network element for which the electrical state is evaluated in the regional or cross-regional process and which value is expected to fulfil regional rules function of the operational security limits.\nThe measurements and limits are as defined in the steady state hypothesis." ;
+        rdfs:label              "AssessedElement"@en ;
+        cims:belongsToCategory  sm:Package_SensitivityMatrixProfile ;
+        cims:stereotype         "NC" .
+
+nc:AssessedElement.ObservableQuantity
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The observable quantity for this assessed element with contingency." ;
+        rdfs:domain           nc:AssessedElement ;
+        rdfs:label            "ObservableQuantity"@en ;
+        rdfs:range            nc:ObservableQuantity ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ObservableQuantity.AssessedElement ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Contingency.ObservableQuantity
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The observable quantity for this contingency." ;
+        rdfs:domain           cim:Contingency ;
+        rdfs:label            "ObservableQuantity"@en ;
+        rdfs:range            nc:ObservableQuantity ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ObservableQuantity.Contingency ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ControllableQuantity
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Controllable quantity is a set point quantity on a grid state alteration or on a remedial action." ;
+        rdfs:label              "ControllableQuantity"@en ;
+        cims:belongsToCategory  sm:Package_SensitivityMatrixProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ControllableQuantity.GridStateAlteration
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The grid state alteration for this controllable quantity." ;
+        rdfs:domain           nc:ControllableQuantity ;
+        rdfs:label            "GridStateAlteration"@en ;
+        rdfs:range            nc:GridStateAlteration ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GridStateAlteration.ControllableQuantity ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ControllableQuantity.RemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action which is associated with the controllable quantity." ;
+        rdfs:domain           nc:ControllableQuantity ;
+        rdfs:label            "RemedialAction"@en ;
+        rdfs:range            nc:RemedialAction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialAction.ControllableQuantity ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ControllableQuantity.SensitivityFactor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The sensitivity factor associated with a controllable quantity." ;
+        rdfs:domain           nc:ControllableQuantity ;
+        rdfs:label            "SensitivityFactor"@en ;
+        rdfs:range            nc:SensitivityFactor ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:SensitivityFactor.ControllableQuantity ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:ControllableQuantity.value
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The value of the change applied to the grid state alteration or remedial action. In the case of multiple changes or non-quantifiable changes (e.g. Topology changes) the value needs to represent the suitable value that makes the derivable value given in the observable quantity for the purpose of the calculation of the sensitivity factor.  The value can be integer, float or boolean. In case of boolean 1 equals true and 0 equals false." ;
+        rdfs:domain        nc:ControllableQuantity ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GridStateAlteration
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Grid state alteration is a change of values describing state (operating point) of one element in the grid model compared to the base case." ;
+        rdfs:label              "GridStateAlteration"@en ;
+        cims:belongsToCategory  sm:Package_SensitivityMatrixProfile ;
+        cims:stereotype         "NC" .
+
+nc:GridStateAlteration.ControllableQuantity
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The controllable quantity associated with this grid state alteration." ;
+        rdfs:domain           nc:GridStateAlteration ;
+        rdfs:label            "ControllableQuantity"@en ;
+        rdfs:range            nc:ControllableQuantity ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ControllableQuantity.GridStateAlteration ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ObservableQuantity
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Observable quantity is an electrical quantity on an assessed element or an assessed element with contingency." ;
+        rdfs:label              "ObservableQuantity"@en ;
+        cims:belongsToCategory  sm:Package_SensitivityMatrixProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ObservableQuantity.AssessedElement
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The assessed element with contingency associated with this observable quantity." ;
+        rdfs:domain           nc:ObservableQuantity ;
+        rdfs:label            "AssessedElement"@en ;
+        rdfs:range            nc:AssessedElement ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AssessedElement.ObservableQuantity ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:ObservableQuantity.Contingency
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The contingency associated with this observable quantity." ;
+        rdfs:domain           nc:ObservableQuantity ;
+        rdfs:label            "Contingency"@en ;
+        rdfs:range            cim:Contingency ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Contingency.ObservableQuantity ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ObservableQuantity.SensitivityFactor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The sensitivity factor associated with an observable quantity." ;
+        rdfs:domain           nc:ObservableQuantity ;
+        rdfs:label            "SensitivityFactor"@en ;
+        rdfs:range            nc:SensitivityFactor ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:SensitivityFactor.ObservableQuantity ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:ObservableQuantity.observableQuantityKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of observable quantity." ;
+        rdfs:domain        nc:ObservableQuantity ;
+        rdfs:label         "observableQuantityKind"@en ;
+        rdfs:range         nc:ObservableQuantityKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ObservableQuantityKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of observable quantity." ;
+        rdfs:label              "ObservableQuantityKind"@en ;
+        cims:belongsToCategory  sm:Package_SensitivityMatrixProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:ObservableQuantityKind.activePower
+        rdf:type         nc:ObservableQuantityKind ;
+        rdfs:comment     "The observable quantity is the active power." ;
+        rdfs:label       "activePower"@en ;
+        cims:stereotype  "enum" .
+
+nc:ObservableQuantityKind.reactivePower
+        rdf:type         nc:ObservableQuantityKind ;
+        rdfs:comment     "The observable quantity is the reactive power." ;
+        rdfs:label       "reactivePower"@en ;
+        cims:stereotype  "enum" .
+
+nc:ObservableQuantityKind.voltageAngle
+        rdf:type         nc:ObservableQuantityKind ;
+        rdfs:comment     "The observable quantity is the angle of terminal voltage." ;
+        rdfs:label       "voltageAngle"@en ;
+        cims:stereotype  "enum" .
+
+nc:ObservableQuantityKind.voltageMagnitude
+        rdf:type         nc:ObservableQuantityKind ;
+        rdfs:comment     "The observable quantity is the magnitude of terminal voltage." ;
+        rdfs:label       "voltageMagnitude"@en ;
+        cims:stereotype  "enum" .
+
+nc:RemedialAction  rdf:type     rdfs:Class ;
+        rdfs:comment            "Remedial action describes one or more actions that can be performed on a given power system model situation to eliminate one or more identified breaches of constraints. The remedial action can be costly, and have a cost characteristic, or non costly. " ;
+        rdfs:label              "RemedialAction"@en ;
+        cims:belongsToCategory  sm:Package_SensitivityMatrixProfile ;
+        cims:stereotype         "NC" .
+
+nc:RemedialAction.ControllableQuantity
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The controllable quantity for a remedial action." ;
+        rdfs:domain           nc:RemedialAction ;
+        rdfs:label            "ControllableQuantity"@en ;
+        rdfs:range            nc:ControllableQuantity ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ControllableQuantity.RemedialAction ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SensitivityFactor  rdf:type  rdfs:Class ;
+        rdfs:comment            "The sensitivity factor which represents the sensitivity between observable and controllable elements. " ;
+        rdfs:label              "SensitivityFactor"@en ;
+        cims:belongsToCategory  sm:Package_SensitivityMatrixProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SensitivityFactor.ControllableQuantity
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The controllable quantity for this sensitivity factor." ;
+        rdfs:domain           nc:SensitivityFactor ;
+        rdfs:label            "ControllableQuantity"@en ;
+        rdfs:range            nc:ControllableQuantity ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ControllableQuantity.SensitivityFactor ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:SensitivityFactor.ObservableQuantity
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The observable quantity for this sensitivity factor." ;
+        rdfs:domain           nc:SensitivityFactor ;
+        rdfs:label            "ObservableQuantity"@en ;
+        rdfs:range            nc:ObservableQuantity ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ObservableQuantity.SensitivityFactor ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:SensitivityFactor.SensitivityMatrix
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The sensitivity matrix which contains this sensitivity factor." ;
+        rdfs:domain           nc:SensitivityFactor ;
+        rdfs:label            "SensitivityMatrix"@en ;
+        rdfs:range            nc:SensitivityMatrix ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SensitivityMatrix.SensitivityFactor ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:SensitivityFactor.value
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The value of the sensitivity factor." ;
+        rdfs:domain        nc:SensitivityFactor ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SensitivityMatrix  rdf:type  rdfs:Class ;
+        rdfs:comment            "The sensitivity matrix which represents the sensitivity factors between observable and controllable elements. " ;
+        rdfs:label              "SensitivityMatrix"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  sm:Package_SensitivityMatrixProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SensitivityMatrix.SensitivityFactor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The sensitivity factor which belongs to this sensitivity matrix." ;
+        rdfs:domain           nc:SensitivityMatrix ;
+        rdfs:label            "SensitivityFactor"@en ;
+        rdfs:range            nc:SensitivityFactor ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:SensitivityFactor.SensitivityMatrix ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:SensitivityMatrix.kind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The kind of sensitivity matrix. " ;
+        rdfs:domain        nc:SensitivityMatrix ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         nc:SensitivityMatrixKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SensitivityMatrixKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kinds of sensitivity matrix." ;
+        rdfs:label              "SensitivityMatrixKind"@en ;
+        cims:belongsToCategory  sm:Package_SensitivityMatrixProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:SensitivityMatrixKind.other
+        rdf:type         nc:SensitivityMatrixKind ;
+        rdfs:comment     "Other kind of sensitivity matrix." ;
+        rdfs:label       "other"@en ;
+        cims:stereotype  "enum" .
+
+nc:SensitivityMatrixKind.uniformLoad
+        rdf:type         nc:SensitivityMatrixKind ;
+        rdfs:comment     "Uniform load matrix." ;
+        rdfs:label       "uniformLoad"@en ;
+        cims:stereotype  "enum" .
+
+nc:SensitivityMatrixKind.uniformNode
+        rdf:type         nc:SensitivityMatrixKind ;
+        rdfs:comment     "Uniform node matrix." ;
+        rdfs:label       "uniformNode"@en ;
+        cims:stereotype  "enum" .
+
+nc:SensitivityMatrixKind.zoneToSlack
+        rdf:type         nc:SensitivityMatrixKind ;
+        rdfs:comment     "Zone to slack kind of sensitivity matrix." ;
+        rdfs:label       "zoneToSlack"@en ;
+        cims:stereotype  "enum" .
+
+profcim:IRI  rdf:type           rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as rdf:resource in RDFXML.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "IRI"@en ;
+        cims:belongsToCategory  sm:Package_DocSensitivityMatrixProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+profcim:StringFixedLanguage
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited.\nThe primitive is serialized as literal without language support." ;
+        rdfs:label              "StringFixedLanguage"@en ;
+        cims:belongsToCategory  sm:Package_DocSensitivityMatrixProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringIRI  rdf:type     rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as literal without language support.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "StringIRI"@en ;
+        cims:belongsToCategory  sm:Package_DocSensitivityMatrixProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:URL  rdf:type           rdfs:Class ;
+        rdfs:comment            "A Uniform Resource Locator (URL), colloquially termed a web address, is a reference to a web resource that specifies its location on a computer network and a mechanism for retrieving it. A URL is a specific type of Uniform Resource Identifier (URI), although many people use the two terms interchangeably.URLs occur most commonly to reference web pages (http), but are also used for file transfer (ftp), email (mailto), database access (JDBC), and many other applications." ;
+        rdfs:label              "URL"@en ;
+        cims:belongsToCategory  sm:Package_DocSensitivityMatrixProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+sm:Ontology  rdf:type         owl:Ontology ;
+        dcterms:conformsTo    "file://iec61970cim17v40_iec61968cim13v13a_iec62325cim03v17a.eap" , "urn:iso:std:iec:61970-401:draft:ed-1" , "urn:iso:std:iec:61970-501:draft:ed-2" , "urn:iso:std:iec:61970-301:ed-7:amd1" , "urn:iso:std:iec:61970-600-2:ed-1" , "file://CIM100_CGMES31v01_501-20v02_NC23v62_MM10v01.eap" ;
+        dcterms:creator       "ENTSO-E CIM WG NC project"@en ;
+        dcterms:description   "This vocabulary is describing the sensitivity matrix."@en ;
+        dcterms:identifier    "urn:uuid:d89a8510-528b-49a9-81f1-c51be51caa6f" ;
+        dcterms:language      "en-GB" ;
+        dcterms:license       "https://www.apache.org/licenses/LICENSE-2.0"@en ;
+        dcterms:modified      "2024-03-20"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        dcterms:publisher     "ENTSO-E"@en ;
+        dcterms:rightsHolder  "ENTSO-E"@en ;
+        dcterms:title         "Sensitivity Matrix Vocabulary"@en ;
+        owl:priorVersion      <http://entsoe.eu/ns/CIM/SensitivityMatrix-EU/2.2> ;
+        owl:versionIRI        <https://ap.cim4.eu/SensitivityMatrix/2.3> ;
+        owl:versionInfo       "2.3.0"@en ;
+        dcat:keyword          "SM" ;
+        dcat:theme            "vocabulary"@en .
+
+sm:Package_DocSensitivityMatrixProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains datatypes used only in the RDFS header." ;
+        rdfs:label    "DocSensitivityMatrixProfile"@en .
+
+sm:Package_SensitivityMatrixProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains sensitivity matrix profile." ;
+        rdfs:label    "SensitivityMatrixProfile"@en .
+

--- a/r2.3/ap-voc/ttl/StateInstructionSchedule-AP-Voc-RDFS2020.ttl
+++ b/r2.3/ap-voc/ttl/StateInstructionSchedule-AP-Voc-RDFS2020.ttl
@@ -1,0 +1,4166 @@
+@prefix cim:     <https://cim.ucaiug.io/ns#> .
+@prefix cims:    <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/#> .
+@prefix nc:      <https://cim4.eu/ns/nc#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix profcim: <https://cim.ucaiug.io/ns/prof-cim#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sis:     <https://ap.cim4.eu/StateInstructionSchedule#> .
+
+cim:ActivePower  rdf:type       rdfs:Class ;
+        rdfs:comment            "Product of RMS value of the voltage and the RMS value of the in-phase component of the current." ;
+        rdfs:label              "ActivePower"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:ActivePower.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePower.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "W" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePower.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:AngleDegrees  rdf:type      rdfs:Class ;
+        rdfs:comment            "Measurement of angle in degrees." ;
+        rdfs:label              "AngleDegrees"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:AngleDegrees.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:AngleDegrees ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:AngleDegrees.unit
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:AngleDegrees ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "deg" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:AngleDegrees.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:AngleDegrees ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Boolean  rdf:type           rdfs:Class ;
+        rdfs:comment            "A type with the value space \"true\" and \"false\"." ;
+        rdfs:label              "Boolean"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:ConductingEquipment
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The parts of the AC power system that are designed to carry current or that are conductively connected through terminals." ;
+        rdfs:label              "ConductingEquipment"@en ;
+        rdfs:subClassOf         cim:Equipment ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile .
+
+cim:Contingency  rdf:type       rdfs:Class ;
+        rdfs:comment            "An event threatening system reliability, consisting of one or more contingency elements." ;
+        rdfs:label              "Contingency"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile .
+
+cim:Currency  rdf:type          rdfs:Class ;
+        rdfs:comment            "Monetary currencies.  ISO 4217 standard including 3-character currency code." ;
+        rdfs:label              "Currency"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:Currency.AED  rdf:type  cim:Currency ;
+        rdfs:comment     "United Arab Emirates dirham." ;
+        rdfs:label       "AED"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AFN  rdf:type  cim:Currency ;
+        rdfs:comment     "Afghan afghani." ;
+        rdfs:label       "AFN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ALL  rdf:type  cim:Currency ;
+        rdfs:comment     "Albanian lek." ;
+        rdfs:label       "ALL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AMD  rdf:type  cim:Currency ;
+        rdfs:comment     "Armenian dram." ;
+        rdfs:label       "AMD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ANG  rdf:type  cim:Currency ;
+        rdfs:comment     "Netherlands Antillean guilder." ;
+        rdfs:label       "ANG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AOA  rdf:type  cim:Currency ;
+        rdfs:comment     "Angolan kwanza." ;
+        rdfs:label       "AOA"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ARS  rdf:type  cim:Currency ;
+        rdfs:comment     "Argentine peso." ;
+        rdfs:label       "ARS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AUD  rdf:type  cim:Currency ;
+        rdfs:comment     "Australian dollar." ;
+        rdfs:label       "AUD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AWG  rdf:type  cim:Currency ;
+        rdfs:comment     "Aruban florin." ;
+        rdfs:label       "AWG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AZN  rdf:type  cim:Currency ;
+        rdfs:comment     "Azerbaijani manat." ;
+        rdfs:label       "AZN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BAM  rdf:type  cim:Currency ;
+        rdfs:comment     "Bosnia and Herzegovina convertible mark." ;
+        rdfs:label       "BAM"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BBD  rdf:type  cim:Currency ;
+        rdfs:comment     "Barbados dollar." ;
+        rdfs:label       "BBD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BDT  rdf:type  cim:Currency ;
+        rdfs:comment     "Bangladeshi taka." ;
+        rdfs:label       "BDT"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BGN  rdf:type  cim:Currency ;
+        rdfs:comment     "Bulgarian lev." ;
+        rdfs:label       "BGN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BHD  rdf:type  cim:Currency ;
+        rdfs:comment     "Bahraini dinar." ;
+        rdfs:label       "BHD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BIF  rdf:type  cim:Currency ;
+        rdfs:comment     "Burundian franc." ;
+        rdfs:label       "BIF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BMD  rdf:type  cim:Currency ;
+        rdfs:comment     "Bermudian dollar (customarily known as Bermuda dollar)." ;
+        rdfs:label       "BMD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BND  rdf:type  cim:Currency ;
+        rdfs:comment     "Brunei dollar." ;
+        rdfs:label       "BND"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BOB  rdf:type  cim:Currency ;
+        rdfs:comment     "Boliviano." ;
+        rdfs:label       "BOB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BOV  rdf:type  cim:Currency ;
+        rdfs:comment     "Bolivian Mvdol (funds code)." ;
+        rdfs:label       "BOV"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BRL  rdf:type  cim:Currency ;
+        rdfs:comment     "Brazilian real." ;
+        rdfs:label       "BRL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BSD  rdf:type  cim:Currency ;
+        rdfs:comment     "Bahamian dollar." ;
+        rdfs:label       "BSD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BTN  rdf:type  cim:Currency ;
+        rdfs:comment     "Bhutanese ngultrum." ;
+        rdfs:label       "BTN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BWP  rdf:type  cim:Currency ;
+        rdfs:comment     "Botswana pula." ;
+        rdfs:label       "BWP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BYR  rdf:type  cim:Currency ;
+        rdfs:comment     "Belarusian ruble." ;
+        rdfs:label       "BYR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BZD  rdf:type  cim:Currency ;
+        rdfs:comment     "Belize dollar." ;
+        rdfs:label       "BZD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CAD  rdf:type  cim:Currency ;
+        rdfs:comment     "Canadian dollar." ;
+        rdfs:label       "CAD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CDF  rdf:type  cim:Currency ;
+        rdfs:comment     "Congolese franc." ;
+        rdfs:label       "CDF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CHF  rdf:type  cim:Currency ;
+        rdfs:comment     "Swiss franc." ;
+        rdfs:label       "CHF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CLF  rdf:type  cim:Currency ;
+        rdfs:comment     "Unidad de Fomento (funds code), Chile." ;
+        rdfs:label       "CLF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CLP  rdf:type  cim:Currency ;
+        rdfs:comment     "Chilean peso." ;
+        rdfs:label       "CLP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CNY  rdf:type  cim:Currency ;
+        rdfs:comment     "Chinese yuan." ;
+        rdfs:label       "CNY"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.COP  rdf:type  cim:Currency ;
+        rdfs:comment     "Colombian peso." ;
+        rdfs:label       "COP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.COU  rdf:type  cim:Currency ;
+        rdfs:comment     "Unidad de Valor Real." ;
+        rdfs:label       "COU"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CRC  rdf:type  cim:Currency ;
+        rdfs:comment     "Costa Rican colon." ;
+        rdfs:label       "CRC"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CUC  rdf:type  cim:Currency ;
+        rdfs:comment     "Cuban convertible peso." ;
+        rdfs:label       "CUC"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CUP  rdf:type  cim:Currency ;
+        rdfs:comment     "Cuban peso." ;
+        rdfs:label       "CUP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CVE  rdf:type  cim:Currency ;
+        rdfs:comment     "Cape Verde escudo." ;
+        rdfs:label       "CVE"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CZK  rdf:type  cim:Currency ;
+        rdfs:comment     "Czech koruna." ;
+        rdfs:label       "CZK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.DJF  rdf:type  cim:Currency ;
+        rdfs:comment     "Djiboutian franc." ;
+        rdfs:label       "DJF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.DKK  rdf:type  cim:Currency ;
+        rdfs:comment     "Danish krone." ;
+        rdfs:label       "DKK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.DOP  rdf:type  cim:Currency ;
+        rdfs:comment     "Dominican peso." ;
+        rdfs:label       "DOP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.DZD  rdf:type  cim:Currency ;
+        rdfs:comment     "Algerian dinar." ;
+        rdfs:label       "DZD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.EEK  rdf:type  cim:Currency ;
+        rdfs:comment     "Estonian kroon." ;
+        rdfs:label       "EEK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.EGP  rdf:type  cim:Currency ;
+        rdfs:comment     "Egyptian pound." ;
+        rdfs:label       "EGP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ERN  rdf:type  cim:Currency ;
+        rdfs:comment     "Eritrean nakfa." ;
+        rdfs:label       "ERN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ETB  rdf:type  cim:Currency ;
+        rdfs:comment     "Ethiopian birr." ;
+        rdfs:label       "ETB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.EUR  rdf:type  cim:Currency ;
+        rdfs:comment     "Euro." ;
+        rdfs:label       "EUR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.FJD  rdf:type  cim:Currency ;
+        rdfs:comment     "Fiji dollar." ;
+        rdfs:label       "FJD"@en ;
+        cims:stereotype  "enum" .
+cim:Currency.FKP  rdf:type  cim:Currency ;
+        rdfs:comment     "Falkland Islands pound." ;
+        rdfs:label       "FKP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GBP  rdf:type  cim:Currency ;
+        rdfs:comment     "Pound sterling." ;
+        rdfs:label       "GBP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GEL  rdf:type  cim:Currency ;
+        rdfs:comment     "Georgian lari." ;
+        rdfs:label       "GEL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GHS  rdf:type  cim:Currency ;
+        rdfs:comment     "Ghanaian cedi." ;
+        rdfs:label       "GHS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GIP  rdf:type  cim:Currency ;
+        rdfs:comment     "Gibraltar pound." ;
+        rdfs:label       "GIP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GMD  rdf:type  cim:Currency ;
+        rdfs:comment     "Gambian dalasi." ;
+        rdfs:label       "GMD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GNF  rdf:type  cim:Currency ;
+        rdfs:comment     "Guinean franc." ;
+        rdfs:label       "GNF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GTQ  rdf:type  cim:Currency ;
+        rdfs:comment     "Guatemalan quetzal." ;
+        rdfs:label       "GTQ"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GYD  rdf:type  cim:Currency ;
+        rdfs:comment     "Guyanese dollar." ;
+        rdfs:label       "GYD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HKD  rdf:type  cim:Currency ;
+        rdfs:comment     "Hong Kong dollar." ;
+        rdfs:label       "HKD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HNL  rdf:type  cim:Currency ;
+        rdfs:comment     "Honduran lempira." ;
+        rdfs:label       "HNL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HRK  rdf:type  cim:Currency ;
+        rdfs:comment     "Croatian kuna." ;
+        rdfs:label       "HRK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HTG  rdf:type  cim:Currency ;
+        rdfs:comment     "Haitian gourde." ;
+        rdfs:label       "HTG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HUF  rdf:type  cim:Currency ;
+        rdfs:comment     "Hungarian forint." ;
+        rdfs:label       "HUF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.IDR  rdf:type  cim:Currency ;
+        rdfs:comment     "Indonesian rupiah." ;
+        rdfs:label       "IDR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ILS  rdf:type  cim:Currency ;
+        rdfs:comment     "Israeli new sheqel." ;
+        rdfs:label       "ILS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.INR  rdf:type  cim:Currency ;
+        rdfs:comment     "Indian rupee." ;
+        rdfs:label       "INR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.IQD  rdf:type  cim:Currency ;
+        rdfs:comment     "Iraqi dinar." ;
+        rdfs:label       "IQD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.IRR  rdf:type  cim:Currency ;
+        rdfs:comment     "Iranian rial." ;
+        rdfs:label       "IRR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ISK  rdf:type  cim:Currency ;
+        rdfs:comment     "Icelandic króna." ;
+        rdfs:label       "ISK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.JMD  rdf:type  cim:Currency ;
+        rdfs:comment     "Jamaican dollar." ;
+        rdfs:label       "JMD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.JOD  rdf:type  cim:Currency ;
+        rdfs:comment     "Jordanian dinar." ;
+        rdfs:label       "JOD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.JPY  rdf:type  cim:Currency ;
+        rdfs:comment     "Japanese yen." ;
+        rdfs:label       "JPY"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KES  rdf:type  cim:Currency ;
+        rdfs:comment     "Kenyan shilling." ;
+        rdfs:label       "KES"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KGS  rdf:type  cim:Currency ;
+        rdfs:comment     "Kyrgyzstani som." ;
+        rdfs:label       "KGS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KHR  rdf:type  cim:Currency ;
+        rdfs:comment     "Cambodian riel." ;
+        rdfs:label       "KHR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KMF  rdf:type  cim:Currency ;
+        rdfs:comment     "Comoro franc." ;
+        rdfs:label       "KMF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KPW  rdf:type  cim:Currency ;
+        rdfs:comment     "North Korean won." ;
+        rdfs:label       "KPW"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KRW  rdf:type  cim:Currency ;
+        rdfs:comment     "South Korean won." ;
+        rdfs:label       "KRW"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KWD  rdf:type  cim:Currency ;
+        rdfs:comment     "Kuwaiti dinar." ;
+        rdfs:label       "KWD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KYD  rdf:type  cim:Currency ;
+        rdfs:comment     "Cayman Islands dollar." ;
+        rdfs:label       "KYD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KZT  rdf:type  cim:Currency ;
+        rdfs:comment     "Kazakhstani tenge." ;
+        rdfs:label       "KZT"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LAK  rdf:type  cim:Currency ;
+        rdfs:comment     "Lao kip." ;
+        rdfs:label       "LAK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LBP  rdf:type  cim:Currency ;
+        rdfs:comment     "Lebanese pound." ;
+        rdfs:label       "LBP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LKR  rdf:type  cim:Currency ;
+        rdfs:comment     "Sri Lanka rupee." ;
+        rdfs:label       "LKR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LRD  rdf:type  cim:Currency ;
+        rdfs:comment     "Liberian dollar." ;
+        rdfs:label       "LRD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LSL  rdf:type  cim:Currency ;
+        rdfs:comment     "Lesotho loti." ;
+        rdfs:label       "LSL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LTL  rdf:type  cim:Currency ;
+        rdfs:comment     "Lithuanian litas." ;
+        rdfs:label       "LTL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LVL  rdf:type  cim:Currency ;
+        rdfs:comment     "Latvian lats." ;
+        rdfs:label       "LVL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LYD  rdf:type  cim:Currency ;
+        rdfs:comment     "Libyan dinar." ;
+        rdfs:label       "LYD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MAD  rdf:type  cim:Currency ;
+        rdfs:comment     "Moroccan dirham." ;
+        rdfs:label       "MAD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MDL  rdf:type  cim:Currency ;
+        rdfs:comment     "Moldovan leu." ;
+        rdfs:label       "MDL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MGA  rdf:type  cim:Currency ;
+        rdfs:comment     "Malagasy ariary." ;
+        rdfs:label       "MGA"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MKD  rdf:type  cim:Currency ;
+        rdfs:comment     "Macedonian denar." ;
+        rdfs:label       "MKD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MMK  rdf:type  cim:Currency ;
+        rdfs:comment     "Myanma kyat." ;
+        rdfs:label       "MMK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MNT  rdf:type  cim:Currency ;
+        rdfs:comment     "Mongolian tugrik." ;
+        rdfs:label       "MNT"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MOP  rdf:type  cim:Currency ;
+        rdfs:comment     "Macanese pataca." ;
+        rdfs:label       "MOP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MRO  rdf:type  cim:Currency ;
+        rdfs:comment     "Mauritanian ouguiya." ;
+        rdfs:label       "MRO"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MUR  rdf:type  cim:Currency ;
+        rdfs:comment     "Mauritian rupee." ;
+        rdfs:label       "MUR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MVR  rdf:type  cim:Currency ;
+        rdfs:comment     "Maldivian rufiyaa." ;
+        rdfs:label       "MVR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MWK  rdf:type  cim:Currency ;
+        rdfs:comment     "Malawian kwacha." ;
+        rdfs:label       "MWK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MXN  rdf:type  cim:Currency ;
+        rdfs:comment     "Mexican peso." ;
+        rdfs:label       "MXN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MYR  rdf:type  cim:Currency ;
+        rdfs:comment     "Malaysian ringgit." ;
+        rdfs:label       "MYR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MZN  rdf:type  cim:Currency ;
+        rdfs:comment     "Mozambican metical." ;
+        rdfs:label       "MZN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NAD  rdf:type  cim:Currency ;
+        rdfs:comment     "Namibian dollar." ;
+        rdfs:label       "NAD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NGN  rdf:type  cim:Currency ;
+        rdfs:comment     "Nigerian naira." ;
+        rdfs:label       "NGN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NIO  rdf:type  cim:Currency ;
+        rdfs:comment     "Cordoba oro." ;
+        rdfs:label       "NIO"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NOK  rdf:type  cim:Currency ;
+        rdfs:comment     "Norwegian krone." ;
+        rdfs:label       "NOK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NPR  rdf:type  cim:Currency ;
+        rdfs:comment     "Nepalese rupee." ;
+        rdfs:label       "NPR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NZD  rdf:type  cim:Currency ;
+        rdfs:comment     "New Zealand dollar." ;
+        rdfs:label       "NZD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.OMR  rdf:type  cim:Currency ;
+        rdfs:comment     "Omani rial." ;
+        rdfs:label       "OMR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PAB  rdf:type  cim:Currency ;
+        rdfs:comment     "Panamanian balboa." ;
+        rdfs:label       "PAB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PEN  rdf:type  cim:Currency ;
+        rdfs:comment     "Peruvian nuevo sol." ;
+        rdfs:label       "PEN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PGK  rdf:type  cim:Currency ;
+        rdfs:comment     "Papua New Guinean kina." ;
+        rdfs:label       "PGK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PHP  rdf:type  cim:Currency ;
+        rdfs:comment     "Philippine peso." ;
+        rdfs:label       "PHP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PKR  rdf:type  cim:Currency ;
+        rdfs:comment     "Pakistani rupee." ;
+        rdfs:label       "PKR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PLN  rdf:type  cim:Currency ;
+        rdfs:comment     "Polish zloty." ;
+        rdfs:label       "PLN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PYG  rdf:type  cim:Currency ;
+        rdfs:comment     "Paraguayan guaraní." ;
+        rdfs:label       "PYG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.QAR  rdf:type  cim:Currency ;
+        rdfs:comment     "Qatari rial." ;
+        rdfs:label       "QAR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.RON  rdf:type  cim:Currency ;
+        rdfs:comment     "Romanian new leu." ;
+        rdfs:label       "RON"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.RSD  rdf:type  cim:Currency ;
+        rdfs:comment     "Serbian dinar." ;
+        rdfs:label       "RSD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.RUB  rdf:type  cim:Currency ;
+        rdfs:comment     "Russian rouble." ;
+        rdfs:label       "RUB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.RWF  rdf:type  cim:Currency ;
+        rdfs:comment     "Rwandan franc." ;
+        rdfs:label       "RWF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SAR  rdf:type  cim:Currency ;
+        rdfs:comment     "Saudi riyal." ;
+        rdfs:label       "SAR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SBD  rdf:type  cim:Currency ;
+        rdfs:comment     "Solomon Islands dollar." ;
+        rdfs:label       "SBD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SCR  rdf:type  cim:Currency ;
+        rdfs:comment     "Seychelles rupee." ;
+        rdfs:label       "SCR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SDG  rdf:type  cim:Currency ;
+        rdfs:comment     "Sudanese pound." ;
+        rdfs:label       "SDG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SEK  rdf:type  cim:Currency ;
+        rdfs:comment     "Swedish krona/kronor." ;
+        rdfs:label       "SEK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SGD  rdf:type  cim:Currency ;
+        rdfs:comment     "Singapore dollar." ;
+        rdfs:label       "SGD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SHP  rdf:type  cim:Currency ;
+        rdfs:comment     "Saint Helena pound." ;
+        rdfs:label       "SHP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SLL  rdf:type  cim:Currency ;
+        rdfs:comment     "Sierra Leonean leone." ;
+        rdfs:label       "SLL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SOS  rdf:type  cim:Currency ;
+        rdfs:comment     "Somali shilling." ;
+        rdfs:label       "SOS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SRD  rdf:type  cim:Currency ;
+        rdfs:comment     "Surinamese dollar." ;
+        rdfs:label       "SRD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.STD  rdf:type  cim:Currency ;
+        rdfs:comment     "São Tomé and Príncipe dobra." ;
+        rdfs:label       "STD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SYP  rdf:type  cim:Currency ;
+        rdfs:comment     "Syrian pound." ;
+        rdfs:label       "SYP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SZL  rdf:type  cim:Currency ;
+        rdfs:comment     "Lilangeni." ;
+        rdfs:label       "SZL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.THB  rdf:type  cim:Currency ;
+        rdfs:comment     "Thai baht." ;
+        rdfs:label       "THB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TJS  rdf:type  cim:Currency ;
+        rdfs:comment     "Tajikistani somoni." ;
+        rdfs:label       "TJS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TMT  rdf:type  cim:Currency ;
+        rdfs:comment     "Turkmenistani manat." ;
+        rdfs:label       "TMT"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TND  rdf:type  cim:Currency ;
+        rdfs:comment     "Tunisian dinar." ;
+        rdfs:label       "TND"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TOP  rdf:type  cim:Currency ;
+        rdfs:comment     "Tongan pa'anga." ;
+        rdfs:label       "TOP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TRY  rdf:type  cim:Currency ;
+        rdfs:comment     "Turkish lira." ;
+        rdfs:label       "TRY"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TTD  rdf:type  cim:Currency ;
+        rdfs:comment     "Trinidad and Tobago dollar." ;
+        rdfs:label       "TTD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TWD  rdf:type  cim:Currency ;
+        rdfs:comment     "New Taiwan dollar." ;
+        rdfs:label       "TWD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TZS  rdf:type  cim:Currency ;
+        rdfs:comment     "Tanzanian shilling." ;
+        rdfs:label       "TZS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.UAH  rdf:type  cim:Currency ;
+        rdfs:comment     "Ukrainian hryvnia." ;
+        rdfs:label       "UAH"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.UGX  rdf:type  cim:Currency ;
+        rdfs:comment     "Ugandan shilling." ;
+        rdfs:label       "UGX"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.USD  rdf:type  cim:Currency ;
+        rdfs:comment     "United States dollar." ;
+        rdfs:label       "USD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.UYU  rdf:type  cim:Currency ;
+        rdfs:comment     "Uruguayan peso." ;
+        rdfs:label       "UYU"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.UZS  rdf:type  cim:Currency ;
+        rdfs:comment     "Uzbekistan som." ;
+        rdfs:label       "UZS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.VEF  rdf:type  cim:Currency ;
+        rdfs:comment     "Venezuelan bolívar fuerte." ;
+        rdfs:label       "VEF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.VND  rdf:type  cim:Currency ;
+        rdfs:comment     "Vietnamese Dong." ;
+        rdfs:label       "VND"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.VUV  rdf:type  cim:Currency ;
+        rdfs:comment     "Vanuatu vatu." ;
+        rdfs:label       "VUV"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.WST  rdf:type  cim:Currency ;
+        rdfs:comment     "Samoan tala." ;
+        rdfs:label       "WST"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.XAF  rdf:type  cim:Currency ;
+        rdfs:comment     "CFA franc BEAC." ;
+        rdfs:label       "XAF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.XCD  rdf:type  cim:Currency ;
+        rdfs:comment     "East Caribbean dollar." ;
+        rdfs:label       "XCD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.XOF  rdf:type  cim:Currency ;
+        rdfs:comment     "CFA Franc BCEAO." ;
+        rdfs:label       "XOF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.XPF  rdf:type  cim:Currency ;
+        rdfs:comment     "CFP franc." ;
+        rdfs:label       "XPF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.YER  rdf:type  cim:Currency ;
+        rdfs:comment     "Yemeni rial." ;
+        rdfs:label       "YER"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ZAR  rdf:type  cim:Currency ;
+        rdfs:comment     "South African rand." ;
+        rdfs:label       "ZAR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ZMK  rdf:type  cim:Currency ;
+        rdfs:comment     "Zambian kwacha." ;
+        rdfs:label       "ZMK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ZWL  rdf:type  cim:Currency ;
+        rdfs:comment     "Zimbabwe dollar." ;
+        rdfs:label       "ZWL"@en ;
+        cims:stereotype  "enum" .
+
+cim:CurrentFlow  rdf:type       rdfs:Class ;
+        rdfs:comment            "Electrical current with sign convention: positive flow is out of the conducting equipment into the connectivity node. Can be both AC and DC." ;
+        rdfs:label              "CurrentFlow"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:CurrentFlow.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:CurrentFlow ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:CurrentFlow.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:CurrentFlow ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "A" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:CurrentFlow.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:CurrentFlow ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Date  rdf:type              rdfs:Class ;
+        rdfs:comment            "Date as \"yyyy-mm-dd\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddZ\". A local timezone relative UTC is specified as \"yyyy-mm-dd(+/-)hh:mm\"." ;
+        rdfs:label              "Date"@en ;
+        cims:belongsToCategory  sis:Package_DocStateInstructionScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:DateTime  rdf:type          rdfs:Class ;
+        rdfs:comment            "Date and time as \"yyyy-mm-ddThh:mm:ss.sss\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddThh:mm:ss.sssZ\". A local timezone relative UTC is specified as \"yyyy-mm-ddThh:mm:ss.sss-hh:mm\". The second component (shown here as \"ss.sss\") could have any number of digits in its fractional part to allow any kind of precision beyond seconds." ;
+        rdfs:label              "DateTime"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Decimal  rdf:type           rdfs:Class ;
+        rdfs:comment            "Decimal is the base-10 notational system for representing real numbers." ;
+        rdfs:label              "Decimal"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Duration  rdf:type          rdfs:Class ;
+        rdfs:comment            "Duration as \"PnYnMnDTnHnMnS\" which conforms to ISO 8601, where nY expresses a number of years, nM a number of months, nD a number of days. The letter T separates the date expression from the time expression and, after it, nH identifies a number of hours, nM a number of minutes and nS a number of seconds. The number of seconds could be expressed as a decimal number, but all other numbers are integers." ;
+        rdfs:label              "Duration"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:EnergyConnection  rdf:type  rdfs:Class ;
+        rdfs:comment            "A connection of energy generation or consumption on the power system model." ;
+        rdfs:label              "EnergyConnection"@en ;
+        rdfs:subClassOf         cim:ConductingEquipment ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile .
+
+cim:EnergyConsumer  rdf:type    rdfs:Class ;
+        rdfs:comment            "Generic user of energy - a  point of consumption on the power system model.\nEnergyConsumer.pfixed, .qfixed, .pfixedPct and .qfixedPct have meaning only if there is no LoadResponseCharacteristic associated with EnergyConsumer or if LoadResponseCharacteristic.exponentModel is set to False." ;
+        rdfs:label              "EnergyConsumer"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile .
+
+cim:EnergySource  rdf:type      rdfs:Class ;
+        rdfs:comment            "A generic equivalent for an energy supplier on a transmission or distribution voltage level." ;
+        rdfs:label              "EnergySource"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile .
+
+cim:Equipment  rdf:type         rdfs:Class ;
+        rdfs:comment            "The parts of a power system that are physical devices, electronic or mechanical." ;
+        rdfs:label              "Equipment"@en ;
+        rdfs:subClassOf         cim:PowerSystemResource ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile .
+
+cim:EquivalentInjection
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "This class represents equivalent injections (generation or load).  Voltage regulation is allowed only at the point of connection." ;
+        rdfs:label              "EquivalentInjection"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile .
+
+cim:ExternalNetworkInjection
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "This class represents the external network and it is used for IEC 60909 calculations." ;
+        rdfs:label              "ExternalNetworkInjection"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile .
+
+cim:Float  rdf:type             rdfs:Class ;
+        rdfs:comment            "A floating point number. The range is unspecified and not limited." ;
+        rdfs:label              "Float"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:GeneratingUnit  rdf:type    rdfs:Class ;
+        rdfs:comment            "A single or set of synchronous machines for converting mechanical power into alternating-current power. For example, individual machines within a set may be defined for scheduling purposes while a single control signal is derived for the set. In this case there would be a GeneratingUnit for each member of the set and an additional GeneratingUnit corresponding to the set." ;
+        rdfs:label              "GeneratingUnit"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile .
+
+cim:HydroPump  rdf:type         rdfs:Class ;
+        rdfs:comment            "A synchronous motor-driven pump, typically associated with a pumped storage plant." ;
+        rdfs:label              "HydroPump"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile .
+
+cim:IdentifiedObject  rdf:type  rdfs:Class ;
+        rdfs:comment            "This is a root class to provide common identification for all classes needing identification and naming attributes." ;
+        rdfs:label              "IdentifiedObject"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile .
+
+cim:IdentifiedObject.description
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The description is a free human readable text describing or naming the object. It may be non unique and may not correlate to a naming hierarchy." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "description"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.name
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The name is any free human readable and possibly non unique text naming the object." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "name"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Integer  rdf:type           rdfs:Class ;
+        rdfs:comment            "An integer number. The range is unspecified and not limited." ;
+        rdfs:label              "Integer"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Money  rdf:type             rdfs:Class ;
+        rdfs:comment            "Amount of money." ;
+        rdfs:label              "Money"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Money.multiplier  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Money ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Money.unit  rdf:type   rdf:Property ;
+        rdfs:domain        cim:Money ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:Currency ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Money.value  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Money ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Decimal ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:MonthDay  rdf:type          rdfs:Class ;
+        rdfs:comment            "MonthDay format as \"--mm-dd\", which conforms with XSD data type gMonthDay." ;
+        rdfs:label              "MonthDay"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:PerCent  rdf:type           rdfs:Class ;
+        rdfs:comment            "Percentage on a defined base.   For example, specify as 100 to indicate at the defined base." ;
+        rdfs:label              "PerCent"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:PerCent.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent.value  rdf:type  rdf:Property ;
+        rdfs:comment       "Normally 0 to 100 on a defined base." ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PowerElectronicsUnit
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A generating unit or battery or aggregation that connects to the AC network using power electronics rather than rotating machines." ;
+        rdfs:label              "PowerElectronicsUnit"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile .
+
+cim:PowerSystemResource
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A power system resource (PSR) can be an item of equipment such as a switch, an equipment container containing many individual items of equipment such as a substation, or an organisational entity such as sub-control area. Power system resources can have measurements associated." ;
+        rdfs:label              "PowerSystemResource"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile .
+
+cim:RealEnergy  rdf:type        rdfs:Class ;
+        rdfs:comment            "Real electrical energy." ;
+        rdfs:label              "RealEnergy"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:RealEnergy.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:RealEnergy ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:RealEnergy.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:RealEnergy ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "Wh" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:RealEnergy.value  rdf:type  rdf:Property ;
+        rdfs:domain        cim:RealEnergy ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Season  rdf:type            rdfs:Class ;
+        rdfs:comment            "A specified time period of the year." ;
+        rdfs:label              "Season"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:Season.endDate  rdf:type  rdf:Property ;
+        rdfs:comment       "Date season ends." ;
+        rdfs:domain        cim:Season ;
+        rdfs:label         "endDate"@en ;
+        cims:dataType      cim:MonthDay ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Season.startDate  rdf:type  rdf:Property ;
+        rdfs:comment       "Date season starts." ;
+        rdfs:domain        cim:Season ;
+        rdfs:label         "startDate"@en ;
+        cims:dataType      cim:MonthDay ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Seconds  rdf:type           rdfs:Class ;
+        rdfs:comment            "Time, in seconds." ;
+        rdfs:label              "Seconds"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Seconds.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:Seconds ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Seconds.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Seconds ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "s" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Seconds.value  rdf:type  rdf:Property ;
+        rdfs:comment       "Time, in seconds" ;
+        rdfs:domain        cim:Seconds ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:String  rdf:type            rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited." ;
+        rdfs:label              "String"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Time  rdf:type              rdfs:Class ;
+        rdfs:comment            "Time as \"hh:mm:ss.sss\", which conforms with ISO 8601. UTC time zone is specified as \"hh:mm:ss.sssZ\". A local timezone relative UTC is specified as \"hh:mm:ss.sss±hh:mm\". The second component (shown here as \"ss.sss\") could have any number of digits in its fractional part to allow any kind of precision beyond seconds." ;
+        rdfs:label              "Time"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:UnitMultiplier  rdf:type    rdfs:Class ;
+        rdfs:comment            "The unit multipliers defined for the CIM.  When applied to unit symbols, the unit symbol is treated as a derived unit. Regardless of the contents of the unit symbol text, the unit symbol shall be treated as if it were a single-character unit symbol. Unit symbols should not contain multipliers, and it should be left to the multiplier to define the multiple for an entire data type. \n\nFor example, if a unit symbol is \"m2Pers\" and the multiplier is \"k\", then the value is k(m**2/s), and the multiplier applies to the entire final value, not to any individual part of the value. This can be conceptualized by substituting a derived unit symbol for the unit type. If one imagines that the symbol \"Þ\" represents the derived unit \"m2Pers\", then applying the multiplier \"k\" can be conceptualized simply as \"kÞ\".\n\nFor example, the SI unit for mass is \"kg\" and not \"g\".  If the unit symbol is defined as \"kg\", then the multiplier is applied to \"kg\" as a whole and does not replace the \"k\" in front of the \"g\". In this case, the multiplier of \"m\" would be used with the unit symbol of \"kg\" to represent one gram.  As a text string, this violates the instructions in IEC 80000-1. However, because the unit symbol in CIM is treated as a derived unit instead of as an SI unit, it makes more sense to conceptualize the \"kg\" as if it were replaced by one of the proposed replacements for the SI mass symbol. If one imagines that the \"kg\" were replaced by a symbol \"Þ\", then it is easier to conceptualize the multiplier \"m\" as creating the proper unit \"mÞ\", and not the forbidden unit \"mkg\"." ;
+        rdfs:label              "UnitMultiplier"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitMultiplier.M  rdf:type  cim:UnitMultiplier ;
+        rdfs:comment     "Mega 10**6." ;
+        rdfs:label       "M"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitMultiplier.none
+        rdf:type         cim:UnitMultiplier ;
+        rdfs:comment     "No multiplier or equivalently multiply by 1." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol  rdf:type        rdfs:Class ;
+        rdfs:comment            "The derived units defined for usage in the CIM. In some cases, the derived unit is equal to an SI unit. Whenever possible, the standard derived symbol is used instead of the formula for the derived unit. For example, the unit symbol Farad is defined as \"F\" instead of \"CPerV\". In cases where a standard symbol does not exist for a derived unit, the formula for the unit is used as the unit symbol. For example, density does not have a standard symbol and so it is represented as \"kgPerm3\". With the exception of the \"kg\", which is an SI unit, the unit symbols do not contain multipliers and therefore represent the base derived unit to which a multiplier can be applied as a whole. \nEvery unit symbol is treated as an unparseable text as if it were a single-letter symbol. The meaning of each unit symbol is defined by the accompanying descriptive text and not by the text contents of the unit symbol.\nTo allow the widest possible range of serializations without requiring special character handling, several substitutions are made which deviate from the format described in IEC 80000-1. The division symbol \"/\" is replaced by the letters \"Per\". Exponents are written in plain text after the unit as \"m3\" instead of being formatted as \"m\" with a superscript of 3  or introducing a symbol as in \"m^3\". The degree symbol \"°\" is replaced with the letters \"deg\". Any clarification of the meaning for a substitution is included in the description for the unit symbol.\nNon-SI units are included in list of unit symbols to allow sources of data to be correctly labelled with their non-SI units (for example, a GPS sensor that is reporting numbers that represent feet instead of meters). This allows software to use the unit symbol information correctly convert and scale the raw data of those sources into SI-based units. \nThe integer values are used for harmonization with IEC 61850." ;
+        rdfs:label              "UnitSymbol"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitSymbol.W  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Real power in watts (J/s). Electrical power may have real and reactive components. The real portion of electrical power (I&#178;R or VIcos(phi)), is expressed in Watts. See also apparent power and reactive power." ;
+        rdfs:label       "W"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.Wh  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Real energy in watt hours." ;
+        rdfs:label       "Wh"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.none  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Dimension less quantity, e.g. count, per unit, etc." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.s  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Time in seconds." ;
+        rdfs:label       "s"@en ;
+        cims:stereotype  "enum" .
+
+nc:AssessedElement  rdf:type    rdfs:Class ;
+        rdfs:comment            "Assessed element is a network element for which the electrical state is evaluated in the regional or cross-regional process and which value is expected to fulfil regional rules function of the operational security limits.\nThe measurements and limits are as defined in the steady state hypothesis." ;
+        rdfs:label              "AssessedElement"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:AssessedElement.AssessedElementRegularSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Regular schedule that belongs to an assessed element." ;
+        rdfs:domain           nc:AssessedElement ;
+        rdfs:label            "AssessedElementRegularSchedule"@en ;
+        rdfs:range            nc:AssessedElementRegularSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AssessedElementRegularSchedule.AssessedElement ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElement.AssessedElementSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Assessed element schedule for an assessed element." ;
+        rdfs:domain           nc:AssessedElement ;
+        rdfs:label            "AssessedElementSchedule"@en ;
+        rdfs:range            nc:AssessedElementSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AssessedElementSchedule.AssessedElement ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElementRegularSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Regular schedule for assessed element." ;
+        rdfs:label              "AssessedElementRegularSchedule"@en ;
+        rdfs:subClassOf         nc:BaseRegularIntervalSchedule ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AssessedElementRegularSchedule.AssessedElement
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Assessed Element that has regular schedules." ;
+        rdfs:domain           nc:AssessedElementRegularSchedule ;
+        rdfs:label            "AssessedElement"@en ;
+        rdfs:range            nc:AssessedElement ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AssessedElement.AssessedElementRegularSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElementRegularSchedule.AssessedElementRegularTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Assessed element regular time point which belong to an assessed element regular schedule." ;
+        rdfs:domain           nc:AssessedElementRegularSchedule ;
+        rdfs:label            "AssessedElementRegularTimePoint"@en ;
+        rdfs:range            nc:AssessedElementRegularTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AssessedElementRegularTimePoint.AssessedElementRegularSchedule ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:AssessedElementRegularTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Assessed element instruction value at a given point in time." ;
+        rdfs:label              "AssessedElementRegularTimePoint"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AssessedElementRegularTimePoint.AssessedElementRegularSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Assessed element regular schedule which has assessed element regular time points." ;
+        rdfs:domain           nc:AssessedElementRegularTimePoint ;
+        rdfs:label            "AssessedElementRegularSchedule"@en ;
+        rdfs:range            nc:AssessedElementRegularSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AssessedElementRegularSchedule.AssessedElementRegularTimePoint ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElementRegularTimePoint.appointedMargin
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The percentage (appointed to a region) of the remaining margin obtained in the grid model to reach its current limit. The maximum percentage shall by default be 10% of the remaining margin.\nIt is only used when an assessed element is considered conservative for a region.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:AssessedElementRegularTimePoint ;
+        rdfs:label         "appointedMargin"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementRegularTimePoint.enabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "It identifies if the assessed element is enabled. True means enabled, False means disabled." ;
+        rdfs:domain        nc:AssessedElementRegularTimePoint ;
+        rdfs:label         "enabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementRegularTimePoint.maxFlow
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum flow on an a conducting equipment or a collection of conducting equipment forming a power transfer corridor. For assessed elements that is becomes critical due to contingency, this value represents the maximum flow with remedial action taken into consideration." ;
+        rdfs:domain        nc:AssessedElementRegularTimePoint ;
+        rdfs:label         "maxFlow"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementRegularTimePoint.scannedThresholdMargin
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Threshold percentage that a scanned element can be overloaded, on a given element, on top of any overload prior to optimisation (default= 5%). e.g. Initial loading of the element is 110%, with a 5% scanned threshold margin, the new maximum is 115% of the limit (e.g. PATL, TATL, etc).\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:AssessedElementRegularTimePoint ;
+        rdfs:label         "scannedThresholdMargin"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementRegularTimePoint.virtualPositiveMargin
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A margin defined only for scanned AssessedElement (If AssessedElement.ScannedForRegion is present) in order to represent the influence of available remedial action which is not cross-border relevant remedial action.\nThe margin is modifying the limits used for the assessment whatever the limit it is (e.g. PATL, TATL).This symbolizes a remedial action that can be applied internally by the System Operator. It will be resolved by the System Operator and not by the optimization of remedial actions. The attribute shall be a positive value.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:AssessedElementRegularTimePoint ;
+        rdfs:label         "virtualPositiveMargin"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Schedule for assessed element." ;
+        rdfs:label              "AssessedElementSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AssessedElementSchedule.AssessedElement
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Assessed element which has an assessed element schedule." ;
+        rdfs:domain           nc:AssessedElementSchedule ;
+        rdfs:label            "AssessedElement"@en ;
+        rdfs:range            nc:AssessedElement ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AssessedElement.AssessedElementSchedule ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElementSchedule.AssessedElementTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this assessed element schedule." ;
+        rdfs:domain           nc:AssessedElementSchedule ;
+        rdfs:label            "AssessedElementTimePoint"@en ;
+        rdfs:range            nc:AssessedElementTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AssessedElementTimePoint.AssessedElementSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:AssessedElementTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Assessed element instruction value at a given point in time." ;
+        rdfs:label              "AssessedElementTimePoint"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AssessedElementTimePoint.AssessedElementSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The assessed element schedule that has this time point." ;
+        rdfs:domain           nc:AssessedElementTimePoint ;
+        rdfs:label            "AssessedElementSchedule"@en ;
+        rdfs:range            nc:AssessedElementSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AssessedElementSchedule.AssessedElementTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElementTimePoint.appointedMargin
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The percentage (appointed to a region) of the remaining margin obtained in the grid model to reach its current limit. The maximum percentage shall by default be 10% of the remaining margin.\nIt is only used when an assessed element is considered conservative for a region.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:AssessedElementTimePoint ;
+        rdfs:label         "appointedMargin"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:AssessedElementTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementTimePoint.coordinatedValidationAdjustment
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A positive value expressed in MW, calculated and provided by the coordinated capacity calculator (CCC) for the reduction of Remaining Available Margin (RAM) in order to ensure grid security." ;
+        rdfs:domain        nc:AssessedElementTimePoint ;
+        rdfs:label         "coordinatedValidationAdjustment"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementTimePoint.coordinatedValidationAdjustmentJustification
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A text description provided by the coordinated capacity calculator (CCC) for justifying the reduction of Remaining Available Margin (RAM) by means of Coordinated Validation Adjustment (CVA). This justification is not intended for any application processing purpose, it should only be used for reporting." ;
+        rdfs:domain        nc:AssessedElementTimePoint ;
+        rdfs:label         "coordinatedValidationAdjustmentJustification"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementTimePoint.criticalElementContingencyJustification
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Justification indicating the kind of critical element contingency. This justification is not intended for any application processing purpose, it should only be used for reporting." ;
+        rdfs:domain        nc:AssessedElementTimePoint ;
+        rdfs:label         "criticalElementContingencyJustification"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementTimePoint.enabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "It identifies if the assessed element is enabled. True means enabled, False means disabled." ;
+        rdfs:domain        nc:AssessedElementTimePoint ;
+        rdfs:label         "enabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementTimePoint.exclusionReason
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Reason for not associating this assessed element with a secured region." ;
+        rdfs:domain        nc:AssessedElementTimePoint ;
+        rdfs:label         "exclusionReason"@en ;
+        rdfs:range         nc:SecuredExclusionReasonKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementTimePoint.individualValidationAdjustment
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A positive value expressed in MW, calculated and provided by System Operators from their individual validation process for the reduction of Remaining Available Margin in order to ensure grid security." ;
+        rdfs:domain        nc:AssessedElementTimePoint ;
+        rdfs:label         "individualValidationAdjustment"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementTimePoint.individualValidationAdjustmentJustification
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A text description provided by System Operators for justifying the reduction of Remaining Available Margin (RAM) by means of Individual Validation Adjustment (IVA). This justification is not intended for any application processing purpose, it should only be used for reporting." ;
+        rdfs:domain        nc:AssessedElementTimePoint ;
+        rdfs:label         "individualValidationAdjustmentJustification"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementTimePoint.individualValidationAdjustmentShare
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A positive value expressed in MW, calculated by the coordinated capacity calculator (CCC) based on the provided Individual Validation Adjustment (IVA) by System Operators in order to show the actual reduction of Remaining Available Margin (RAM). Individual Validation Adjustment Share is a positive non-zero value. It is equal or less than the Individual Validation Adjustment value. " ;
+        rdfs:domain        nc:AssessedElementTimePoint ;
+        rdfs:label         "individualValidationAdjustmentShare"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementTimePoint.maxFlow
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum flow on an a conducting equipment or a collection of conducting equipment forming a power transfer corridor. For assessed elements that is becomes critical due to contingency, this value represents the maximum flow with remedial action taken into consideration." ;
+        rdfs:domain        nc:AssessedElementTimePoint ;
+        rdfs:label         "maxFlow"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementTimePoint.scannedThresholdMargin
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Threshold percentage that a scanned element can be overloaded, on a given element, on top of any overload prior to optimisation (default= 5%). e.g. Initial loading of the element is 110%, with a 5% scanned threshold margin, the new maximum is 115% of the limit (e.g. PATL, TATL, etc).\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:AssessedElementTimePoint ;
+        rdfs:label         "scannedThresholdMargin"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementTimePoint.targetRemainingAvailableMarginJustification
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Justification indicating the target remaining available margin. This justification is not intended for any application processing purpose, it should only be used for reporting." ;
+        rdfs:domain        nc:AssessedElementTimePoint ;
+        rdfs:label         "targetRemainingAvailableMarginJustification"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementTimePoint.virtualPositiveMargin
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A margin defined only for scanned AssessedElement (If AssessedElement.ScannedForRegion is present) in order to represent the influence of available remedial action which is not cross-border relevant remedial action.\nThe margin is modifying the limits used for the assessment whatever the limit it is (e.g. PATL, TATL).This symbolizes a remedial action that can be applied internally by the System Operator. It will be resolved by the System Operator and not by the optimization of remedial actions. The attribute shall be a positive value.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:AssessedElementTimePoint ;
+        rdfs:label         "virtualPositiveMargin"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementWithContingency
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Combination of an assessed element and a contingency." ;
+        rdfs:label              "AssessedElementWithContingency"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:AssessedElementWithContingency.GenericEnablingSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Enabling schedule which belongs to the assessed element with contingency." ;
+        rdfs:domain           nc:AssessedElementWithContingency ;
+        rdfs:label            "GenericEnablingSchedule"@en ;
+        rdfs:range            nc:GenericEnablingSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GenericEnablingSchedule.AssessedElementWithContingency ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:AssessedElementWithRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Combination of an assessed element and a remedial action" ;
+        rdfs:label              "AssessedElementWithRemedialAction"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:AssessedElementWithRemedialAction.GenericEnablingSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Enabling schedule which belongs to the assessed element with remedial action." ;
+        rdfs:domain           nc:AssessedElementWithRemedialAction ;
+        rdfs:label            "GenericEnablingSchedule"@en ;
+        rdfs:range            nc:GenericEnablingSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GenericEnablingSchedule.AssessedElementWithRemedialAction ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:AutomationFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Automation function is a collection of functional block or other automation function that can be executed as a work cycle program as part of an automated system." ;
+        rdfs:label              "AutomationFunction"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:AutomationFunction.GenericEnablingSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Enabling schedule associated to an automation function." ;
+        rdfs:domain           nc:AutomationFunction ;
+        rdfs:label            "GenericEnablingSchedule"@en ;
+        rdfs:range            nc:GenericEnablingSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GenericEnablingSchedule.AutomationFunction ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilityTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Availability instruction value at a given point in time." ;
+        rdfs:label              "AvailabilityTimePoint"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AvailabilityTimePoint.GenericAvailabilitySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The availability schedule which belongs to the availability timepoint." ;
+        rdfs:domain           nc:AvailabilityTimePoint ;
+        rdfs:label            "GenericAvailabilitySchedule"@en ;
+        rdfs:range            nc:GenericAvailableSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GenericAvailableSchedule.AvailabilityTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:AvailabilityTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:AvailabilityTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AvailabilityTimePoint.available
+        rdf:type           rdf:Property ;
+        rdfs:comment       "It identifies if the element is available. True means available, False means unavailable." ;
+        rdfs:domain        nc:AvailabilityTimePoint ;
+        rdfs:label         "available"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseIrregularTimeSeries
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Time series that has irregular points in time." ;
+        rdfs:label              "BaseIrregularTimeSeries"@en ;
+        rdfs:subClassOf         nc:BaseTimeSeries ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:BaseRegularIntervalSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Time series that has regular points in time." ;
+        rdfs:label              "BaseRegularIntervalSchedule"@en ;
+        rdfs:subClassOf         nc:BaseTimeSeries ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:BaseRegularIntervalSchedule.HourPattern
+        rdf:type              rdf:Property ;
+        rdfs:comment          "HourPattern that has base regular interval schedule." ;
+        rdfs:domain           nc:BaseRegularIntervalSchedule ;
+        rdfs:label            "HourPattern"@en ;
+        rdfs:range            nc:HourPattern ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:HourPattern.BaseRegularIntervalSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:BaseRegularIntervalSchedule.Season
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Season associated with a base regular interval schedule." ;
+        rdfs:domain           nc:BaseRegularIntervalSchedule ;
+        rdfs:label            "Season"@en ;
+        rdfs:range            cim:Season ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Season.BaseRegularIntervalSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:BaseRegularIntervalSchedule.dayOfWeek
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Day of the week for which the schedule is valid for." ;
+        rdfs:domain        nc:BaseRegularIntervalSchedule ;
+        rdfs:label         "dayOfWeek"@en ;
+        rdfs:range         nc:DayOfWeekKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseRegularIntervalSchedule.intervalEndTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Interval end time for which the schedule is valid for." ;
+        rdfs:domain        nc:BaseRegularIntervalSchedule ;
+        rdfs:label         "intervalEndTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseRegularIntervalSchedule.intervalStartTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Interval start time for which the schedule is valid for." ;
+        rdfs:domain        nc:BaseRegularIntervalSchedule ;
+        rdfs:label         "intervalStartTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseTimeSeries  rdf:type     rdfs:Class ;
+        rdfs:comment            "Time series of values at points in time." ;
+        rdfs:label              "BaseTimeSeries"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:BaseTimeSeries.actionMethod
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Action method used to create the value. This is used for identification in the case where there is multiple time series for the same validity period and kind. " ;
+        rdfs:domain        nc:BaseTimeSeries ;
+        rdfs:label         "actionMethod"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseTimeSeries.interpolationKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of interpolation done between time point." ;
+        rdfs:domain        nc:BaseTimeSeries ;
+        rdfs:label         "interpolationKind"@en ;
+        rdfs:range         nc:TimeSeriesInterpolationKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseTimeSeries.timeSeriesKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of base time series." ;
+        rdfs:domain        nc:BaseTimeSeries ;
+        rdfs:label         "timeSeriesKind"@en ;
+        rdfs:range         nc:BaseTimeSeriesKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseTimeSeriesKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of time series. " ;
+        rdfs:label              "BaseTimeSeriesKind"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:BaseTimeSeriesKind.actual
+        rdf:type         nc:BaseTimeSeriesKind ;
+        rdfs:comment     "Time series is actual data. The values represent measured or calculated values that represent the actual behaviour. " ;
+        rdfs:label       "actual"@en ;
+        cims:stereotype  "enum" .
+
+nc:BaseTimeSeriesKind.forecast
+        rdf:type         nc:BaseTimeSeriesKind ;
+        rdfs:comment     "Time series is forecast data. The values represent the result of scientific predictions based on historical time stamped data." ;
+        rdfs:label       "forecast"@en ;
+        cims:stereotype  "enum" .
+
+nc:BaseTimeSeriesKind.hindcast
+        rdf:type         nc:BaseTimeSeriesKind ;
+        rdfs:comment     "Time series is hindcast data. The value represent probable past (historic) condition given by calculation done using actual values. For instance, determine the among of wind based on the energy produced by wind. However, hindcast is typical the result of a simulated forecasts for historical periods." ;
+        rdfs:label       "hindcast"@en ;
+        cims:stereotype  "enum" .
+
+nc:BaseTimeSeriesKind.schedule
+        rdf:type         nc:BaseTimeSeriesKind ;
+        rdfs:comment     "Time series is schedule data. The values represent the result of a committed and plan forecast data that has been through a quality control and could incur penalty when not followed." ;
+        rdfs:label       "schedule"@en ;
+        cims:stereotype  "enum" .
+
+nc:BidDirectionKind  rdf:type   rdfs:Class ;
+        rdfs:comment            "Kind of direction of the bid." ;
+        rdfs:label              "BidDirectionKind"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:BidDirectionKind.down
+        rdf:type         nc:BidDirectionKind ;
+        rdfs:comment     "Down signifies that the available power can be used by the purchasing area to decrease energy." ;
+        rdfs:label       "down"@en ;
+        cims:stereotype  "enum" .
+
+nc:BidDirectionKind.stable
+        rdf:type         nc:BidDirectionKind ;
+        rdfs:comment     "The direction at a given instant in time is considered to be stable." ;
+        rdfs:label       "stable"@en ;
+        cims:stereotype  "enum" .
+
+nc:BidDirectionKind.up
+        rdf:type         nc:BidDirectionKind ;
+        rdfs:comment     "Up signifies that the available power can be used by the purchasing area to increase energy." ;
+        rdfs:label       "up"@en ;
+        cims:stereotype  "enum" .
+
+nc:BidDirectionKind.upAndDown
+        rdf:type         nc:BidDirectionKind ;
+        rdfs:comment     "Up and down signifies that both up and down values are equal." ;
+        rdfs:label       "upAndDown"@en ;
+        cims:stereotype  "enum" .
+
+nc:Contingency.ContingencySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Contingency schedule for a contingecy." ;
+        rdfs:domain           cim:Contingency ;
+        rdfs:label            "ContingencySchedule"@en ;
+        rdfs:range            nc:ContingencySchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ContingencySchedule.Contingency ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ContingencySchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The schedule for Contingency." ;
+        rdfs:label              "ContingencySchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ContingencySchedule.Contingency
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Contingency which has a contingency schedule." ;
+        rdfs:domain           nc:ContingencySchedule ;
+        rdfs:label            "Contingency"@en ;
+        rdfs:range            cim:Contingency ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Contingency.ContingencySchedule ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:ContingencySchedule.ContingencyTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this contingency schedule." ;
+        rdfs:domain           nc:ContingencySchedule ;
+        rdfs:label            "ContingencyTimePoint"@en ;
+        rdfs:range            nc:ContingencyTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ContingencyTimePoint.ContingencySchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:ContingencyTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Contingency instruction value at a given point in time." ;
+        rdfs:label              "ContingencyTimePoint"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ContingencyTimePoint.ContingencySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The contingency schedule that has this time point." ;
+        rdfs:domain           nc:ContingencyTimePoint ;
+        rdfs:label            "ContingencySchedule"@en ;
+        rdfs:range            nc:ContingencySchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ContingencySchedule.ContingencyTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:ContingencyTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:ContingencyTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ContingencyTimePoint.mustStudy
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Set true if must study this contingency." ;
+        rdfs:domain        nc:ContingencyTimePoint ;
+        rdfs:label         "mustStudy"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ContingencyTimePoint.probability
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Probability of occurrence. The allowed value range is [0,100]." ;
+        rdfs:domain        nc:ContingencyTimePoint ;
+        rdfs:label         "probability"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ContingencyWithRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Combination of a contingency and a remedial action. ContingencyWithRemedialAction shall not be instantiated for preventive RemedialAction (RemedialAction.kind equals RemedialActionKind.preventive)." ;
+        rdfs:label              "ContingencyWithRemedialAction"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:ContingencyWithRemedialAction.GenericEnablingSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Enabling schedule associated to a contingency with remedial action." ;
+        rdfs:domain           nc:ContingencyWithRemedialAction ;
+        rdfs:label            "GenericEnablingSchedule"@en ;
+        rdfs:range            nc:GenericEnablingSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GenericEnablingSchedule.ContingencyWithRemedialAction ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:CrossBorderRelevant
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Combination of an assessed element and a bidding zone border." ;
+        rdfs:label              "CrossBorderRelevant"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:CrossBorderRelevant.GenericEnablingSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Cross border relevant that has enabling schedules." ;
+        rdfs:domain           nc:CrossBorderRelevant ;
+        rdfs:label            "GenericEnablingSchedule"@en ;
+        rdfs:range            nc:GenericEnablingSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GenericEnablingSchedule.CrossBorderRelevant ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:DCPole  rdf:type             rdfs:Class ;
+        rdfs:comment            "The direct current (DC) system pole (IEC 60633) is part of a DC system consisting of all the equipment in the DC substations and the interconnecting transmission lines, if any, which during normal operation exhibit a common direct voltage polarity with respect to earth." ;
+        rdfs:label              "DCPole"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:DCPole.PowerShiftKeySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The Power Shift Key schedule for a DCPole." ;
+        rdfs:domain           nc:DCPole ;
+        rdfs:label            "PowerShiftKeySchedule"@en ;
+        rdfs:range            nc:PowerShiftKeySchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerShiftKeySchedule.DCPole ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:DayOfWeekKind  rdf:type      rdfs:Class ;
+        rdfs:comment            "The kind of day to be included in a regular schedule." ;
+        rdfs:label              "DayOfWeekKind"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:DayOfWeekKind.all  rdf:type  nc:DayOfWeekKind ;
+        rdfs:comment     "All days of the week." ;
+        rdfs:label       "all"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.bridgeDay
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:comment     "A day that is a gap between two distinguished days e.g holiday and weekend that leads to an abnormal scheduling behavior. e.g. if Ascension day falls on a Thursday, then Friday would be a bridge day due to the schedule will not have a normal Friday consumption and production." ;
+        rdfs:label       "bridgeDay"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.friday
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:comment     "Friday as the day of the week." ;
+        rdfs:label       "friday"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.holiday
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:label       "holiday"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.monday
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:comment     "Monday as the day of the week." ;
+        rdfs:label       "monday"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.saturday
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:comment     "Saturday as the day of the week." ;
+        rdfs:label       "saturday"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.sunday
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:comment     "Sunday as the day of the week." ;
+        rdfs:label       "sunday"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.thursday
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:comment     "Thursday as the day of the week." ;
+        rdfs:label       "thursday"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.tuesday
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:comment     "Tuesday as the day of the week." ;
+        rdfs:label       "tuesday"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.wednesday
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:comment     "Wednesday as the day of the week." ;
+        rdfs:label       "wednesday"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.weekday
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:comment     "A day of the week other than Sunday or Saturday." ;
+        rdfs:label       "weekday"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.weekend
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:comment     "A day of the week which is Sunday or Saturday." ;
+        rdfs:label       "weekend"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnablingTimePoint  rdf:type  rdfs:Class ;
+        rdfs:comment            "Enabling instruction value at a given point in time." ;
+        rdfs:label              "EnablingTimePoint"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EnablingTimePoint.GenericEnablingSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The enabling schedule which belongs to the enabling timepoint." ;
+        rdfs:domain           nc:EnablingTimePoint ;
+        rdfs:label            "GenericEnablingSchedule"@en ;
+        rdfs:range            nc:GenericEnablingSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GenericEnablingSchedule.EnablingTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:EnablingTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:EnablingTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EnablingTimePoint.enabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "It identifies if the element is enabled. True means enabled, False means not enabled." ;
+        rdfs:domain        nc:EnablingTimePoint ;
+        rdfs:label         "enabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EnergyBlockOrder  rdf:type   rdfs:Class ;
+        rdfs:comment            "The energy block order is a block (an amount) of energy that forms the sequence of orders that are going to be distributed to an energy block component." ;
+        rdfs:label              "EnergyBlockOrder"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:EnergyBlockOrder.PowerShiftKeySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The Power Shift Key schedule for an energy block order." ;
+        rdfs:domain           nc:EnergyBlockOrder ;
+        rdfs:label            "PowerShiftKeySchedule"@en ;
+        rdfs:range            nc:PowerShiftKeySchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerShiftKeySchedule.EnergyBlockOrder ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EnergyConsumer.PowerShiftKeySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The Power Shift Key schedule for an Energy Consumer." ;
+        rdfs:domain           cim:EnergyConsumer ;
+        rdfs:label            "PowerShiftKeySchedule"@en ;
+        rdfs:range            nc:PowerShiftKeySchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerShiftKeySchedule.EnergyConsumer ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EnergyDemandKind  rdf:type   rdfs:Class ;
+        rdfs:comment            "Kind of energy demand." ;
+        rdfs:label              "EnergyDemandKind"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:EnergyDemandKind.consumption
+        rdf:type         nc:EnergyDemandKind ;
+        rdfs:label       "consumption"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyDemandKind.export
+        rdf:type         nc:EnergyDemandKind ;
+        rdfs:label       "export"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyDemandKind.import
+        rdf:type         nc:EnergyDemandKind ;
+        rdfs:label       "import"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyDemandKind.production
+        rdf:type         nc:EnergyDemandKind ;
+        rdfs:label       "production"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyDemandKind.storage
+        rdf:type         nc:EnergyDemandKind ;
+        rdfs:label       "storage"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyGroup  rdf:type        rdfs:Class ;
+        rdfs:comment            "An energy group is an aggregation of energy components which have the same energy characteristic, e.g. fuel type and technology. It can be used to allocate energy. " ;
+        rdfs:label              "EnergyGroup"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:EnergyGroup.PowerShiftKeySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The Power Shift Key schedule for an energy group." ;
+        rdfs:domain           nc:EnergyGroup ;
+        rdfs:label            "PowerShiftKeySchedule"@en ;
+        rdfs:range            nc:PowerShiftKeySchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerShiftKeySchedule.EnergyGroup ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EnergySource.PowerShiftKeySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The power shift key schedule for an energy source." ;
+        rdfs:domain           cim:EnergySource ;
+        rdfs:label            "PowerShiftKeySchedule"@en ;
+        rdfs:range            nc:PowerShiftKeySchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerShiftKeySchedule.EnergySource ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EquivalentInjection.PowerShiftKeySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power shift key schedule associated with an equivalent injection." ;
+        rdfs:domain           cim:EquivalentInjection ;
+        rdfs:label            "PowerShiftKeySchedule"@en ;
+        rdfs:range            nc:PowerShiftKeySchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerShiftKeySchedule.EquivalentInjection ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ExternalNetworkInjection.PowerShiftKeySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The power shift key schedule for an external network injection." ;
+        rdfs:domain           cim:ExternalNetworkInjection ;
+        rdfs:label            "PowerShiftKeySchedule"@en ;
+        rdfs:range            nc:PowerShiftKeySchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerShiftKeySchedule.ExternalNetworkInjection ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:FunctionBlock  rdf:type      rdfs:Class ;
+        rdfs:comment            "Function block is a function described as a set of elementary blocks. The blocks describe the function between input variables and output variables." ;
+        rdfs:label              "FunctionBlock"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:FunctionBlock.GenericEnablingSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Enabling schedule associated to a function block." ;
+        rdfs:domain           nc:FunctionBlock ;
+        rdfs:label            "GenericEnablingSchedule"@en ;
+        rdfs:range            nc:GenericEnablingSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GenericEnablingSchedule.FunctionBlock ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:GeneratingUnit.PowerShiftKeySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The Power Shift Key schedule for a Generating Unit." ;
+        rdfs:domain           cim:GeneratingUnit ;
+        rdfs:label            "PowerShiftKeySchedule"@en ;
+        rdfs:range            nc:PowerShiftKeySchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerShiftKeySchedule.GeneratingUnit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:GeneratingUnit.UnitCostSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Unit cost schedule associated with a generating unit." ;
+        rdfs:domain           cim:GeneratingUnit ;
+        rdfs:label            "UnitCostSchedule"@en ;
+        rdfs:range            nc:UnitCostSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:UnitCostSchedule.GeneratingUnit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:GenericAvailableSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The schedule for the availability of elements." ;
+        rdfs:label              "GenericAvailableSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:GenericAvailableSchedule.AvailabilityTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The availability timepoint for an available schedule." ;
+        rdfs:domain           nc:GenericAvailableSchedule ;
+        rdfs:label            "AvailabilityTimePoint"@en ;
+        rdfs:range            nc:AvailabilityTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AvailabilityTimePoint.GenericAvailabilitySchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:GenericAvailableSchedule.RemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action which has available schedules." ;
+        rdfs:domain           nc:GenericAvailableSchedule ;
+        rdfs:label            "RemedialAction"@en ;
+        rdfs:range            nc:RemedialAction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialAction.GenericAvailableSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:GenericEnablingSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The schedule for the enabling of elements." ;
+        rdfs:label              "GenericEnablingSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:GenericEnablingSchedule.AssessedElementWithContingency
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Assessed element with contingency that has enabling schedules." ;
+        rdfs:domain           nc:GenericEnablingSchedule ;
+        rdfs:label            "AssessedElementWithContingency"@en ;
+        rdfs:range            nc:AssessedElementWithContingency ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AssessedElementWithContingency.GenericEnablingSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:GenericEnablingSchedule.AssessedElementWithRemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Assessed element with remedial action that has enabling schedules." ;
+        rdfs:domain           nc:GenericEnablingSchedule ;
+        rdfs:label            "AssessedElementWithRemedialAction"@en ;
+        rdfs:range            nc:AssessedElementWithRemedialAction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AssessedElementWithRemedialAction.GenericEnablingSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:GenericEnablingSchedule.AutomationFunction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Automation function which has enabling schedules." ;
+        rdfs:domain           nc:GenericEnablingSchedule ;
+        rdfs:label            "AutomationFunction"@en ;
+        rdfs:range            nc:AutomationFunction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AutomationFunction.GenericEnablingSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:GenericEnablingSchedule.ContingencyWithRemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Contingency with remedial action which has enabling schedules." ;
+        rdfs:domain           nc:GenericEnablingSchedule ;
+        rdfs:label            "ContingencyWithRemedialAction"@en ;
+        rdfs:range            nc:ContingencyWithRemedialAction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ContingencyWithRemedialAction.GenericEnablingSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:GenericEnablingSchedule.CrossBorderRelevant
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Enabling schedule which belongs to the cross border relevant." ;
+        rdfs:domain           nc:GenericEnablingSchedule ;
+        rdfs:label            "CrossBorderRelevant"@en ;
+        rdfs:range            nc:CrossBorderRelevant ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:CrossBorderRelevant.GenericEnablingSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:GenericEnablingSchedule.EnablingTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The enabling timepoint for a assessed element with enabling schedule." ;
+        rdfs:domain           nc:GenericEnablingSchedule ;
+        rdfs:label            "EnablingTimePoint"@en ;
+        rdfs:range            nc:EnablingTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EnablingTimePoint.GenericEnablingSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:GenericEnablingSchedule.FunctionBlock
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Function block which has enabling schedules." ;
+        rdfs:domain           nc:GenericEnablingSchedule ;
+        rdfs:label            "FunctionBlock"@en ;
+        rdfs:range            nc:FunctionBlock ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:FunctionBlock.GenericEnablingSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:GenericEnablingSchedule.PowerTransferCorridor
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power transfer corridor which has generic enabling schedules." ;
+        rdfs:domain           nc:GenericEnablingSchedule ;
+        rdfs:label            "PowerTransferCorridor"@en ;
+        rdfs:range            nc:PowerTransferCorridor ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerTransferCorridor.GenericEnablingSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:GenericEnablingSchedule.RemedialActionDependency
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action dependency which has enabling schedules." ;
+        rdfs:domain           nc:GenericEnablingSchedule ;
+        rdfs:label            "RemedialActionDependency"@en ;
+        rdfs:range            nc:RemedialActionDependency ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialActionDependency.GenericEnablingSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:GenericValueSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Time series represent irregular generic value at given points in time. The type of value is given by the reference association.  " ;
+        rdfs:label              "GenericValueSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:GenericValueSchedule.GenericValueTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Value for the point in time." ;
+        rdfs:domain           nc:GenericValueSchedule ;
+        rdfs:label            "GenericValueTimePoint"@en ;
+        rdfs:range            nc:GenericValueTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GenericValueTimePoint.GenericValueSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:GenericValueSchedule.RangeConstraint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Range constraint for the generic value schedule." ;
+        rdfs:domain           nc:GenericValueSchedule ;
+        rdfs:label            "RangeConstraint"@en ;
+        rdfs:range            nc:RangeConstraint ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RangeConstraint.GenericValueSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:GenericValueTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Generic value for a given point in time." ;
+        rdfs:label              "GenericValueTimePoint"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:GenericValueTimePoint.GenericValueSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Time series the time point values belongs to." ;
+        rdfs:domain           nc:GenericValueTimePoint ;
+        rdfs:label            "GenericValueSchedule"@en ;
+        rdfs:range            nc:GenericValueSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GenericValueSchedule.GenericValueTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:GenericValueTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:GenericValueTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GenericValueTimePoint.value
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The value at the time. The meaning of the value is defined by the derived type of the associated schedule. The value can be integer, float or boolean. In case of boolean 1 equals true and 0 equals false." ;
+        rdfs:domain        nc:GenericValueTimePoint ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GridStateAlteration
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Grid state alteration is a change of values describing state (operating point) of one element in the grid model compared to the base case." ;
+        rdfs:label              "GridStateAlteration"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:GridStateAlteration.GridStateAlterationSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Grid state alteration schedule associated with a grid state alteration." ;
+        rdfs:domain           nc:GridStateAlteration ;
+        rdfs:label            "GridStateAlterationSchedule"@en ;
+        rdfs:range            nc:GridStateAlterationSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GridStateAlterationSchedule.GridStateAlteration ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:GridStateAlterationSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Schedule for a grid state alteration." ;
+        rdfs:label              "GridStateAlterationSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:GridStateAlterationSchedule.GridStateAlteration
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Grid state alteration which has grid state alteration schedules." ;
+        rdfs:domain           nc:GridStateAlterationSchedule ;
+        rdfs:label            "GridStateAlteration"@en ;
+        rdfs:range            nc:GridStateAlteration ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GridStateAlteration.GridStateAlterationSchedule ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:GridStateAlterationSchedule.GridStateAlterationTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Grid state alteration time point that relates to this grid state alteration schedule." ;
+        rdfs:domain           nc:GridStateAlterationSchedule ;
+        rdfs:label            "GridStateAlterationTimePoint"@en ;
+        rdfs:range            nc:GridStateAlterationTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GridStateAlterationTimePoint.GridStateAlterationSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:GridStateAlterationTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Grid state alteration at a given point in time." ;
+        rdfs:label              "GridStateAlterationTimePoint"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:GridStateAlterationTimePoint.GridStateAlterationSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Grid state alteration schedule that has time point." ;
+        rdfs:domain           nc:GridStateAlterationTimePoint ;
+        rdfs:label            "GridStateAlterationSchedule"@en ;
+        rdfs:range            nc:GridStateAlterationSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GridStateAlterationSchedule.GridStateAlterationTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:GridStateAlterationTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:GridStateAlterationTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GridStateAlterationTimePoint.enabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The status of the GridStateAlteration set by an operation or by a signal resulting from a control action." ;
+        rdfs:domain        nc:GridStateAlterationTimePoint ;
+        rdfs:label         "enabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GridStateAlterationTimePoint.participationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Participation factor describing the entity part of the active power provided by a collection of entities (e.g. an active power forecast to a collection of entities is divided to each of the member entity according to the participation factor). Must be a positive value.\nIn the case of a sharing strategy, the distribution is following entities value (V) equals aggregated value (T) divided by sum of participation factors (PF), i.e. V=T/sum(PF). \nIn the case of priority strategy, the item with the lowest number gets allocated energy first.\ne.g. If 0 this grid alteration does not participate. The sum of all participation factors for all grid state alterations associated with same remedial action shall be equal to 100%." ;
+        rdfs:domain        nc:GridStateAlterationTimePoint ;
+        rdfs:label         "participationFactor"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GridStateIntensitySchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Defines the intensity applied for a given grid state alteration. It is primarily used in exchanges related to the remedial action schedule. The value provided by the schedule replaces the value of the attribute to which the schedule refers to." ;
+        rdfs:label              "GridStateIntensitySchedule"@en ;
+        rdfs:subClassOf         nc:GenericValueSchedule ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:GridStateIntensitySchedule.valueKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The kind of value1 and value2 of the associated IrregularIntervalSchedule." ;
+        rdfs:domain        nc:GridStateIntensitySchedule ;
+        rdfs:label         "valueKind"@en ;
+        rdfs:range         nc:ValueOffsetKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:HourPattern  rdf:type        rdfs:Class ;
+        rdfs:comment            "A period of the day with a given pattern." ;
+        rdfs:label              "HourPattern"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:HourPattern.BaseRegularIntervalSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Base regulat interval schedule which belongs to an hour pattern." ;
+        rdfs:domain           nc:HourPattern ;
+        rdfs:label            "BaseRegularIntervalSchedule"@en ;
+        rdfs:range            nc:BaseRegularIntervalSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:BaseRegularIntervalSchedule.HourPattern ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:HourPattern.HourPeriod
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Hour period which belongs to an hour pattern." ;
+        rdfs:domain           nc:HourPattern ;
+        rdfs:label            "HourPeriod"@en ;
+        rdfs:range            nc:HourPeriod ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:HourPeriod.HourPattern ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:HourPattern.energyDemandKind
+        rdf:type           rdf:Property ;
+        rdfs:domain        nc:HourPattern ;
+        rdfs:label         "energyDemandKind"@en ;
+        rdfs:range         nc:EnergyDemandKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:HourPattern.peakKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of peak for a given hour pattern." ;
+        rdfs:domain        nc:HourPattern ;
+        rdfs:label         "peakKind"@en ;
+        rdfs:range         nc:PeakKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:HourPeriod  rdf:type         rdfs:Class ;
+        rdfs:label              "HourPeriod"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:HourPeriod.HourPattern
+        rdf:type              rdf:Property ;
+        rdfs:comment          "HourPattern which has some hour periods." ;
+        rdfs:domain           nc:HourPeriod ;
+        rdfs:label            "HourPattern"@en ;
+        rdfs:range            nc:HourPattern ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:HourPattern.HourPeriod ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:HourPeriod.endTime
+        rdf:type           rdf:Property ;
+        rdfs:domain        nc:HourPeriod ;
+        rdfs:label         "endTime"@en ;
+        cims:dataType      cim:Time ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:HourPeriod.mRID  rdf:type  rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:HourPeriod ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:HourPeriod.startTime
+        rdf:type           rdf:Property ;
+        rdfs:domain        nc:HourPeriod ;
+        rdfs:label         "startTime"@en ;
+        cims:dataType      cim:Time ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:HydroPump.PowerShiftKeySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The Power Shift Key schedule for a Hydro Pump." ;
+        rdfs:domain           cim:HydroPump ;
+        rdfs:label            "PowerShiftKeySchedule"@en ;
+        rdfs:range            nc:PowerShiftKeySchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerShiftKeySchedule.HydroPump ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:InfeedLimit  rdf:type        rdfs:Class ;
+        rdfs:comment            "Infeed limit set constraints fed in to the network by two or more terminals." ;
+        rdfs:label              "InfeedLimit"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:InfeedLimit.InfeedLimitSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Infeed limit schedule associated with an infeed  limit." ;
+        rdfs:domain           nc:InfeedLimit ;
+        rdfs:label            "InfeedLimitSchedule"@en ;
+        rdfs:range            nc:InfeedLimitSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:InfeedLimitSchedule.InfeedLimit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:InfeedLimitSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The schedule for an infeed limit." ;
+        rdfs:label              "InfeedLimitSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:InfeedLimitSchedule.InfeedLimit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Infeed limit which has infeed limit schedules." ;
+        rdfs:domain           nc:InfeedLimitSchedule ;
+        rdfs:label            "InfeedLimit"@en ;
+        rdfs:range            nc:InfeedLimit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:InfeedLimit.InfeedLimitSchedule ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:InfeedLimitSchedule.InfeedLimitTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Infeed limit time point that relates to this voltage angle schedule." ;
+        rdfs:domain           nc:InfeedLimitSchedule ;
+        rdfs:label            "InfeedLimitTimePoint"@en ;
+        rdfs:range            nc:InfeedLimitTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:InfeedLimitTimePoint.InfeedLimitSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:InfeedLimitTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Infeed limit at a given point in time." ;
+        rdfs:label              "InfeedLimitTimePoint"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:InfeedLimitTimePoint.InfeedLimitSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Infeed limit schedule that has time point." ;
+        rdfs:domain           nc:InfeedLimitTimePoint ;
+        rdfs:label            "InfeedLimitSchedule"@en ;
+        rdfs:range            nc:InfeedLimitSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:InfeedLimitSchedule.InfeedLimitTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:InfeedLimitTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:InfeedLimitTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:InfeedLimitTimePoint.valueA
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Value of current limit. The attribute shall be a positive value or zero." ;
+        rdfs:domain        nc:InfeedLimitTimePoint ;
+        rdfs:label         "valueA"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:InfeedLimitTimePoint.valueW
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Value of active power limit. The attribute shall be a positive value or zero." ;
+        rdfs:domain        nc:InfeedLimitTimePoint ;
+        rdfs:label         "valueW"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ParticipationFactorTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Participation factor for a given point in time." ;
+        rdfs:label              "ParticipationFactorTimePoint"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ParticipationFactorTimePoint.PowerShiftKeySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The Power Shift Key schedule which belongs to the participation factor timepoint." ;
+        rdfs:domain           nc:ParticipationFactorTimePoint ;
+        rdfs:label            "PowerShiftKeySchedule"@en ;
+        rdfs:range            nc:PowerShiftKeySchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerShiftKeySchedule.ParticipationFactorTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:ParticipationFactorTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:ParticipationFactorTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ParticipationFactorTimePoint.participationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Participation factor describing the entity part of the active power provided by a collection of entities (e.g. an active power forecast to a collection of entities is divided to each of the member entity according to the participation factor). Must be a positive value.\nIn the case of a sharing strategy, the distribution is following entities value (V) equals aggregated value (T) divided by sum of participation factors (PF), i.e. V=T/sum(PF). \nIn the case of priority strategy, the item with the lowest number gets allocated energy first." ;
+        rdfs:domain        nc:ParticipationFactorTimePoint ;
+        rdfs:label         "participationFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PeakKind  rdf:type           rdfs:Class ;
+        rdfs:label              "PeakKind"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:PeakKind.offPeak  rdf:type  nc:PeakKind ;
+        rdfs:comment     "Off-peak refer to periods of lower demand for a particular service or commodity." ;
+        rdfs:label       "offPeak"@en ;
+        cims:stereotype  "enum" .
+
+nc:PeakKind.onPeak  rdf:type  nc:PeakKind ;
+        rdfs:comment     "Off-peak refer to periods of higher demand for a particular service or commodity." ;
+        rdfs:label       "onPeak"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerBidDependency
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Dependency between the related power bids." ;
+        rdfs:label              "PowerBidDependency"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerBidDependency.DependentPowerBidSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Dependent power bid which has some dependent bid delays." ;
+        rdfs:domain           nc:PowerBidDependency ;
+        rdfs:label            "DependentPowerBidSchedule"@en ;
+        rdfs:range            nc:PowerBidSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerBidSchedule.DependentBidDelay ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerBidDependency.MainPowerBidSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Main power bid which some dependent power bids." ;
+        rdfs:domain           nc:PowerBidDependency ;
+        rdfs:label            "MainPowerBidSchedule"@en ;
+        rdfs:range            nc:PowerBidSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerBidSchedule.PowerBidDependency ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerBidDependency.delay
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Time delay between activation of the parents until the dependent offer will be available." ;
+        rdfs:domain        nc:PowerBidDependency ;
+        rdfs:label         "delay"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidDependency.kind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Type of dependency between bids." ;
+        rdfs:domain        nc:PowerBidDependency ;
+        rdfs:label         "kind"@en ;
+        rdfs:range         nc:PowerBidDependencyKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidDependency.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:PowerBidDependency ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidDependencyKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of power bid dependency." ;
+        rdfs:label              "PowerBidDependencyKind"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:PowerBidDependencyKind.exclusive
+        rdf:type         nc:PowerBidDependencyKind ;
+        rdfs:comment     "Bids are exclusive depending on each other. e.g. Only one of the bids can be activated at the same time." ;
+        rdfs:label       "exclusive"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerBidDependencyKind.inclusive
+        rdf:type         nc:PowerBidDependencyKind ;
+        rdfs:comment     "Bids are inclusive depending on each other. e.g. Both bids need to be activated if one of them is activated." ;
+        rdfs:label       "inclusive"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerBidDependencyKind.restrictive
+        rdf:type         nc:PowerBidDependencyKind ;
+        rdfs:comment     "Bids are restrictive depending on each other. e.g. You have to take the father bid before you might take the child bid." ;
+        rdfs:label       "restrictive"@en ;
+        cims:stereotype  "enum" .
+
+nc:PowerBidSchedule  rdf:type   rdfs:Class ;
+        rdfs:comment            "Power bid or offer related to a redispatch or countertrading measures. In the case of market place for economic efficiency of the bids and offers, this is equivalent to BidTimeSeries class in 62325 package." ;
+        rdfs:label              "PowerBidSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerBidSchedule.DependentBidDelay
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Bid delay which depends on a main power bid." ;
+        rdfs:domain           nc:PowerBidSchedule ;
+        rdfs:label            "DependentBidDelay"@en ;
+        rdfs:range            nc:PowerBidDependency ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerBidDependency.DependentPowerBidSchedule ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerBidSchedule.PowerBidDependency
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power bids which depends on main bid." ;
+        rdfs:domain           nc:PowerBidSchedule ;
+        rdfs:label            "PowerBidDependency"@en ;
+        rdfs:range            nc:PowerBidDependency ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerBidDependency.MainPowerBidSchedule ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:PowerBidSchedule.PowerBidScheduleTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power bid schedule time points which belong to a power bid schedule." ;
+        rdfs:domain           nc:PowerBidSchedule ;
+        rdfs:label            "PowerBidScheduleTimePoint"@en ;
+        rdfs:range            nc:PowerBidScheduleTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerBidScheduleTimePoint.PowerBidSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:PowerBidSchedule.PowerRemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power remedial action for which the bid is given." ;
+        rdfs:domain           nc:PowerBidSchedule ;
+        rdfs:label            "PowerRemedialAction"@en ;
+        rdfs:range            nc:PowerRemedialAction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerRemedialAction.PowerBidSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerBidSchedule.PowerShiftKeyDistribution
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Distribution of the power bid amongst the power shift keys." ;
+        rdfs:domain           nc:PowerBidSchedule ;
+        rdfs:label            "PowerShiftKeyDistribution"@en ;
+        rdfs:range            nc:PowerShiftKeyDistribution ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerShiftKeyDistribution.PowerBidSchedule ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerBidSchedule.ScheduleResource
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Schedule resource which has several power bid schedules." ;
+        rdfs:domain           nc:PowerBidSchedule ;
+        rdfs:label            "ScheduleResource"@en ;
+        rdfs:range            nc:ScheduleResource ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ScheduleResource.PowerBidSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerBidSchedule.activationCost
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Cost to activate the bid." ;
+        rdfs:domain        nc:PowerBidSchedule ;
+        rdfs:label         "activationCost"@en ;
+        cims:dataType      cim:Decimal ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidSchedule.currency
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Currency of the bid." ;
+        rdfs:domain        nc:PowerBidSchedule ;
+        rdfs:label         "currency"@en ;
+        rdfs:range         cim:Currency ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidSchedule.direction
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Define the direction of the energy adjustment." ;
+        rdfs:domain        nc:PowerBidSchedule ;
+        rdfs:label         "direction"@en ;
+        rdfs:range         nc:BidDirectionKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidSchedule.isFixed
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Indicates if the power bid schedule is fixed, meaning that all the different power bid schedule values need to be taken without changes. e.g. It is a take-it-or-leave-it bid offer." ;
+        rdfs:domain        nc:PowerBidSchedule ;
+        rdfs:label         "isFixed"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidSchedule.isOffer
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Indicates if the power bid is an offer or not. True, means that the bid is an offer. False, means that the bid is not an offer." ;
+        rdfs:domain        nc:PowerBidSchedule ;
+        rdfs:label         "isOffer"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidSchedule.leadTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Time it takes for the bid to be called upon until it is active." ;
+        rdfs:domain        nc:PowerBidSchedule ;
+        rdfs:label         "leadTime"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidSchedule.maxRampDownP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum decrease of the active power change from one time point to the next." ;
+        rdfs:domain        nc:PowerBidSchedule ;
+        rdfs:label         "maxRampDownP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidSchedule.maxRampUpP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum increase of the active power change from one time point to the next." ;
+        rdfs:domain        nc:PowerBidSchedule ;
+        rdfs:label         "maxRampUpP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidSchedule.maximumUptime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum duration the action needs to be remain active after startup. " ;
+        rdfs:domain        nc:PowerBidSchedule ;
+        rdfs:label         "maximumUptime"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidSchedule.minimumOffTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Minimum time interval between activation of the bid involving startup and shutdown. This value overrides any value on the unit." ;
+        rdfs:domain        nc:PowerBidSchedule ;
+        rdfs:label         "minimumOffTime"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidSchedule.minimumUptime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Minimum duration the action needs to be remain active after startup. " ;
+        rdfs:domain        nc:PowerBidSchedule ;
+        rdfs:label         "minimumUptime"@en ;
+        cims:dataType      cim:Duration ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidSchedule.priority
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The numeric local priority given to a bid. Lower numeric values will have higher priority." ;
+        rdfs:domain        nc:PowerBidSchedule ;
+        rdfs:label         "priority"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidSchedule.shutdownCost
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Total shutdown cost incurred for all the units involved in the bid. This overrides any cost on the specific unit." ;
+        rdfs:domain        nc:PowerBidSchedule ;
+        rdfs:label         "shutdownCost"@en ;
+        cims:dataType      cim:Decimal ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidSchedule.totalMaximumEnergy
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum total energy that can be activated by the bid." ;
+        rdfs:domain        nc:PowerBidSchedule ;
+        rdfs:label         "totalMaximumEnergy"@en ;
+        cims:dataType      cim:RealEnergy ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidSchedule.totalMinimumEnergy
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Minimum total energy that has to be activated by the bid." ;
+        rdfs:domain        nc:PowerBidSchedule ;
+        rdfs:label         "totalMinimumEnergy"@en ;
+        cims:dataType      cim:RealEnergy ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidScheduleTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Time series represent irregular power, active and reactive, values at given points in time." ;
+        rdfs:label              "PowerBidScheduleTimePoint"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerBidScheduleTimePoint.PowerBidSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power bid schedule that has many power bid schedule time points." ;
+        rdfs:domain           nc:PowerBidScheduleTimePoint ;
+        rdfs:label            "PowerBidSchedule"@en ;
+        rdfs:range            nc:PowerBidSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerBidSchedule.PowerBidScheduleTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerBidScheduleTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:PowerBidScheduleTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidScheduleTimePoint.minimumActivationP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Minimum active power given in the time point." ;
+        rdfs:domain        nc:PowerBidScheduleTimePoint ;
+        rdfs:label         "minimumActivationP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidScheduleTimePoint.p
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Active power given in the time point." ;
+        rdfs:domain        nc:PowerBidScheduleTimePoint ;
+        rdfs:label         "p"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidScheduleTimePoint.price
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Quantity given in the time points." ;
+        rdfs:domain        nc:PowerBidScheduleTimePoint ;
+        rdfs:label         "price"@en ;
+        cims:dataType      cim:Decimal ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidScheduleTimePoint.reservePrice
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Price for reserving the step increment active power." ;
+        rdfs:domain        nc:PowerBidScheduleTimePoint ;
+        rdfs:label         "reservePrice"@en ;
+        cims:dataType      cim:Decimal ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerBidScheduleTimePoint.stepIncrementP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The minimum increment that can be applied for an increase in an activation request." ;
+        rdfs:domain        nc:PowerBidScheduleTimePoint ;
+        rdfs:label         "stepIncrementP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerElectronicsUnit.PowerShiftKeySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The Power Shift Key schedule for a Power Electronics Unit." ;
+        rdfs:domain           cim:PowerElectronicsUnit ;
+        rdfs:label            "PowerShiftKeySchedule"@en ;
+        rdfs:range            nc:PowerShiftKeySchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerShiftKeySchedule.PowerElectronicsUnit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Energy remedial action describes actions to rearrange power schedules." ;
+        rdfs:label              "PowerRemedialAction"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:PowerRemedialAction.PowerBidSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power bid schedule addressing the power remedial action." ;
+        rdfs:domain           nc:PowerRemedialAction ;
+        rdfs:label            "PowerBidSchedule"@en ;
+        rdfs:range            nc:PowerBidSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerBidSchedule.PowerRemedialAction ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerRemedialAction.PowerRemedialActionSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power remedial action schedule which has a power remedial action." ;
+        rdfs:domain           nc:PowerRemedialAction ;
+        rdfs:label            "PowerRemedialActionSchedule"@en ;
+        rdfs:range            nc:PowerRemedialActionSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerRemedialActionSchedule.PowerRemedialAction ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerRemedialActionSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The schedule for a power remedial action." ;
+        rdfs:label              "PowerRemedialActionSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerRemedialActionSchedule.PowerRemedialAction
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power remedial action for the power remedial action schedule." ;
+        rdfs:domain           nc:PowerRemedialActionSchedule ;
+        rdfs:label            "PowerRemedialAction"@en ;
+        rdfs:range            nc:PowerRemedialAction ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerRemedialAction.PowerRemedialActionSchedule ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerRemedialActionSchedule.PowerRemedialActionTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this power remedial action schedule." ;
+        rdfs:domain           nc:PowerRemedialActionSchedule ;
+        rdfs:label            "PowerRemedialActionTimePoint"@en ;
+        rdfs:range            nc:PowerRemedialActionTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerRemedialActionTimePoint.PowerRemedialActionSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:PowerRemedialActionTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Regulating values at a given point in time." ;
+        rdfs:label              "PowerRemedialActionTimePoint"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerRemedialActionTimePoint.PowerRemedialActionSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The power remedial action schedule that has this time point." ;
+        rdfs:domain           nc:PowerRemedialActionTimePoint ;
+        rdfs:label            "PowerRemedialActionSchedule"@en ;
+        rdfs:range            nc:PowerRemedialActionSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerRemedialActionSchedule.PowerRemedialActionTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerRemedialActionTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:PowerRemedialActionTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerRemedialActionTimePoint.maxRegulatingDown
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum net amount of active power that the remedial action can regulate down." ;
+        rdfs:domain        nc:PowerRemedialActionTimePoint ;
+        rdfs:label         "maxRegulatingDown"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerRemedialActionTimePoint.maxRegulatingUp
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum net amount of active power that the remedial action can regulate up." ;
+        rdfs:domain        nc:PowerRemedialActionTimePoint ;
+        rdfs:label         "maxRegulatingUp"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerShiftKeyDistribution
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Distribution of the bid action on the power shift keys." ;
+        rdfs:label              "PowerShiftKeyDistribution"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerShiftKeyDistribution.PowerBidSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power bid schedule for the given distribution." ;
+        rdfs:domain           nc:PowerShiftKeyDistribution ;
+        rdfs:label            "PowerBidSchedule"@en ;
+        rdfs:range            nc:PowerBidSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerBidSchedule.PowerShiftKeyDistribution ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerShiftKeyDistribution.PowerShiftKeySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power Shift Key schedule in power shift key distribution." ;
+        rdfs:domain           nc:PowerShiftKeyDistribution ;
+        rdfs:label            "PowerShiftKeySchedule"@en ;
+        rdfs:range            nc:PowerShiftKeySchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerShiftKeySchedule.PowerShiftKeyDistribution ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerShiftKeyDistribution.PowerShiftKeyStrategy
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power Shift Key Strategy which has a Power Shift Key Distribution." ;
+        rdfs:domain           nc:PowerShiftKeyDistribution ;
+        rdfs:label            "PowerShiftKeyStrategy"@en ;
+        rdfs:range            nc:PowerShiftKeyStrategy ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerShiftKeyStrategy.PowerShiftKeyDistribution ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerShiftKeySchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The schedule for Power Shift Keys." ;
+        rdfs:label              "PowerShiftKeySchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerShiftKeySchedule.DCPole
+        rdf:type              rdf:Property ;
+        rdfs:comment          "A DC Pole which has a Power Shift Key Schedule." ;
+        rdfs:domain           nc:PowerShiftKeySchedule ;
+        rdfs:label            "DCPole"@en ;
+        rdfs:range            nc:DCPole ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:DCPole.PowerShiftKeySchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerShiftKeySchedule.EnergyBlockOrder
+        rdf:type              rdf:Property ;
+        rdfs:comment          "An energy block order which has a Power Shift Key Schedule." ;
+        rdfs:domain           nc:PowerShiftKeySchedule ;
+        rdfs:label            "EnergyBlockOrder"@en ;
+        rdfs:range            nc:EnergyBlockOrder ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EnergyBlockOrder.PowerShiftKeySchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerShiftKeySchedule.EnergyConsumer
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The EnergyConsumer that has a Power Shift Key schedule." ;
+        rdfs:domain           nc:PowerShiftKeySchedule ;
+        rdfs:label            "EnergyConsumer"@en ;
+        rdfs:range            cim:EnergyConsumer ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EnergyConsumer.PowerShiftKeySchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerShiftKeySchedule.EnergyGroup
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The energy group which has a Power Shift Key Schedule." ;
+        rdfs:domain           nc:PowerShiftKeySchedule ;
+        rdfs:label            "EnergyGroup"@en ;
+        rdfs:range            nc:EnergyGroup ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EnergyGroup.PowerShiftKeySchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerShiftKeySchedule.EnergySource
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The energy source which has a power shift key schedule. The renewable resources should be modelled as PowerElecronicsUnit." ;
+        rdfs:domain           nc:PowerShiftKeySchedule ;
+        rdfs:label            "EnergySource"@en ;
+        rdfs:range            cim:EnergySource ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EnergySource.PowerShiftKeySchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerShiftKeySchedule.EquivalentInjection
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Equivalent injection which is part of a powoer shift key schedule." ;
+        rdfs:domain           nc:PowerShiftKeySchedule ;
+        rdfs:label            "EquivalentInjection"@en ;
+        rdfs:range            cim:EquivalentInjection ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EquivalentInjection.PowerShiftKeySchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerShiftKeySchedule.ExternalNetworkInjection
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The energy source which has a power shift key schedule." ;
+        rdfs:domain           nc:PowerShiftKeySchedule ;
+        rdfs:label            "ExternalNetworkInjection"@en ;
+        rdfs:range            cim:ExternalNetworkInjection ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ExternalNetworkInjection.PowerShiftKeySchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerShiftKeySchedule.GeneratingUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The Generating Unit which has a Power Shift Key Schedule." ;
+        rdfs:domain           nc:PowerShiftKeySchedule ;
+        rdfs:label            "GeneratingUnit"@en ;
+        rdfs:range            cim:GeneratingUnit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GeneratingUnit.PowerShiftKeySchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerShiftKeySchedule.HydroPump
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The Hydro Pump which has a Power Shift Key schedule." ;
+        rdfs:domain           nc:PowerShiftKeySchedule ;
+        rdfs:label            "HydroPump"@en ;
+        rdfs:range            cim:HydroPump ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:HydroPump.PowerShiftKeySchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerShiftKeySchedule.ParticipationFactorTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The participation factor timepoint for a Power Shift Key schedule." ;
+        rdfs:domain           nc:PowerShiftKeySchedule ;
+        rdfs:label            "ParticipationFactorTimePoint"@en ;
+        rdfs:range            nc:ParticipationFactorTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ParticipationFactorTimePoint.PowerShiftKeySchedule ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:PowerShiftKeySchedule.PowerElectronicsUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The Power Electronics Unit which has a  Power Shift Key schedule." ;
+        rdfs:domain           nc:PowerShiftKeySchedule ;
+        rdfs:label            "PowerElectronicsUnit"@en ;
+        rdfs:range            cim:PowerElectronicsUnit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:PowerElectronicsUnit.PowerShiftKeySchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerShiftKeySchedule.PowerShiftKeyDistribution
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power Shift Key distribution for the Power Shift Key schedule." ;
+        rdfs:domain           nc:PowerShiftKeySchedule ;
+        rdfs:label            "PowerShiftKeyDistribution"@en ;
+        rdfs:range            nc:PowerShiftKeyDistribution ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerShiftKeyDistribution.PowerShiftKeySchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerShiftKeySchedule.ScheduleResource
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The Schedule Resource which has a  Power Shift Key schedule." ;
+        rdfs:domain           nc:PowerShiftKeySchedule ;
+        rdfs:label            "ScheduleResource"@en ;
+        rdfs:range            nc:ScheduleResource ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ScheduleResource.PowerShiftKeySchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:PowerShiftKeyStrategy
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Strategy of the power shift key." ;
+        rdfs:label              "PowerShiftKeyStrategy"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:PowerShiftKeyStrategy.PowerShiftKeyDistribution
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power Shift Key Distribution associated to this power shift key strategy." ;
+        rdfs:domain           nc:PowerShiftKeyStrategy ;
+        rdfs:label            "PowerShiftKeyDistribution"@en ;
+        rdfs:range            nc:PowerShiftKeyDistribution ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerShiftKeyDistribution.PowerShiftKeyStrategy ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:PowerTransferCorridor
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A power transfer corridor is defined as a set of circuits (transmission lines or transformers) separating two portions of the power system, or a subset of circuits exposed to a substantial portion of the transmission exchange between two parts of the system." ;
+        rdfs:label              "PowerTransferCorridor"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:PowerTransferCorridor.GenericEnablingSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Generic enabling schedule associated with a power transfer corridor." ;
+        rdfs:domain           nc:PowerTransferCorridor ;
+        rdfs:label            "GenericEnablingSchedule"@en ;
+        rdfs:range            nc:GenericEnablingSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GenericEnablingSchedule.PowerTransferCorridor ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RangeConstraint  rdf:type    rdfs:Class ;
+        rdfs:comment            "Defines the rage constraint." ;
+        rdfs:label              "RangeConstraint"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:RangeConstraint.GenericValueSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Generic value schedule which has a range constraint." ;
+        rdfs:domain           nc:RangeConstraint ;
+        rdfs:label            "GenericValueSchedule"@en ;
+        rdfs:range            nc:GenericValueSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GenericValueSchedule.RangeConstraint ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialAction  rdf:type     rdfs:Class ;
+        rdfs:comment            "Remedial action describes one or more actions that can be performed on a given power system model situation to eliminate one or more identified breaches of constraints. The remedial action can be costly, and have a cost characteristic, or non costly. " ;
+        rdfs:label              "RemedialAction"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:RemedialAction.GenericAvailableSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Available schedule associated to a remedial action." ;
+        rdfs:domain           nc:RemedialAction ;
+        rdfs:label            "GenericAvailableSchedule"@en ;
+        rdfs:range            nc:GenericAvailableSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GenericAvailableSchedule.RemedialAction ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionDependency
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Remedial action dependency is making two remedial actions depending on each other. Multiple dependency is done by multiple instances of this class. The dependency can arrive by having one of the following examples.\n<ul>\n\t<li>The dependent remedial action is controlled by different system operator (Modeling Authority)  (e.g. SIPS that goes across control area).</li>\n\t<li>The dependent remedial action is representing  two or more remedial action that represent the same grid state alteration but with different modeling resolution (e.g. detail direct current model versus a simplified model).</li>\n\t<li>The remedial action can be combined with other remedial action without the need to create multiple remedial action with the same grid alteration for enabling dependency.</li>\n</ul>" ;
+        rdfs:label              "RemedialActionDependency"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:RemedialActionDependency.GenericEnablingSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Enabling schedule associated to a remedial action dependency." ;
+        rdfs:domain           nc:RemedialActionDependency ;
+        rdfs:label            "GenericEnablingSchedule"@en ;
+        rdfs:range            nc:GenericEnablingSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GenericEnablingSchedule.RemedialActionDependency ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionGroup
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Grouping of remedial actions that can be operated together." ;
+        rdfs:label              "RemedialActionGroup"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:RemedialActionGroup.RemedialActionGroupSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action group schedule associated with a remedial action group." ;
+        rdfs:domain           nc:RemedialActionGroup ;
+        rdfs:label            "RemedialActionGroupSchedule"@en ;
+        rdfs:range            nc:RemedialActionGroupSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialActionGroupSchedule.RemedialActionGroup ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionGroupSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The schedule for a remedial action group." ;
+        rdfs:label              "RemedialActionGroupSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RemedialActionGroupSchedule.RemedialActionGroup
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action group which has remedial action group schedules." ;
+        rdfs:domain           nc:RemedialActionGroupSchedule ;
+        rdfs:label            "RemedialActionGroup"@en ;
+        rdfs:range            nc:RemedialActionGroup ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialActionGroup.RemedialActionGroupSchedule ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionGroupSchedule.RemedialActionGroupTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action group time point that relates to this remedial action group schedule." ;
+        rdfs:domain           nc:RemedialActionGroupSchedule ;
+        rdfs:label            "RemedialActionGroupTimePoint"@en ;
+        rdfs:range            nc:RemedialActionGroupTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialActionGroupTimePoint.RemedialActionGroupSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionGroupTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Remedial action group at a given point in time." ;
+        rdfs:label              "RemedialActionGroupTimePoint"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RemedialActionGroupTimePoint.RemedialActionGroupSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action group schedule that has time point." ;
+        rdfs:domain           nc:RemedialActionGroupTimePoint ;
+        rdfs:label            "RemedialActionGroupSchedule"@en ;
+        rdfs:range            nc:RemedialActionGroupSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialActionGroupSchedule.RemedialActionGroupTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionGroupTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:RemedialActionGroupTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionGroupTimePoint.maxRegulatingDown
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum net amount of active power that the group of remedial actions can regulate down." ;
+        rdfs:domain        nc:RemedialActionGroupTimePoint ;
+        rdfs:label         "maxRegulatingDown"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionGroupTimePoint.maxRegulatingUp
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum net amount of active power that the group of remedial actions can regulate up." ;
+        rdfs:domain        nc:RemedialActionGroupTimePoint ;
+        rdfs:label         "maxRegulatingUp"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionScheme
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Remedial Action Scheme (RAS), Special Protection Schemes (SPS), System Protection Schemes (SPS) or System Integrity Protection Schemes (SIPS).\nA Remedial Action Scheme consists of one or more stages that can trigger and execute a protection action." ;
+        rdfs:label              "RemedialActionScheme"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:RemedialActionScheme.RemedialActionSchemeSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action scheme schedule associated with a remedial action scheme." ;
+        rdfs:domain           nc:RemedialActionScheme ;
+        rdfs:label            "RemedialActionSchemeSchedule"@en ;
+        rdfs:range            nc:RemedialActionSchemeSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialActionSchemeSchedule.RemedialActionScheme ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionSchemeSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The schedule for a remedial action scheme." ;
+        rdfs:label              "RemedialActionSchemeSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RemedialActionSchemeSchedule.RemedialActionScheme
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action scheme which has remedial action scheme schedules." ;
+        rdfs:domain           nc:RemedialActionSchemeSchedule ;
+        rdfs:label            "RemedialActionScheme"@en ;
+        rdfs:range            nc:RemedialActionScheme ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialActionScheme.RemedialActionSchemeSchedule ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionSchemeSchedule.RemedialActionSchemeTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action scheme time point that relates to this remedial action scheme schedule." ;
+        rdfs:domain           nc:RemedialActionSchemeSchedule ;
+        rdfs:label            "RemedialActionSchemeTimePoint"@en ;
+        rdfs:range            nc:RemedialActionSchemeTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RemedialActionSchemeTimePoint.RemedialActionSchemeSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:RemedialActionSchemeTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Remedial action scheme at a given point in time." ;
+        rdfs:label              "RemedialActionSchemeTimePoint"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RemedialActionSchemeTimePoint.RemedialActionSchemeSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Remedial action scheme schedule that has time point." ;
+        rdfs:domain           nc:RemedialActionSchemeTimePoint ;
+        rdfs:label            "RemedialActionSchemeSchedule"@en ;
+        rdfs:range            nc:RemedialActionSchemeSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RemedialActionSchemeSchedule.RemedialActionSchemeTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:RemedialActionSchemeTimePoint.armed
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Defines the arming status of the remedial action scheme. It is set by operation or by signal." ;
+        rdfs:domain        nc:RemedialActionSchemeTimePoint ;
+        rdfs:label         "armed"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionSchemeTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:RemedialActionSchemeTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionSchemeTimePoint.inService
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Specifies the availability of the Remedial Action Scheme (RAS). If true, the RAS is available for contingency processing. If false, the RAS is treated by contingency processing as if it is not in the model." ;
+        rdfs:domain        nc:RemedialActionSchemeTimePoint ;
+        rdfs:label         "inService"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ScheduleResource  rdf:type   rdfs:Class ;
+        rdfs:comment            "A schedule resource is a market-based method for handling participation of small units, particularly located on the lower voltage level that is controlled by a Distributed System Operator (DSO). It is a collection of units that can operate in the market by providing bids, offers and a resulting committed operational schedule for the collection." ;
+        rdfs:label              "ScheduleResource"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:ScheduleResource.PowerBidSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Power bid schedule which belongs to a schedule resource." ;
+        rdfs:domain           nc:ScheduleResource ;
+        rdfs:label            "PowerBidSchedule"@en ;
+        rdfs:range            nc:PowerBidSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerBidSchedule.ScheduleResource ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ScheduleResource.PowerShiftKeySchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The  Power Shift Key schedule for a schedule resource." ;
+        rdfs:domain           nc:ScheduleResource ;
+        rdfs:label            "PowerShiftKeySchedule"@en ;
+        rdfs:range            nc:PowerShiftKeySchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:PowerShiftKeySchedule.ScheduleResource ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Season.BaseRegularIntervalSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Base regular interval schedule which has seasons." ;
+        rdfs:domain           cim:Season ;
+        rdfs:label            "BaseRegularIntervalSchedule"@en ;
+        rdfs:range            nc:BaseRegularIntervalSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:BaseRegularIntervalSchedule.Season ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SecuredExclusionReasonKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The kind of secured exclusion reason." ;
+        rdfs:label              "SecuredExclusionReasonKind"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:SecuredExclusionReasonKind.capacityCalculationRegion
+        rdf:type         nc:SecuredExclusionReasonKind ;
+        rdfs:comment     "The network element that is going to be assessed is excluded for being secured by the capacity calculation region." ;
+        rdfs:label       "capacityCalculationRegion"@en ;
+        cims:stereotype  "enum" .
+
+nc:SecuredExclusionReasonKind.nonNativeCapacityCalculationRegion
+        rdf:type         nc:SecuredExclusionReasonKind ;
+        rdfs:comment     "The network element that is going to be assessed is excluded for being secured for the native capacity calculation region since it would be secured for a non native capacity calculation region." ;
+        rdfs:label       "nonNativeCapacityCalculationRegion"@en ;
+        cims:stereotype  "enum" .
+
+nc:SecuredExclusionReasonKind.systemOperator
+        rdf:type         nc:SecuredExclusionReasonKind ;
+        rdfs:comment     "The network element that is going to be assessed is excluded for being secured by the system operator." ;
+        rdfs:label       "systemOperator"@en ;
+        cims:stereotype  "enum" .
+
+nc:TimeSeriesInterpolationKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kinds of interpolation of values between two time point. " ;
+        rdfs:label              "TimeSeriesInterpolationKind"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:TimeSeriesInterpolationKind.linear
+        rdf:type         nc:TimeSeriesInterpolationKind ;
+        rdfs:comment     "Linear interpolation is applied for values between two time points." ;
+        rdfs:label       "linear"@en ;
+        cims:stereotype  "enum" .
+
+nc:TimeSeriesInterpolationKind.next
+        rdf:type         nc:TimeSeriesInterpolationKind ;
+        rdfs:comment     "The value between two time points is set to next value." ;
+        rdfs:label       "next"@en ;
+        cims:stereotype  "enum" .
+
+nc:TimeSeriesInterpolationKind.none
+        rdf:type         nc:TimeSeriesInterpolationKind ;
+        rdfs:comment     "No interpolation is applied." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+nc:UnitCostSchedule  rdf:type   rdfs:Class ;
+        rdfs:comment            "The schedule for a unit cost." ;
+        rdfs:label              "UnitCostSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:UnitCostSchedule.GeneratingUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "GeneratingUnit which has unit cost schedules." ;
+        rdfs:domain           nc:UnitCostSchedule ;
+        rdfs:label            "GeneratingUnit"@en ;
+        rdfs:range            cim:GeneratingUnit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GeneratingUnit.UnitCostSchedule ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:UnitCostSchedule.UnitCostTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The unit cost time point that relates to this unit cost schedule." ;
+        rdfs:domain           nc:UnitCostSchedule ;
+        rdfs:label            "UnitCostTimePoint"@en ;
+        rdfs:range            nc:UnitCostTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:UnitCostTimePoint.UnitCostSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:UnitCostTimePoint  rdf:type  rdfs:Class ;
+        rdfs:comment            "Unit cost at a given point in time." ;
+        rdfs:label              "UnitCostTimePoint"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:UnitCostTimePoint.UnitCostSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The unit cost schedule that has time point." ;
+        rdfs:domain           nc:UnitCostTimePoint ;
+        rdfs:label            "UnitCostSchedule"@en ;
+        rdfs:range            nc:UnitCostSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:UnitCostSchedule.UnitCostTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:UnitCostTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:UnitCostTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:UnitCostTimePoint.startupCost
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The initial startup cost incurred for each start of the GeneratingUnit." ;
+        rdfs:domain        nc:UnitCostTimePoint ;
+        rdfs:label         "startupCost"@en ;
+        cims:dataType      cim:Money ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:UnitCostTimePoint.warmStartupCost
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The warm startup cost incurred for each start of the GeneratingUnit." ;
+        rdfs:domain        nc:UnitCostTimePoint ;
+        rdfs:label         "warmStartupCost"@en ;
+        cims:dataType      cim:Money ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ValueOffsetKind  rdf:type    rdfs:Class ;
+        rdfs:comment            "The kind of the value offset." ;
+        rdfs:label              "ValueOffsetKind"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:ValueOffsetKind.absolute
+        rdf:type         nc:ValueOffsetKind ;
+        rdfs:comment     "Value of the range constraint is replacing the attribute value referenced by the PropertyReference in a determined operational scenario." ;
+        rdfs:label       "absolute"@en ;
+        cims:stereotype  "enum" .
+
+nc:ValueOffsetKind.incremental
+        rdf:type         nc:ValueOffsetKind ;
+        rdfs:comment     "Value of the range constraint is incrementing the attribute value referenced by the PropertyReference in a determined operational scenario." ;
+        rdfs:label       "incremental"@en ;
+        cims:stereotype  "enum" .
+
+nc:ValueOffsetKind.incrementalPercentage
+        rdf:type         nc:ValueOffsetKind ;
+        rdfs:comment     "Value of the range constraint is incrementing in percentage the attribute value referenced by the PropertyReference in a determined operational scenario. " ;
+        rdfs:label       "incrementalPercentage"@en ;
+        cims:stereotype  "enum" .
+
+nc:VoltageAngleLimit  rdf:type  rdfs:Class ;
+        rdfs:comment            "Voltage angle limit between two terminals. The association end OperationalLimitSet.Terminal defines one end and the host of the limit. The association end VoltageAngleLimit.AngleReferenceTerminal defines the reference terminal." ;
+        rdfs:label              "VoltageAngleLimit"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:VoltageAngleLimit.VoltageAngleSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Voltage angle schedule associated with a voltage angle limit." ;
+        rdfs:domain           nc:VoltageAngleLimit ;
+        rdfs:label            "VoltageAngleSchedule"@en ;
+        rdfs:range            nc:VoltageAngleSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:VoltageAngleSchedule.VoltageAngleLimit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:VoltageAngleSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The schedule for a voltage angle." ;
+        rdfs:label              "VoltageAngleSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:VoltageAngleSchedule.VoltageAngleLimit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Voltage angle limit which has voltage angle schedules." ;
+        rdfs:domain           nc:VoltageAngleSchedule ;
+        rdfs:label            "VoltageAngleLimit"@en ;
+        rdfs:range            nc:VoltageAngleLimit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:VoltageAngleLimit.VoltageAngleSchedule ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:VoltageAngleSchedule.VoltageAngletimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The voltage angle time point that relates to this voltage angle schedule." ;
+        rdfs:domain           nc:VoltageAngleSchedule ;
+        rdfs:label            "VoltageAngletimePoint"@en ;
+        rdfs:range            nc:VoltageAngleTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:VoltageAngleTimePoint.VoltageAngleSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:VoltageAngleTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Voltage angle at a given point in time." ;
+        rdfs:label              "VoltageAngleTimePoint"@en ;
+        cims:belongsToCategory  sis:Package_StateInstructionScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:VoltageAngleTimePoint.VoltageAngleSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The voltage angle schedule that has time point." ;
+        rdfs:domain           nc:VoltageAngleTimePoint ;
+        rdfs:label            "VoltageAngleSchedule"@en ;
+        rdfs:range            nc:VoltageAngleSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:VoltageAngleSchedule.VoltageAngletimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:VoltageAngleTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:VoltageAngleTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VoltageAngleTimePoint.value
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The difference in angle degrees between referenced by the association end OperationalLimitSet.Terminal and the Terminal referenced by the association end VoltageAngleLimit.AngleReferenceTerminal. The value shall be positive (greater than zero)." ;
+        rdfs:domain        nc:VoltageAngleTimePoint ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:AngleDegrees ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+profcim:IRI  rdf:type           rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as rdf:resource in RDFXML.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "IRI"@en ;
+        cims:belongsToCategory  sis:Package_DocStateInstructionScheduleProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringFixedLanguage
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited.\nThe primitive is serialized as literal without language support." ;
+        rdfs:label              "StringFixedLanguage"@en ;
+        cims:belongsToCategory  sis:Package_DocStateInstructionScheduleProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringIRI  rdf:type     rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as literal without language support.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "StringIRI"@en ;
+        cims:belongsToCategory  sis:Package_DocStateInstructionScheduleProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:URL  rdf:type           rdfs:Class ;
+        rdfs:comment            "A Uniform Resource Locator (URL), colloquially termed a web address, is a reference to a web resource that specifies its location on a computer network and a mechanism for retrieving it. A URL is a specific type of Uniform Resource Identifier (URI), although many people use the two terms interchangeably.URLs occur most commonly to reference web pages (http), but are also used for file transfer (ftp), email (mailto), database access (JDBC), and many other applications." ;
+        rdfs:label              "URL"@en ;
+        cims:belongsToCategory  sis:Package_DocStateInstructionScheduleProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+sis:Ontology  rdf:type        owl:Ontology ;
+        dcterms:conformsTo    "file://CIM100_CGMES31v01_501-20v02_NC23v62_MM10v01.eap" , "file://iec61970cim17v40_iec61968cim13v13a_iec62325cim03v17a.eap" , "urn:iso:std:iec:61970-501:draft:ed-2" , "urn:iso:std:iec:61970-600-2:ed-1" , "urn:iso:std:iec:61970-301:ed-7:amd1" , "urn:iso:std:iec:61970-401:draft:ed-1" ;
+        dcterms:creator       "ENTSO-E CIM WG NC project"@en ;
+        dcterms:description   "This vocabulary is describing the state instruction schedule profile."@en ;
+        dcterms:identifier    "urn:uuid:af884936-ea95-416b-b4c9-1214caa68658" ;
+        dcterms:language      "en-GB" ;
+        dcterms:license       "https://www.apache.org/licenses/LICENSE-2.0"@en ;
+        dcterms:modified      "2024-03-20"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        dcterms:publisher     "ENTSO-E"@en ;
+        dcterms:rightsHolder  "ENTSO-E"@en ;
+        dcterms:title         "State instruction schedule vocabulary"@en ;
+        owl:priorVersion      <http://entsoe.eu/ns/CIM/StateInstructionSchedule-EU/2.2> ;
+        owl:versionIRI        <https://ap.cim4.eu/StateInstructionSchedule/2.3> ;
+        owl:versionInfo       "2.3.0"@en ;
+        dcat:keyword          "SIS" ;
+        dcat:theme            "vocabulary"@en .
+
+sis:Package_DocStateInstructionScheduleProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains datatypes used only in the RDFS header." ;
+        rdfs:label    "DocStateInstructionScheduleProfile"@en .
+
+sis:Package_StateInstructionScheduleProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains the state instruction schedule profile." ;
+        rdfs:label    "StateInstructionScheduleProfile"@en .
+

--- a/r2.3/ap-voc/ttl/SteadyStateHypothesisSchedule-AP-Voc-RDFS2020.ttl
+++ b/r2.3/ap-voc/ttl/SteadyStateHypothesisSchedule-AP-Voc-RDFS2020.ttl
@@ -1,0 +1,4060 @@
+@prefix cim:     <https://cim.ucaiug.io/ns#> .
+@prefix cims:    <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/#> .
+@prefix nc:      <https://cim4.eu/ns/nc#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix profcim: <https://cim.ucaiug.io/ns/prof-cim#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix shs:     <https://ap.cim4.eu/SteadyStateHypothesisSchedule#> .
+
+cim:ActivePower  rdf:type       rdfs:Class ;
+        rdfs:comment            "Product of RMS value of the voltage and the RMS value of the in-phase component of the current." ;
+        rdfs:label              "ActivePower"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:ActivePower.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePower.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "W" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePower.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePowerLimit  rdf:type  rdfs:Class ;
+        rdfs:comment            "Limit on active power flow." ;
+        rdfs:label              "ActivePowerLimit"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:AngleDegrees  rdf:type      rdfs:Class ;
+        rdfs:comment            "Measurement of angle in degrees." ;
+        rdfs:label              "AngleDegrees"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:AngleDegrees.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:AngleDegrees ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:AngleDegrees.unit
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:AngleDegrees ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "deg" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:AngleDegrees.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:AngleDegrees ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ApparentPower  rdf:type     rdfs:Class ;
+        rdfs:comment            "Product of the RMS value of the voltage and the RMS value of the current." ;
+        rdfs:label              "ApparentPower"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:ApparentPower.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ApparentPower ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ApparentPower.unit
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ApparentPower ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "VA" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ApparentPower.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ApparentPower ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ApparentPowerLimit
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Apparent power limit." ;
+        rdfs:label              "ApparentPowerLimit"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:AsynchronousMachine
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A rotating machine whose shaft rotates asynchronously with the electrical field.  Also known as an induction machine with no external connection to the rotor windings, e.g. squirrel-cage induction machine." ;
+        rdfs:label              "AsynchronousMachine"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:AsynchronousMachineKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of Asynchronous Machine." ;
+        rdfs:label              "AsynchronousMachineKind"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:AsynchronousMachineKind.generator
+        rdf:type         cim:AsynchronousMachineKind ;
+        rdfs:comment     "The Asynchronous Machine is a generator." ;
+        rdfs:label       "generator"@en ;
+        cims:stereotype  "enum" .
+
+cim:AsynchronousMachineKind.motor
+        rdf:type         cim:AsynchronousMachineKind ;
+        rdfs:comment     "The Asynchronous Machine is a motor." ;
+        rdfs:label       "motor"@en ;
+        cims:stereotype  "enum" .
+
+cim:BatteryStateKind  rdf:type  rdfs:Class ;
+        rdfs:comment            "The state of the battery unit." ;
+        rdfs:label              "BatteryStateKind"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:BatteryStateKind.charging
+        rdf:type         cim:BatteryStateKind ;
+        rdfs:comment     "Stored energy is increasing." ;
+        rdfs:label       "charging"@en ;
+        cims:stereotype  "enum" .
+
+cim:BatteryStateKind.discharging
+        rdf:type         cim:BatteryStateKind ;
+        rdfs:comment     "Stored energy is decreasing." ;
+        rdfs:label       "discharging"@en ;
+        cims:stereotype  "enum" .
+
+cim:BatteryStateKind.empty
+        rdf:type         cim:BatteryStateKind ;
+        rdfs:comment     "Unable to discharge, and not charging." ;
+        rdfs:label       "empty"@en ;
+        cims:stereotype  "enum" .
+
+cim:BatteryStateKind.full
+        rdf:type         cim:BatteryStateKind ;
+        rdfs:comment     "Unable to charge, and not discharging." ;
+        rdfs:label       "full"@en ;
+        cims:stereotype  "enum" .
+
+cim:BatteryStateKind.waiting
+        rdf:type         cim:BatteryStateKind ;
+        rdfs:comment     "Neither charging nor discharging, but able to do so." ;
+        rdfs:label       "waiting"@en ;
+        cims:stereotype  "enum" .
+
+cim:BatteryUnit  rdf:type       rdfs:Class ;
+        rdfs:comment            "An electrochemical energy storage device." ;
+        rdfs:label              "BatteryUnit"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:Boolean  rdf:type           rdfs:Class ;
+        rdfs:comment            "A type with the value space \"true\" and \"false\"." ;
+        rdfs:label              "Boolean"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:ControlArea  rdf:type       rdfs:Class ;
+        rdfs:comment            "A control area is a grouping of generating units and/or loads and a cutset of tie lines (as terminals) which may be used for a variety of purposes including automatic generation control, power flow solution area interchange control specification, and input to load forecasting. All generation and load within the area defined by the terminals on the border are considered in the area interchange control. Note that any number of overlapping control area specifications can be superimposed on the physical model. The following general principles apply to ControlArea:\n1.  The control area orientation for net interchange is positive for an import, negative for an export.\n2.  The control area net interchange is determined by summing flows in Terminals. The Terminals are identified by creating a set of TieFlow objects associated with a ControlArea object. Each TieFlow object identifies one Terminal.\n3.  In a single network model, a tie between two control areas must be modelled in both control area specifications, such that the two representations of the tie flow sum to zero.\n4.  The normal orientation of Terminal flow is positive for flow into the conducting equipment that owns the Terminal. (i.e. flow from a bus into a device is positive.) However, the orientation of each flow in the control area specification must align with the control area convention, i.e. import is positive. If the orientation of the Terminal flow referenced by a TieFlow is positive into the control area, then this is confirmed by setting TieFlow.positiveFlowIn flag TRUE. If not, the orientation must be reversed by setting the TieFlow.positiveFlowIn flag FALSE." ;
+        rdfs:label              "ControlArea"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:CsConverter  rdf:type       rdfs:Class ;
+        rdfs:comment            "DC side of the current source converter (CSC).\nThe firing angle controls the dc voltage at the converter, both for rectifier and inverter. The difference between the dc voltages of the rectifier and inverter determines the dc current. The extinction angle is used to limit the dc voltage at the inverter, if needed, and is not used in active power control. The firing angle, transformer tap position and number of connected filters are the primary means to control a current source dc line. Higher level controls are built on top, e.g. dc voltage, dc current and active power. From a steady state perspective it is sufficient to specify the wanted active power transfer (ACDCConverter.targetPpcc) and the control functions will set the dc voltage, dc current, firing angle, transformer tap position and number of connected filters to meet this. Therefore attributes targetAlpha and targetGamma are not applicable in this case.\nThe reactive power consumed by the converter is a function of the firing angle, transformer tap position and number of connected filter, which can be approximated with half of the active power. The losses is a function of the dc voltage and dc current.\nThe attributes minAlpha and maxAlpha define the range of firing angles for rectifier operation between which no discrete tap changer action takes place. The range is typically 10-18 degrees.\nThe attributes minGamma and maxGamma define the range of extinction angles for inverter operation between which no discrete tap changer action takes place. The range is typically 17-20 degrees." ;
+        rdfs:label              "CsConverter"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:CsOperatingModeKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Operating mode for HVDC line operating as Current Source Converter." ;
+        rdfs:label              "CsOperatingModeKind"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:CsOperatingModeKind.inverter
+        rdf:type         cim:CsOperatingModeKind ;
+        rdfs:comment     "Operating as inverter, which is the power receiving end." ;
+        rdfs:label       "inverter"@en ;
+        cims:stereotype  "enum" .
+
+cim:CsOperatingModeKind.rectifier
+        rdf:type         cim:CsOperatingModeKind ;
+        rdfs:comment     "Operating as rectifier, which is the power sending end." ;
+        rdfs:label       "rectifier"@en ;
+        cims:stereotype  "enum" .
+
+cim:CsPpccControlKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Active power control modes for HVDC line operating as Current Source Converter." ;
+        rdfs:label              "CsPpccControlKind"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:CsPpccControlKind.activePower
+        rdf:type         cim:CsPpccControlKind ;
+        rdfs:comment     "Control is active power control at AC side, at point of common coupling. Target is provided by ACDCConverter.targetPpcc." ;
+        rdfs:label       "activePower"@en ;
+        cims:stereotype  "enum" .
+
+cim:CsPpccControlKind.dcCurrent
+        rdf:type         cim:CsPpccControlKind ;
+        rdfs:comment     "Control is DC current  with target value provided by CsConverter.targetIdc." ;
+        rdfs:label       "dcCurrent"@en ;
+        cims:stereotype  "enum" .
+
+cim:CsPpccControlKind.dcVoltage
+        rdf:type         cim:CsPpccControlKind ;
+        rdfs:comment     "Control is DC voltage  with target value provided by ACDCConverter.targetUdc." ;
+        rdfs:label       "dcVoltage"@en ;
+        cims:stereotype  "enum" .
+
+cim:CurrentFlow  rdf:type       rdfs:Class ;
+        rdfs:comment            "Electrical current with sign convention: positive flow is out of the conducting equipment into the connectivity node. Can be both AC and DC." ;
+        rdfs:label              "CurrentFlow"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:CurrentFlow.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:CurrentFlow ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:CurrentFlow.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:CurrentFlow ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "A" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:CurrentFlow.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:CurrentFlow ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:CurrentLimit  rdf:type      rdfs:Class ;
+        rdfs:comment            "Operational limit on current. " ;
+        rdfs:label              "CurrentLimit"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:Date  rdf:type              rdfs:Class ;
+        rdfs:comment            "Date as \"yyyy-mm-dd\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddZ\". A local timezone relative UTC is specified as \"yyyy-mm-dd(+/-)hh:mm\"." ;
+        rdfs:label              "Date"@en ;
+        cims:belongsToCategory  shs:Package_DocSteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:DateTime  rdf:type          rdfs:Class ;
+        rdfs:comment            "Date and time as \"yyyy-mm-ddThh:mm:ss.sss\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddThh:mm:ss.sssZ\". A local timezone relative UTC is specified as \"yyyy-mm-ddThh:mm:ss.sss-hh:mm\". The second component (shown here as \"ss.sss\") could have any number of digits in its fractional part to allow any kind of precision beyond seconds." ;
+        rdfs:label              "DateTime"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:EnergyConnection  rdf:type  rdfs:Class ;
+        rdfs:comment            "A connection of energy generation or consumption on the power system model." ;
+        rdfs:label              "EnergyConnection"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:Equipment  rdf:type         rdfs:Class ;
+        rdfs:comment            "The parts of a power system that are physical devices, electronic or mechanical." ;
+        rdfs:label              "Equipment"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:EquivalentInjection
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "This class represents equivalent injections (generation or load).  Voltage regulation is allowed only at the point of connection." ;
+        rdfs:label              "EquivalentInjection"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:ExternalNetworkInjection
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "This class represents the external network and it is used for IEC 60909 calculations." ;
+        rdfs:label              "ExternalNetworkInjection"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:Float  rdf:type             rdfs:Class ;
+        rdfs:comment            "A floating point number. The range is unspecified and not limited." ;
+        rdfs:label              "Float"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:GeneratingUnit  rdf:type    rdfs:Class ;
+        rdfs:comment            "A single or set of synchronous machines for converting mechanical power into alternating-current power. For example, individual machines within a set may be defined for scheduling purposes while a single control signal is derived for the set. In this case there would be a GeneratingUnit for each member of the set and an additional GeneratingUnit corresponding to the set." ;
+        rdfs:label              "GeneratingUnit"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:IdentifiedObject  rdf:type  rdfs:Class ;
+        rdfs:comment            "This is a root class to provide common identification for all classes needing identification and naming attributes." ;
+        rdfs:label              "IdentifiedObject"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:IdentifiedObject.description
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The description is a free human readable text describing or naming the object. It may be non unique and may not correlate to a naming hierarchy." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "description"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.mRID
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:IdentifiedObject.name
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The name is any free human readable and possibly non unique text naming the object." ;
+        rdfs:domain        cim:IdentifiedObject ;
+        rdfs:label         "name"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Integer  rdf:type           rdfs:Class ;
+        rdfs:comment            "An integer number. The range is unspecified and not limited." ;
+        rdfs:label              "Integer"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:MonthDay  rdf:type          rdfs:Class ;
+        rdfs:comment            "MonthDay format as \"--mm-dd\", which conforms with XSD data type gMonthDay." ;
+        rdfs:label              "MonthDay"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:PU  rdf:type                rdfs:Class ;
+        rdfs:comment            "Per Unit - a positive or negative value referred to a defined base. Values typically range from -10 to +10." ;
+        rdfs:label              "PU"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:PU.multiplier  rdf:type  rdf:Property ;
+        rdfs:domain        cim:PU ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PU.unit  rdf:type      rdf:Property ;
+        rdfs:domain        cim:PU ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PU.value  rdf:type     rdf:Property ;
+        rdfs:domain        cim:PU ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent  rdf:type           rdfs:Class ;
+        rdfs:comment            "Percentage on a defined base.   For example, specify as 100 to indicate at the defined base." ;
+        rdfs:label              "PerCent"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:PerCent.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent.value  rdf:type  rdf:Property ;
+        rdfs:comment       "Normally 0 to 100 on a defined base." ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ReactivePower  rdf:type     rdfs:Class ;
+        rdfs:comment            "Product of RMS value of the voltage and the RMS value of the quadrature component of the current." ;
+        rdfs:label              "ReactivePower"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:ReactivePower.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ReactivePower ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ReactivePower.unit
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ReactivePower ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "VAr" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ReactivePower.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ReactivePower ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:RealEnergy  rdf:type        rdfs:Class ;
+        rdfs:comment            "Real electrical energy." ;
+        rdfs:label              "RealEnergy"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:RealEnergy.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:RealEnergy ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:RealEnergy.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:RealEnergy ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "Wh" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:RealEnergy.value  rdf:type  rdf:Property ;
+        rdfs:domain        cim:RealEnergy ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:RegulatingControl
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Specifies a set of equipment that works together to control a power system quantity such as voltage or flow. \nRemote bus voltage control is possible by specifying the controlled terminal located at some place remote from the controlling equipment.\nThe specified terminal shall be associated with the connectivity node of the controlled point.  The most specific subtype of RegulatingControl shall be used in case such equipment participate in the control, e.g. TapChangerControl for tap changers.\nFor flow control, load sign convention is used, i.e. positive sign means flow out from a TopologicalNode (bus) into the conducting equipment.\nThe attribute minAllowedTargetValue and maxAllowedTargetValue are required in the following cases:\n- For a power generating module operated in power factor control mode to specify maximum and minimum power factor values;\n- Whenever it is necessary to have an off center target voltage for the tap changer regulator. For instance, due to long cables to off shore wind farms and the need to have a simpler setup at the off shore transformer platform, the voltage is controlled from the land at the connection point for the off shore wind farm. Since there usually is a voltage rise along the cable, there is typical and overvoltage of up 3-4 kV compared to the on shore station. Thus in normal operation the tap changer on the on shore station is operated with a target set point, which is in the lower parts of the dead band.\nThe attributes minAllowedTargetValue and maxAllowedTargetValue are not related to the attribute targetDeadband and thus they are not treated as an alternative of the targetDeadband. They are needed due to limitations in the local substation controller. The attribute targetDeadband is used to prevent the power flow from move the tap position in circles (hunting) that is to be used regardless of the attributes minAllowedTargetValue and maxAllowedTargetValue." ;
+        rdfs:label              "RegulatingControl"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:Resistance  rdf:type        rdfs:Class ;
+        rdfs:comment            "Resistance (real part of impedance)." ;
+        rdfs:label              "Resistance"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Resistance.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:Resistance ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Resistance.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Resistance ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "ohm" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Resistance.value  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Resistance ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Season  rdf:type            rdfs:Class ;
+        rdfs:comment            "A specified time period of the year." ;
+        rdfs:label              "Season"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:Season.endDate  rdf:type  rdf:Property ;
+        rdfs:comment       "Date season ends." ;
+        rdfs:domain        cim:Season ;
+        rdfs:label         "endDate"@en ;
+        cims:dataType      cim:MonthDay ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Season.startDate  rdf:type  rdf:Property ;
+        rdfs:comment       "Date season starts." ;
+        rdfs:domain        cim:Season ;
+        rdfs:label         "startDate"@en ;
+        cims:dataType      cim:MonthDay ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ShuntCompensator  rdf:type  rdfs:Class ;
+        rdfs:comment            "A shunt capacitor or reactor or switchable bank of shunt capacitors or reactors. A section of a shunt compensator is an individual capacitor or reactor. A negative value for bPerSection indicates that the compensator is a reactor. ShuntCompensator is a single terminal device.  Ground is implied." ;
+        rdfs:label              "ShuntCompensator"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:StaticVarCompensator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A facility for providing variable and controllable shunt reactive power. The SVC typically consists of a stepdown transformer, filter, thyristor-controlled reactor, and thyristor-switched capacitor arms.\n\nThe SVC may operate in fixed MVar output mode or in voltage control mode. When in voltage control mode, the output of the SVC will be proportional to the deviation of voltage at the controlled bus from the voltage setpoint.  The SVC characteristic slope defines the proportion.  If the voltage at the controlled bus is equal to the voltage setpoint, the SVC MVar output is zero." ;
+        rdfs:label              "StaticVarCompensator"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:String  rdf:type            rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited." ;
+        rdfs:label              "String"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Switch  rdf:type            rdfs:Class ;
+        rdfs:comment            "A generic device designed to close, or open, or both, one or more electric circuits.  All switches are two terminal devices including grounding switches. The ACDCTerminal.connected at the two sides of the switch shall not be considered for assessing switch connectivity, i.e. only Switch.open, .normalOpen and .locked are relevant." ;
+        rdfs:label              "Switch"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:SynchronousMachine
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "An electromechanical device that operates with shaft rotating synchronously with the network. It is a single machine operating either as a generator or synchronous condenser or pump." ;
+        rdfs:label              "SynchronousMachine"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:SynchronousMachineOperatingMode
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Synchronous machine operating mode." ;
+        rdfs:label              "SynchronousMachineOperatingMode"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:SynchronousMachineOperatingMode.condenser
+        rdf:type         cim:SynchronousMachineOperatingMode ;
+        rdfs:comment     "Operating as condenser." ;
+        rdfs:label       "condenser"@en ;
+        cims:stereotype  "enum" .
+
+cim:SynchronousMachineOperatingMode.generator
+        rdf:type         cim:SynchronousMachineOperatingMode ;
+        rdfs:comment     "Operating as generator." ;
+        rdfs:label       "generator"@en ;
+        cims:stereotype  "enum" .
+
+cim:SynchronousMachineOperatingMode.motor
+        rdf:type         cim:SynchronousMachineOperatingMode ;
+        rdfs:comment     "Operating as motor." ;
+        rdfs:label       "motor"@en ;
+        cims:stereotype  "enum" .
+
+cim:TapChanger  rdf:type        rdfs:Class ;
+        rdfs:comment            "Mechanism for changing transformer winding tap positions." ;
+        rdfs:label              "TapChanger"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:TapChangerControl
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Describes behaviour specific to tap changers, e.g. how the voltage at the end of a line varies with the load level and compensation of the voltage drop by tap adjustment." ;
+        rdfs:label              "TapChangerControl"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:Time  rdf:type              rdfs:Class ;
+        rdfs:comment            "Time as \"hh:mm:ss.sss\", which conforms with ISO 8601. UTC time zone is specified as \"hh:mm:ss.sssZ\". A local timezone relative UTC is specified as \"hh:mm:ss.sss±hh:mm\". The second component (shown here as \"ss.sss\") could have any number of digits in its fractional part to allow any kind of precision beyond seconds." ;
+        rdfs:label              "Time"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:UnitMultiplier  rdf:type    rdfs:Class ;
+        rdfs:comment            "The unit multipliers defined for the CIM.  When applied to unit symbols, the unit symbol is treated as a derived unit. Regardless of the contents of the unit symbol text, the unit symbol shall be treated as if it were a single-character unit symbol. Unit symbols should not contain multipliers, and it should be left to the multiplier to define the multiple for an entire data type. \n\nFor example, if a unit symbol is \"m2Pers\" and the multiplier is \"k\", then the value is k(m**2/s), and the multiplier applies to the entire final value, not to any individual part of the value. This can be conceptualized by substituting a derived unit symbol for the unit type. If one imagines that the symbol \"Þ\" represents the derived unit \"m2Pers\", then applying the multiplier \"k\" can be conceptualized simply as \"kÞ\".\n\nFor example, the SI unit for mass is \"kg\" and not \"g\".  If the unit symbol is defined as \"kg\", then the multiplier is applied to \"kg\" as a whole and does not replace the \"k\" in front of the \"g\". In this case, the multiplier of \"m\" would be used with the unit symbol of \"kg\" to represent one gram.  As a text string, this violates the instructions in IEC 80000-1. However, because the unit symbol in CIM is treated as a derived unit instead of as an SI unit, it makes more sense to conceptualize the \"kg\" as if it were replaced by one of the proposed replacements for the SI mass symbol. If one imagines that the \"kg\" were replaced by a symbol \"Þ\", then it is easier to conceptualize the multiplier \"m\" as creating the proper unit \"mÞ\", and not the forbidden unit \"mkg\"." ;
+        rdfs:label              "UnitMultiplier"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitMultiplier.M  rdf:type  cim:UnitMultiplier ;
+        rdfs:comment     "Mega 10**6." ;
+        rdfs:label       "M"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitMultiplier.k  rdf:type  cim:UnitMultiplier ;
+        rdfs:comment     "Kilo 10**3." ;
+        rdfs:label       "k"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitMultiplier.none
+        rdf:type         cim:UnitMultiplier ;
+        rdfs:comment     "No multiplier or equivalently multiply by 1." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol  rdf:type        rdfs:Class ;
+        rdfs:comment            "The derived units defined for usage in the CIM. In some cases, the derived unit is equal to an SI unit. Whenever possible, the standard derived symbol is used instead of the formula for the derived unit. For example, the unit symbol Farad is defined as \"F\" instead of \"CPerV\". In cases where a standard symbol does not exist for a derived unit, the formula for the unit is used as the unit symbol. For example, density does not have a standard symbol and so it is represented as \"kgPerm3\". With the exception of the \"kg\", which is an SI unit, the unit symbols do not contain multipliers and therefore represent the base derived unit to which a multiplier can be applied as a whole. \nEvery unit symbol is treated as an unparseable text as if it were a single-letter symbol. The meaning of each unit symbol is defined by the accompanying descriptive text and not by the text contents of the unit symbol.\nTo allow the widest possible range of serializations without requiring special character handling, several substitutions are made which deviate from the format described in IEC 80000-1. The division symbol \"/\" is replaced by the letters \"Per\". Exponents are written in plain text after the unit as \"m3\" instead of being formatted as \"m\" with a superscript of 3  or introducing a symbol as in \"m^3\". The degree symbol \"°\" is replaced with the letters \"deg\". Any clarification of the meaning for a substitution is included in the description for the unit symbol.\nNon-SI units are included in list of unit symbols to allow sources of data to be correctly labelled with their non-SI units (for example, a GPS sensor that is reporting numbers that represent feet instead of meters). This allows software to use the unit symbol information correctly convert and scale the raw data of those sources into SI-based units. \nThe integer values are used for harmonization with IEC 61850." ;
+        rdfs:label              "UnitSymbol"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitSymbol.A  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Current in amperes." ;
+        rdfs:label       "A"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.V  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Electric potential in volts (W/A)." ;
+        rdfs:label       "V"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.VA  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Apparent power in volt amperes. See also real power and reactive power." ;
+        rdfs:label       "VA"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.VAr  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Reactive power in volt amperes reactive. The “reactive” or “imaginary” component of electrical power (VIsin(phi)). (See also real power and apparent power).\nNote: Different meter designs use different methods to arrive at their results. Some meters may compute reactive power as an arithmetic value, while others compute the value vectorially. The data consumer should determine the method in use and the suitability of the measurement for the intended purpose." ;
+        rdfs:label       "VAr"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.W  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Real power in watts (J/s). Electrical power may have real and reactive components. The real portion of electrical power (I&#178;R or VIcos(phi)), is expressed in Watts. See also apparent power and reactive power." ;
+        rdfs:label       "W"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.Wh  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Real energy in watt hours." ;
+        rdfs:label       "Wh"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.deg  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Plane angle in degrees." ;
+        rdfs:label       "deg"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.none  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Dimension less quantity, e.g. count, per unit, etc." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.ohm  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Electric resistance in ohms (V/A)." ;
+        rdfs:label       "ohm"@en ;
+        cims:stereotype  "enum" .
+
+cim:Voltage  rdf:type           rdfs:Class ;
+        rdfs:comment            "Electrical voltage, can be both AC and DC." ;
+        rdfs:label              "Voltage"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Voltage.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:Voltage ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "k" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Voltage.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Voltage ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "V" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Voltage.value  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Voltage ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:VoltageLimit  rdf:type      rdfs:Class ;
+        rdfs:comment            "Operational limit applied to voltage.\nThe use of operational VoltageLimit is preferred instead of limits defined at VoltageLevel. The operational VoltageLimits are used, if present." ;
+        rdfs:label              "VoltageLimit"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:VsConverter  rdf:type       rdfs:Class ;
+        rdfs:comment            "DC side of the voltage source converter (VSC)." ;
+        rdfs:label              "VsConverter"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile .
+
+cim:VsPpccControlKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Types applicable to the control of real power and/or DC voltage by voltage source converter." ;
+        rdfs:label              "VsPpccControlKind"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:VsPpccControlKind.pPcc
+        rdf:type         cim:VsPpccControlKind ;
+        rdfs:comment     "Control is real power at point of common coupling. The target value is provided by ACDCConverter.targetPpcc." ;
+        rdfs:label       "pPcc"@en ;
+        cims:stereotype  "enum" .
+
+cim:VsPpccControlKind.pPccAndUdcDroop
+        rdf:type         cim:VsPpccControlKind ;
+        rdfs:comment     "Control is active power at point of common coupling and local DC voltage, with the droop. Target values are provided by ACDCConverter.targetPpcc, ACDCConverter.targetUdc and VsConverter.droop." ;
+        rdfs:label       "pPccAndUdcDroop"@en ;
+        cims:stereotype  "enum" .
+
+cim:VsPpccControlKind.pPccAndUdcDroopPilot
+        rdf:type         cim:VsPpccControlKind ;
+        rdfs:comment     "Control is active power at point of common coupling and the pilot DC voltage, with the droop. The mode is used for Multi Terminal High Voltage DC (MTDC) systems where multiple HVDC Substations are connected to the HVDC transmission lines. The pilot voltage is then used to coordinate the control the DC voltage across the HVDC substations. Targets are provided by ACDCConverter.targetPpcc, ACDCConverter.targetUdc and  VsConverter.droop." ;
+        rdfs:label       "pPccAndUdcDroopPilot"@en ;
+        cims:stereotype  "enum" .
+
+cim:VsPpccControlKind.pPccAndUdcDroopWithCompensation
+        rdf:type         cim:VsPpccControlKind ;
+        rdfs:comment     "Control is active power at point of common coupling and compensated DC voltage, with the droop. Compensation factor is the resistance, as an approximation of the DC voltage of a common (real or virtual) node in the DC network. Targets are provided by ACDCConverter.targetPpcc, ACDCConverter.targetUdc, VsConverter.droop and VsConverter.droopCompensation." ;
+        rdfs:label       "pPccAndUdcDroopWithCompensation"@en ;
+        cims:stereotype  "enum" .
+
+cim:VsPpccControlKind.phasePcc
+        rdf:type         cim:VsPpccControlKind ;
+        rdfs:comment     "Control is phase at point of common coupling. Target is provided by VsConverter.targetPhasePcc." ;
+        rdfs:label       "phasePcc"@en ;
+        cims:stereotype  "enum" .
+
+cim:VsPpccControlKind.udc
+        rdf:type         cim:VsPpccControlKind ;
+        rdfs:comment     "Control is DC voltage  with target value provided by ACDCConverter.targetUdc." ;
+        rdfs:label       "udc"@en ;
+        cims:stereotype  "enum" .
+
+cim:VsQpccControlKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of reactive power control at point of common coupling for a voltage source converter." ;
+        rdfs:label              "VsQpccControlKind"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:VsQpccControlKind.powerFactorPcc
+        rdf:type         cim:VsQpccControlKind ;
+        rdfs:comment     "Control is power factor at point of common coupling. Target is provided by VsConverter.targetPowerFactorPcc." ;
+        rdfs:label       "powerFactorPcc"@en ;
+        cims:stereotype  "enum" .
+
+cim:VsQpccControlKind.pulseWidthModulation
+        rdf:type         cim:VsQpccControlKind ;
+        rdfs:comment     "No explicit control. Pulse-modulation factor is directly set in magnitude (VsConverter.targetPWMfactor) and phase (VsConverter.targetPhasePcc)." ;
+        rdfs:label       "pulseWidthModulation"@en ;
+        cims:stereotype  "enum" .
+
+cim:VsQpccControlKind.reactivePcc
+        rdf:type         cim:VsQpccControlKind ;
+        rdfs:comment     "Control is reactive power at point of common coupling. Target is provided by VsConverter.targetQpcc." ;
+        rdfs:label       "reactivePcc"@en ;
+        cims:stereotype  "enum" .
+
+cim:VsQpccControlKind.voltagePcc
+        rdf:type         cim:VsQpccControlKind ;
+        rdfs:comment     "Control is voltage at point of common coupling. Target is provided by VsConverter.targetUpcc." ;
+        rdfs:label       "voltagePcc"@en ;
+        cims:stereotype  "enum" .
+
+nc:ACDCConverterRegularSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Regular schedule for ACDC converter." ;
+        rdfs:label              "ACDCConverterRegularSchedule"@en ;
+        rdfs:subClassOf         nc:BaseRegularIntervalSchedule ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:ACDCConverterRegularSchedule.p
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Active power at the point of common coupling. Load sign convention is used, i.e. positive sign means flow out from a node.\nStarting value for a steady state solution in the case a simplified power flow model is used." ;
+        rdfs:domain        nc:ACDCConverterRegularSchedule ;
+        rdfs:label         "p"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ACDCConverterRegularSchedule.q
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Reactive power at the point of common coupling. Load sign convention is used, i.e. positive sign means flow out from a node.\nStarting value for a steady state solution in the case a simplified power flow model is used." ;
+        rdfs:domain        nc:ACDCConverterRegularSchedule ;
+        rdfs:label         "q"@en ;
+        cims:dataType      cim:ReactivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ACDCConverterRegularSchedule.targetPpcc
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Real power injection target in AC grid, at point of common coupling.  Load sign convention is used, i.e. positive sign means flow out from a node." ;
+        rdfs:domain        nc:ACDCConverterRegularSchedule ;
+        rdfs:label         "targetPpcc"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ACDCConverterRegularSchedule.targetUdc
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Target value for DC voltage magnitude. The attribute shall be a positive value." ;
+        rdfs:domain        nc:ACDCConverterRegularSchedule ;
+        rdfs:label         "targetUdc"@en ;
+        cims:dataType      cim:Voltage ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ACDCTimePoint  rdf:type      rdfs:Class ;
+        rdfs:comment            "ACDC values for a given point in time." ;
+        rdfs:label              "ACDCTimePoint"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:ACDCTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:ACDCTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ACDCTimePoint.p  rdf:type  rdf:Property ;
+        rdfs:comment       "Active power at the point of common coupling. Load sign convention is used, i.e. positive sign means flow out from a node.\nStarting value for a steady state solution in the case a simplified power flow model is used." ;
+        rdfs:domain        nc:ACDCTimePoint ;
+        rdfs:label         "p"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ACDCTimePoint.q  rdf:type  rdf:Property ;
+        rdfs:comment       "Reactive power at the point of common coupling. Load sign convention is used, i.e. positive sign means flow out from a node.\nStarting value for a steady state solution in the case a simplified power flow model is used." ;
+        rdfs:domain        nc:ACDCTimePoint ;
+        rdfs:label         "q"@en ;
+        cims:dataType      cim:ReactivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ACDCTimePoint.targetPpcc
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Real power injection target in AC grid, at point of common coupling.  Load sign convention is used, i.e. positive sign means flow out from a node." ;
+        rdfs:domain        nc:ACDCTimePoint ;
+        rdfs:label         "targetPpcc"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ACDCTimePoint.targetUdc
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Target value for DC voltage magnitude. The attribute shall be a positive value." ;
+        rdfs:domain        nc:ACDCTimePoint ;
+        rdfs:label         "targetUdc"@en ;
+        cims:dataType      cim:Voltage ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ActivePowerLimit.ActivePowerLimitSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Active power limit schedule associated with an active power limit." ;
+        rdfs:domain           cim:ActivePowerLimit ;
+        rdfs:label            "ActivePowerLimitSchedule"@en ;
+        rdfs:range            nc:ActivePowerLimitSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ActivePowerLimitSchedule.ActivePowerLimit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ActivePowerLimitSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Schedule for active power limit." ;
+        rdfs:label              "ActivePowerLimitSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ActivePowerLimitSchedule.ActivePowerLimit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Active power limit which has active power limit schedules." ;
+        rdfs:domain           nc:ActivePowerLimitSchedule ;
+        rdfs:label            "ActivePowerLimit"@en ;
+        rdfs:range            cim:ActivePowerLimit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ActivePowerLimit.ActivePowerLimitSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ActivePowerLimitSchedule.ActivePowerLimitTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this active pwoer limit schedule." ;
+        rdfs:domain           nc:ActivePowerLimitSchedule ;
+        rdfs:label            "ActivePowerLimitTimePoint"@en ;
+        rdfs:range            nc:ActivePowerLimitTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ActivePowerLimitTimePoint.ActivePowerLimitSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:ActivePowerLimitTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Active power limit for a given point in time." ;
+        rdfs:label              "ActivePowerLimitTimePoint"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ActivePowerLimitTimePoint.ActivePowerLimitSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The active power limit schedule that has this time point." ;
+        rdfs:domain           nc:ActivePowerLimitTimePoint ;
+        rdfs:label            "ActivePowerLimitSchedule"@en ;
+        rdfs:range            nc:ActivePowerLimitSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ActivePowerLimitSchedule.ActivePowerLimitTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:ActivePowerLimitTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:ActivePowerLimitTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ActivePowerLimitTimePoint.value
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Value of active power limit. The attribute shall be a positive value or zero." ;
+        rdfs:domain        nc:ActivePowerLimitTimePoint ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ApparentPowerLimit.ApparentPowerLimitSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Apparent power limit schedule associated with an apparent power limit." ;
+        rdfs:domain           cim:ApparentPowerLimit ;
+        rdfs:label            "ApparentPowerLimitSchedule"@en ;
+        rdfs:range            nc:ApparentPowerLimitSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ApparentPowerLimitSchedule.ApparentPowerLimit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ApparentPowerLimitSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Schedule for apparent power limit." ;
+        rdfs:label              "ApparentPowerLimitSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ApparentPowerLimitSchedule.ApparentPowerLimit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Apparent power limit which has apparent power limit schedules." ;
+        rdfs:domain           nc:ApparentPowerLimitSchedule ;
+        rdfs:label            "ApparentPowerLimit"@en ;
+        rdfs:range            cim:ApparentPowerLimit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ApparentPowerLimit.ApparentPowerLimitSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ApparentPowerLimitSchedule.ApparentPowerLimitTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this apparent power limit schedule." ;
+        rdfs:domain           nc:ApparentPowerLimitSchedule ;
+        rdfs:label            "ApparentPowerLimitTimePoint"@en ;
+        rdfs:range            nc:ApparentPowerLimitTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ApparentPowerLimitTimePoint.ApparentPowerLimitSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:ApparentPowerLimitTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Apparent power limit for a given point in time." ;
+        rdfs:label              "ApparentPowerLimitTimePoint"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ApparentPowerLimitTimePoint.ApparentPowerLimitSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The apparent power limit schedule that has this time point." ;
+        rdfs:domain           nc:ApparentPowerLimitTimePoint ;
+        rdfs:label            "ApparentPowerLimitSchedule"@en ;
+        rdfs:range            nc:ApparentPowerLimitSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ApparentPowerLimitSchedule.ApparentPowerLimitTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:ApparentPowerLimitTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:ApparentPowerLimitTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ApparentPowerLimitTimePoint.value
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The apparent power limit. The attribute shall be a positive value or zero." ;
+        rdfs:domain        nc:ApparentPowerLimitTimePoint ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:ApparentPower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AsynchronousMachine.AsynchronousMachineRegularSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "AsynchronousMachineRegularSchedule which belongs to an asynchronous machine." ;
+        rdfs:domain           cim:AsynchronousMachine ;
+        rdfs:label            "AsynchronousMachineRegularSchedule"@en ;
+        rdfs:range            nc:AsynchronousMachineRegularSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AsynchronousMachineRegularSchedule.AsynchronousMachine ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:AsynchronousMachine.AsynchronousMachineSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Asynchronous machine schedule associated with an asynchronous machine." ;
+        rdfs:domain           cim:AsynchronousMachine ;
+        rdfs:label            "AsynchronousMachineSchedule"@en ;
+        rdfs:range            nc:AsynchronousMachineSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AsynchronousMachineSchedule.AsynchronousMachine ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:AsynchronousMachineRegularSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Regular schedule for asynchronous machine." ;
+        rdfs:label              "AsynchronousMachineRegularSchedule"@en ;
+        rdfs:subClassOf         nc:BaseRegularIntervalSchedule ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AsynchronousMachineRegularSchedule.AsynchronousMachine
+        rdf:type              rdf:Property ;
+        rdfs:comment          "AsynchronousMachine which has AsynchronousMachineRegularSchedule." ;
+        rdfs:domain           nc:AsynchronousMachineRegularSchedule ;
+        rdfs:label            "AsynchronousMachine"@en ;
+        rdfs:range            cim:AsynchronousMachine ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AsynchronousMachine.AsynchronousMachineRegularSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AsynchronousMachineRegularSchedule.asynchronousMachineType
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Indicates the type of Asynchronous Machine (motor or generator)." ;
+        rdfs:domain        nc:AsynchronousMachineRegularSchedule ;
+        rdfs:label         "asynchronousMachineType"@en ;
+        rdfs:range         cim:AsynchronousMachineKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AsynchronousMachineSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Schedule for asynchronous machine." ;
+        rdfs:label              "AsynchronousMachineSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AsynchronousMachineSchedule.AsynchronousMachine
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Asynchronous machine which has asynchronous machine schedules." ;
+        rdfs:domain           nc:AsynchronousMachineSchedule ;
+        rdfs:label            "AsynchronousMachine"@en ;
+        rdfs:range            cim:AsynchronousMachine ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AsynchronousMachine.AsynchronousMachineSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:AsynchronousMachineSchedule.AsynchronousMachineTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this asynchronous machine schedule." ;
+        rdfs:domain           nc:AsynchronousMachineSchedule ;
+        rdfs:label            "AsynchronousMachineTimePoint"@en ;
+        rdfs:range            nc:AsynchronousMachineTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:AsynchronousMachineTimePoint.AsynchronousMachineSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:AsynchronousMachineTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Asynchronous machine values for a given point in time." ;
+        rdfs:label              "AsynchronousMachineTimePoint"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AsynchronousMachineTimePoint.AsynchronousMachineSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The asynchronous machine schedule that has this time point." ;
+        rdfs:domain           nc:AsynchronousMachineTimePoint ;
+        rdfs:label            "AsynchronousMachineSchedule"@en ;
+        rdfs:range            nc:AsynchronousMachineSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:AsynchronousMachineSchedule.AsynchronousMachineTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:AsynchronousMachineTimePoint.asynchronousMachineType
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Indicates the type of Asynchronous Machine (motor or generator)." ;
+        rdfs:domain        nc:AsynchronousMachineTimePoint ;
+        rdfs:label         "asynchronousMachineType"@en ;
+        rdfs:range         cim:AsynchronousMachineKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AsynchronousMachineTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:AsynchronousMachineTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseIrregularTimeSeries
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Time series that has irregular points in time." ;
+        rdfs:label              "BaseIrregularTimeSeries"@en ;
+        rdfs:subClassOf         nc:BaseTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:BaseRegularIntervalSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Time series that has regular points in time." ;
+        rdfs:label              "BaseRegularIntervalSchedule"@en ;
+        rdfs:subClassOf         nc:BaseTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:BaseRegularIntervalSchedule.HourPattern
+        rdf:type              rdf:Property ;
+        rdfs:comment          "HourPattern that has base regular interval schedule." ;
+        rdfs:domain           nc:BaseRegularIntervalSchedule ;
+        rdfs:label            "HourPattern"@en ;
+        rdfs:range            nc:HourPattern ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:HourPattern.BaseRegularIntervalSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:BaseRegularIntervalSchedule.Season
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Season associated with a base regular interval schedule." ;
+        rdfs:domain           nc:BaseRegularIntervalSchedule ;
+        rdfs:label            "Season"@en ;
+        rdfs:range            cim:Season ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Season.BaseRegularIntervalSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:BaseRegularIntervalSchedule.dayOfWeek
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Day of the week for which the schedule is valid for." ;
+        rdfs:domain        nc:BaseRegularIntervalSchedule ;
+        rdfs:label         "dayOfWeek"@en ;
+        rdfs:range         nc:DayOfWeekKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseRegularIntervalSchedule.intervalEndTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Interval end time for which the schedule is valid for." ;
+        rdfs:domain        nc:BaseRegularIntervalSchedule ;
+        rdfs:label         "intervalEndTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseRegularIntervalSchedule.intervalStartTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Interval start time for which the schedule is valid for." ;
+        rdfs:domain        nc:BaseRegularIntervalSchedule ;
+        rdfs:label         "intervalStartTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseTimeSeries  rdf:type     rdfs:Class ;
+        rdfs:comment            "Time series of values at points in time." ;
+        rdfs:label              "BaseTimeSeries"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" .
+
+nc:BaseTimeSeries.generatedAtTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time this time series (entity) come to existents and available for use." ;
+        rdfs:domain        nc:BaseTimeSeries ;
+        rdfs:label         "generatedAtTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseTimeSeries.interpolationKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of interpolation done between time point." ;
+        rdfs:domain        nc:BaseTimeSeries ;
+        rdfs:label         "interpolationKind"@en ;
+        rdfs:range         nc:TimeSeriesInterpolationKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseTimeSeries.percentile
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The percentile is a number where a certain percentage of scores/ranking/values of a sample fall below that number. This is a way for expressing uncertainty in the number provided." ;
+        rdfs:domain        nc:BaseTimeSeries ;
+        rdfs:label         "percentile"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseTimeSeries.timeSeriesKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of base time series." ;
+        rdfs:domain        nc:BaseTimeSeries ;
+        rdfs:label         "timeSeriesKind"@en ;
+        rdfs:range         nc:BaseTimeSeriesKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BaseTimeSeriesKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of time series. " ;
+        rdfs:label              "BaseTimeSeriesKind"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:BaseTimeSeriesKind.actual
+        rdf:type         nc:BaseTimeSeriesKind ;
+        rdfs:comment     "Time series is actual data. The values represent measured or calculated values that represent the actual behaviour. " ;
+        rdfs:label       "actual"@en ;
+        cims:stereotype  "enum" .
+
+nc:BaseTimeSeriesKind.forecast
+        rdf:type         nc:BaseTimeSeriesKind ;
+        rdfs:comment     "Time series is forecast data. The values represent the result of scientific predictions based on historical time stamped data." ;
+        rdfs:label       "forecast"@en ;
+        cims:stereotype  "enum" .
+
+nc:BaseTimeSeriesKind.hindcast
+        rdf:type         nc:BaseTimeSeriesKind ;
+        rdfs:comment     "Time series is hindcast data. The value represent probable past (historic) condition given by calculation done using actual values. For instance, determine the among of wind based on the energy produced by wind. However, hindcast is typical the result of a simulated forecasts for historical periods." ;
+        rdfs:label       "hindcast"@en ;
+        cims:stereotype  "enum" .
+
+nc:BaseTimeSeriesKind.schedule
+        rdf:type         nc:BaseTimeSeriesKind ;
+        rdfs:comment     "Time series is schedule data. The values represent the result of a committed and plan forecast data that has been through a quality control and could incur penalty when not followed." ;
+        rdfs:label       "schedule"@en ;
+        cims:stereotype  "enum" .
+
+nc:BatteryUnit.BatteryUnitSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Battery unit schedule associated with a battery unit." ;
+        rdfs:domain           cim:BatteryUnit ;
+        rdfs:label            "BatteryUnitSchedule"@en ;
+        rdfs:range            nc:BatteryUnitSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:BatteryUnitSchedule.BatteryUnit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:BatteryUnitSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Schedule for battery unit." ;
+        rdfs:label              "BatteryUnitSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:BatteryUnitSchedule.BatteryUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Battery unit which has battery unit schedules." ;
+        rdfs:domain           nc:BatteryUnitSchedule ;
+        rdfs:label            "BatteryUnit"@en ;
+        rdfs:range            cim:BatteryUnit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:BatteryUnit.BatteryUnitSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:BatteryUnitSchedule.BatteryUnitTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this battery unit schedule." ;
+        rdfs:domain           nc:BatteryUnitSchedule ;
+        rdfs:label            "BatteryUnitTimePoint"@en ;
+        rdfs:range            nc:BatteryUnitTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:BatteryUnitTimePoint.BatteryUnitSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:BatteryUnitTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Battery unit values for a given point in time." ;
+        rdfs:label              "BatteryUnitTimePoint"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:BatteryUnitTimePoint.BatteryUnitSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The battery unit schedule that has this time point." ;
+        rdfs:domain           nc:BatteryUnitTimePoint ;
+        rdfs:label            "BatteryUnitSchedule"@en ;
+        rdfs:range            nc:BatteryUnitSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:BatteryUnitSchedule.BatteryUnitTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:BatteryUnitTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:BatteryUnitTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BatteryUnitTimePoint.batteryState
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The current state of the battery (charging, full, etc.)." ;
+        rdfs:domain        nc:BatteryUnitTimePoint ;
+        rdfs:label         "batteryState"@en ;
+        rdfs:range         cim:BatteryStateKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BatteryUnitTimePoint.storedE
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Amount of energy currently stored. The attribute shall be a positive value or zero and lower than BatteryUnit.ratedE." ;
+        rdfs:domain        nc:BatteryUnitTimePoint ;
+        rdfs:label         "storedE"@en ;
+        cims:dataType      cim:RealEnergy ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ControlArea.ControlAreaRegularSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "ControlAreaRegularSchedule which belongs to a control area." ;
+        rdfs:domain           cim:ControlArea ;
+        rdfs:label            "ControlAreaRegularSchedule"@en ;
+        rdfs:range            nc:ControlAreaRegularSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ControlAreaRegularSchedule.ControlArea ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ControlArea.ControlAreaSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Control area schedule associated with a control area." ;
+        rdfs:domain           cim:ControlArea ;
+        rdfs:label            "ControlAreaSchedule"@en ;
+        rdfs:range            nc:ControlAreaSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ControlAreaSchedule.ControlArea ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ControlAreaRegularSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Regular schedule for control area." ;
+        rdfs:label              "ControlAreaRegularSchedule"@en ;
+        rdfs:subClassOf         nc:BaseRegularIntervalSchedule ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ControlAreaRegularSchedule.ControlArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "ControlArea which has ControlAreaRegularSchedule." ;
+        rdfs:domain           nc:ControlAreaRegularSchedule ;
+        rdfs:label            "ControlArea"@en ;
+        rdfs:range            cim:ControlArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ControlArea.ControlAreaRegularSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ControlAreaRegularSchedule.netInterchange
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The specified positive net interchange into the control area, i.e. positive sign means flow into the area." ;
+        rdfs:domain        nc:ControlAreaRegularSchedule ;
+        rdfs:label         "netInterchange"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ControlAreaRegularSchedule.pTolerance
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Active power net interchange tolerance. The attribute shall be a positive value or zero." ;
+        rdfs:domain        nc:ControlAreaRegularSchedule ;
+        rdfs:label         "pTolerance"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ControlAreaSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Schedule for control area." ;
+        rdfs:label              "ControlAreaSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ControlAreaSchedule.ControlArea
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Control area which has control area schedules." ;
+        rdfs:domain           nc:ControlAreaSchedule ;
+        rdfs:label            "ControlArea"@en ;
+        rdfs:range            cim:ControlArea ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ControlArea.ControlAreaSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ControlAreaSchedule.ControlAreaTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this control area schedule." ;
+        rdfs:domain           nc:ControlAreaSchedule ;
+        rdfs:label            "ControlAreaTimePoint"@en ;
+        rdfs:range            nc:ControlAreaTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ControlAreaTimePoint.ControlAreaSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:ControlAreaTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Participation factor for a given point in time." ;
+        rdfs:label              "ControlAreaTimePoint"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ControlAreaTimePoint.ControlAreaSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The control area schedule that has this time point." ;
+        rdfs:domain           nc:ControlAreaTimePoint ;
+        rdfs:label            "ControlAreaSchedule"@en ;
+        rdfs:range            nc:ControlAreaSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ControlAreaSchedule.ControlAreaTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:ControlAreaTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:ControlAreaTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ControlAreaTimePoint.netInterchange
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The specified positive net interchange into the control area, i.e. positive sign means flow into the area." ;
+        rdfs:domain        nc:ControlAreaTimePoint ;
+        rdfs:label         "netInterchange"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ControlAreaTimePoint.pTolerance
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Active power net interchange tolerance. The attribute shall be a positive value or zero." ;
+        rdfs:domain        nc:ControlAreaTimePoint ;
+        rdfs:label         "pTolerance"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CsConverter.CsConverterSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Cs converter schedule associated with a control area." , "CsConverterRegularSchedule which belongs to a CSConverter." ;
+        rdfs:domain           cim:CsConverter ;
+        rdfs:label            "CsConverterSchedule"@en ;
+        rdfs:range            nc:CsConverterRegularSchedule , nc:CsConverterSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:CsConverterRegularSchedule.CsConverter , nc:CsConverterSchedule.CsConverter ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:CsConverterRegularSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Regular schedule for CS converter." ;
+        rdfs:label              "CsConverterRegularSchedule"@en ;
+        rdfs:subClassOf         nc:ACDCConverterRegularSchedule ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:CsConverterRegularSchedule.CsConverter
+        rdf:type              rdf:Property ;
+        rdfs:comment          "CsConverter which has CsConverterRegularSchedule." ;
+        rdfs:domain           nc:CsConverterRegularSchedule ;
+        rdfs:label            "CsConverter"@en ;
+        rdfs:range            cim:CsConverter ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:CsConverter.CsConverterSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:CsConverterRegularSchedule.operatingMode
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Indicates whether the DC pole is operating as an inverter or as a rectifier. It is converter’s control variable used in power flow." ;
+        rdfs:domain        nc:CsConverterRegularSchedule ;
+        rdfs:label         "operatingMode"@en ;
+        rdfs:range         cim:CsOperatingModeKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CsConverterRegularSchedule.pPccControl
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of active power control." ;
+        rdfs:domain        nc:CsConverterRegularSchedule ;
+        rdfs:label         "pPccControl"@en ;
+        rdfs:range         cim:CsPpccControlKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CsConverterRegularSchedule.targetAlpha
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Target firing angle. It is converter’s control variable used in power flow. It is only applicable for rectifier if continuous tap changer control is used. Allowed values are within the range minAlpha&lt;=targetAlpha&lt;=maxAlpha. The attribute shall be a positive value." ;
+        rdfs:domain        nc:CsConverterRegularSchedule ;
+        rdfs:label         "targetAlpha"@en ;
+        cims:dataType      cim:AngleDegrees ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CsConverterRegularSchedule.targetGamma
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Target extinction angle. It is converter’s control variable used in power flow. It is only applicable for inverter if continuous tap changer control is used. Allowed values are within the range minGamma&lt;=targetGamma&lt;=maxGamma. The attribute shall be a positive value." ;
+        rdfs:domain        nc:CsConverterRegularSchedule ;
+        rdfs:label         "targetGamma"@en ;
+        cims:dataType      cim:AngleDegrees ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CsConverterRegularSchedule.targetIdc
+        rdf:type           rdf:Property ;
+        rdfs:comment       "DC current target value. It is converter’s control variable used in power flow. The attribute shall be a positive value." ;
+        rdfs:domain        nc:CsConverterRegularSchedule ;
+        rdfs:label         "targetIdc"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CsConverterSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Schedule for CS converter." ;
+        rdfs:label              "CsConverterSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:CsConverterSchedule.CsConverter
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Cs converter which has Cs converter schedules." ;
+        rdfs:domain           nc:CsConverterSchedule ;
+        rdfs:label            "CsConverter"@en ;
+        rdfs:range            cim:CsConverter ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:CsConverter.CsConverterSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:CsConverterSchedule.CsConverterTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this CS converter schedule." ;
+        rdfs:domain           nc:CsConverterSchedule ;
+        rdfs:label            "CsConverterTimePoint"@en ;
+        rdfs:range            nc:CsConverterTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:CsConverterTimePoint.CsConverterSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:CsConverterTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "CSConverter values for a given point in time." ;
+        rdfs:label              "CsConverterTimePoint"@en ;
+        rdfs:subClassOf         nc:ACDCTimePoint ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:CsConverterTimePoint.CsConverterSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The CS converter schedule that has this time point." ;
+        rdfs:domain           nc:CsConverterTimePoint ;
+        rdfs:label            "CsConverterSchedule"@en ;
+        rdfs:range            nc:CsConverterSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:CsConverterSchedule.CsConverterTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:CsConverterTimePoint.operatingMode
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Indicates whether the DC pole is operating as an inverter or as a rectifier. It is converter’s control variable used in power flow." ;
+        rdfs:domain        nc:CsConverterTimePoint ;
+        rdfs:label         "operatingMode"@en ;
+        rdfs:range         cim:CsOperatingModeKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CsConverterTimePoint.pPccControl
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of active power control." ;
+        rdfs:domain        nc:CsConverterTimePoint ;
+        rdfs:label         "pPccControl"@en ;
+        rdfs:range         cim:CsPpccControlKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CsConverterTimePoint.targetAlpha
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Target firing angle. It is converter’s control variable used in power flow. It is only applicable for rectifier if continuous tap changer control is used. Allowed values are within the range minAlpha&lt;=targetAlpha&lt;=maxAlpha. The attribute shall be a positive value." ;
+        rdfs:domain        nc:CsConverterTimePoint ;
+        rdfs:label         "targetAlpha"@en ;
+        cims:dataType      cim:AngleDegrees ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CsConverterTimePoint.targetGamma
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Target extinction angle. It is converter’s control variable used in power flow. It is only applicable for inverter if continuous tap changer control is used. Allowed values are within the range minGamma&lt;=targetGamma&lt;=maxGamma. The attribute shall be a positive value." ;
+        rdfs:domain        nc:CsConverterTimePoint ;
+        rdfs:label         "targetGamma"@en ;
+        cims:dataType      cim:AngleDegrees ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CsConverterTimePoint.targetIdc
+        rdf:type           rdf:Property ;
+        rdfs:comment       "DC current target value. It is converter’s control variable used in power flow. The attribute shall be a positive value." ;
+        rdfs:domain        nc:CsConverterTimePoint ;
+        rdfs:label         "targetIdc"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CurrentLimit.CurrentLimitSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Current limit schedule associated with a current limit." ;
+        rdfs:domain           cim:CurrentLimit ;
+        rdfs:label            "CurrentLimitSchedule"@en ;
+        rdfs:range            nc:CurrentLimitSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:CurrentLimitSchedule.CurrentLimit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:CurrentLimitSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Schedule for current limit." ;
+        rdfs:label              "CurrentLimitSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:CurrentLimitSchedule.CurrentLimit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Current limit which has current limit schedules." ;
+        rdfs:domain           nc:CurrentLimitSchedule ;
+        rdfs:label            "CurrentLimit"@en ;
+        rdfs:range            cim:CurrentLimit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:CurrentLimit.CurrentLimitSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:CurrentLimitSchedule.CurrentLimitTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this current limit schedule." ;
+        rdfs:domain           nc:CurrentLimitSchedule ;
+        rdfs:label            "CurrentLimitTimePoint"@en ;
+        rdfs:range            nc:CurrentLimitTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:CurrentLimitTimePoint.CurrentLimitSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:CurrentLimitTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Current limit values for a given point in time." ;
+        rdfs:label              "CurrentLimitTimePoint"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:CurrentLimitTimePoint.CurrentLimitSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The current limit schedule that has this time point." ;
+        rdfs:domain           nc:CurrentLimitTimePoint ;
+        rdfs:label            "CurrentLimitSchedule"@en ;
+        rdfs:range            nc:CurrentLimitSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:CurrentLimitSchedule.CurrentLimitTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:CurrentLimitTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:CurrentLimitTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CurrentLimitTimePoint.value
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Limit on current flow. The attribute shall be a positive value or zero." ;
+        rdfs:domain        nc:CurrentLimitTimePoint ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DayOfWeekKind  rdf:type      rdfs:Class ;
+        rdfs:comment            "The kind of day to be included in a regular schedule." ;
+        rdfs:label              "DayOfWeekKind"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:DayOfWeekKind.all  rdf:type  nc:DayOfWeekKind ;
+        rdfs:comment     "All days of the week." ;
+        rdfs:label       "all"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.bridgeDay
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:comment     "A day that is a gap between two distinguished days e.g holiday and weekend that leads to an abnormal scheduling behavior. e.g. if Ascension day falls on a Thursday, then Friday would be a bridge day due to the schedule will not have a normal Friday consumption and production." ;
+        rdfs:label       "bridgeDay"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.friday
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:comment     "Friday as the day of the week." ;
+        rdfs:label       "friday"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.holiday
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:label       "holiday"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.monday
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:comment     "Monday as the day of the week." ;
+        rdfs:label       "monday"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.saturday
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:comment     "Saturday as the day of the week." ;
+        rdfs:label       "saturday"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.sunday
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:comment     "Sunday as the day of the week." ;
+        rdfs:label       "sunday"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.thursday
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:comment     "Thursday as the day of the week." ;
+        rdfs:label       "thursday"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.tuesday
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:comment     "Tuesday as the day of the week." ;
+        rdfs:label       "tuesday"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.wednesday
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:comment     "Wednesday as the day of the week." ;
+        rdfs:label       "wednesday"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.weekday
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:comment     "A day of the week other than Sunday or Saturday." ;
+        rdfs:label       "weekday"@en ;
+        cims:stereotype  "enum" .
+
+nc:DayOfWeekKind.weekend
+        rdf:type         nc:DayOfWeekKind ;
+        rdfs:comment     "A day of the week which is Sunday or Saturday." ;
+        rdfs:label       "weekend"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyConnection.EnergyConnectionSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Energy connection schedule associated with a Vs converter." , "EnergyConnectionSchedule which belongs to an energy connection." ;
+        rdfs:domain           cim:EnergyConnection ;
+        rdfs:label            "EnergyConnectionSchedule"@en ;
+        rdfs:range            nc:EnergyConnectionRegularSchedule , nc:EnergyConnectionSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EnergyConnectionSchedule.EnergyConnection , nc:EnergyConnectionRegularSchedule.EnergyConnection ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EnergyConnectionRegularSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Regular schedule for energy connection." ;
+        rdfs:label              "EnergyConnectionRegularSchedule"@en ;
+        rdfs:subClassOf         nc:BaseRegularIntervalSchedule ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EnergyConnectionRegularSchedule.EnergyConnection
+        rdf:type              rdf:Property ;
+        rdfs:comment          "EnergyConnection which has EnergyConnectionSchedule." ;
+        rdfs:domain           nc:EnergyConnectionRegularSchedule ;
+        rdfs:label            "EnergyConnection"@en ;
+        rdfs:range            cim:EnergyConnection ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EnergyConnection.EnergyConnectionSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:EnergyConnectionRegularSchedule.p
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Active power injection. Load sign convention is used, i.e. positive sign means flow out from a node.\nStarting value for a steady state solution." ;
+        rdfs:domain        nc:EnergyConnectionRegularSchedule ;
+        rdfs:label         "p"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EnergyConnectionRegularSchedule.q
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Reactive power injection. Load sign convention is used, i.e. positive sign means flow out from a node.\nStarting value for a steady state solution." ;
+        rdfs:domain        nc:EnergyConnectionRegularSchedule ;
+        rdfs:label         "q"@en ;
+        cims:dataType      cim:ReactivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EnergyConnectionSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Schedule for energy connection." ;
+        rdfs:label              "EnergyConnectionSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EnergyConnectionSchedule.EnergyConnection
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Energy connection which has energy connection schedules." ;
+        rdfs:domain           nc:EnergyConnectionSchedule ;
+        rdfs:label            "EnergyConnection"@en ;
+        rdfs:range            cim:EnergyConnection ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EnergyConnection.EnergyConnectionSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:EnergyConnectionSchedule.EnergyConnectionTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this energy connection schedule." ;
+        rdfs:domain           nc:EnergyConnectionSchedule ;
+        rdfs:label            "EnergyConnectionTimePoint"@en ;
+        rdfs:range            nc:EnergyConnectionTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EnergyConnectionTimePoint.EnergyConnectionSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:EnergyConnectionTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Energy connection values for a given point in time." ;
+        rdfs:label              "EnergyConnectionTimePoint"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EnergyConnectionTimePoint.EnergyConnectionSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The energy connection schedule that has this time point." ;
+        rdfs:domain           nc:EnergyConnectionTimePoint ;
+        rdfs:label            "EnergyConnectionSchedule"@en ;
+        rdfs:range            nc:EnergyConnectionSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EnergyConnectionSchedule.EnergyConnectionTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:EnergyConnectionTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:EnergyConnectionTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EnergyConnectionTimePoint.p
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Active power injection. Load sign convention is used, i.e. positive sign means flow out from a node.\nStarting value for a steady state solution." ;
+        rdfs:domain        nc:EnergyConnectionTimePoint ;
+        rdfs:label         "p"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EnergyConnectionTimePoint.q
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Reactive power injection. Load sign convention is used, i.e. positive sign means flow out from a node.\nStarting value for a steady state solution." ;
+        rdfs:domain        nc:EnergyConnectionTimePoint ;
+        rdfs:label         "q"@en ;
+        cims:dataType      cim:ReactivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+nc:EnergyDemandKind  rdf:type   rdfs:Class ;
+        rdfs:comment            "Kind of energy demand." ;
+        rdfs:label              "EnergyDemandKind"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:EnergyDemandKind.consumption
+        rdf:type         nc:EnergyDemandKind ;
+        rdfs:label       "consumption"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyDemandKind.export
+        rdf:type         nc:EnergyDemandKind ;
+        rdfs:label       "export"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyDemandKind.import
+        rdf:type         nc:EnergyDemandKind ;
+        rdfs:label       "import"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyDemandKind.production
+        rdf:type         nc:EnergyDemandKind ;
+        rdfs:label       "production"@en ;
+        cims:stereotype  "enum" .
+
+nc:EnergyDemandKind.storage
+        rdf:type         nc:EnergyDemandKind ;
+        rdfs:label       "storage"@en ;
+        cims:stereotype  "enum" .
+
+nc:Equipment.InServiceRegularSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "InServiceRegularSchedule which belongs to an equipment." ;
+        rdfs:domain           cim:Equipment ;
+        rdfs:label            "InServiceRegularSchedule"@en ;
+        rdfs:range            nc:InServiceRegularSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:InServiceRegularSchedule.Equipment ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Equipment.InServiceSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "In service schedule associated with an equipment." ;
+        rdfs:domain           cim:Equipment ;
+        rdfs:label            "InServiceSchedule"@en ;
+        rdfs:range            nc:InServiceSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:InServiceSchedule.Equipment ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EquivalentInjection.EquivalentInjectionRegularSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "EquivalentInjectionRegularSchedule which belongs to an equivalent injection." ;
+        rdfs:domain           cim:EquivalentInjection ;
+        rdfs:label            "EquivalentInjectionRegularSchedule"@en ;
+        rdfs:range            nc:EquivalentInjectionRegularSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EquivalentInjectionRegularSchedule.EquivalentInjection ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EquivalentInjection.EquivalentInjectionSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Equivalent injection schedule associated with an equivalent injection." ;
+        rdfs:domain           cim:EquivalentInjection ;
+        rdfs:label            "EquivalentInjectionSchedule"@en ;
+        rdfs:range            nc:EquivalentInjectionSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EquivalentInjectionSchedule.EquivalentInjection ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:EquivalentInjectionRegularSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Regular schedule for equivalent injection." ;
+        rdfs:label              "EquivalentInjectionRegularSchedule"@en ;
+        rdfs:subClassOf         nc:BaseRegularIntervalSchedule ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EquivalentInjectionRegularSchedule.EquivalentInjection
+        rdf:type              rdf:Property ;
+        rdfs:comment          "EquivalentInjection which has EquivalentInjectionRegularSchedule." ;
+        rdfs:domain           nc:EquivalentInjectionRegularSchedule ;
+        rdfs:label            "EquivalentInjection"@en ;
+        rdfs:range            cim:EquivalentInjection ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EquivalentInjection.EquivalentInjectionRegularSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:EquivalentInjectionRegularSchedule.p
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Equivalent active power injection. Load sign convention is used, i.e. positive sign means flow out from a node.\nStarting value for steady state solutions." ;
+        rdfs:domain        nc:EquivalentInjectionRegularSchedule ;
+        rdfs:label         "p"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EquivalentInjectionRegularSchedule.q
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Equivalent reactive power injection. Load sign convention is used, i.e. positive sign means flow out from a node.\nStarting value for steady state solutions." ;
+        rdfs:domain        nc:EquivalentInjectionRegularSchedule ;
+        rdfs:label         "q"@en ;
+        cims:dataType      cim:ReactivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EquivalentInjectionRegularSchedule.regulationStatus
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Specifies the regulation status of the EquivalentInjection.  True is regulating.  False is not regulating." ;
+        rdfs:domain        nc:EquivalentInjectionRegularSchedule ;
+        rdfs:label         "regulationStatus"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EquivalentInjectionRegularSchedule.regulationTarget
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The target voltage for voltage regulation. The attribute shall be a positive value." ;
+        rdfs:domain        nc:EquivalentInjectionRegularSchedule ;
+        rdfs:label         "regulationTarget"@en ;
+        cims:dataType      cim:Voltage ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EquivalentInjectionSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Regular schedule for equivalent injection." ;
+        rdfs:label              "EquivalentInjectionSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EquivalentInjectionSchedule.EquivalentInjection
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Equivalent injection which has equivalent injection schedules." ;
+        rdfs:domain           nc:EquivalentInjectionSchedule ;
+        rdfs:label            "EquivalentInjection"@en ;
+        rdfs:range            cim:EquivalentInjection ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EquivalentInjection.EquivalentInjectionSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:EquivalentInjectionSchedule.EquivalentInjectionTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this equivalent injection schedule." ;
+        rdfs:domain           nc:EquivalentInjectionSchedule ;
+        rdfs:label            "EquivalentInjectionTimePoint"@en ;
+        rdfs:range            nc:EquivalentInjectionTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:EquivalentInjectionTimePoint.EquivalentInjectionSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:EquivalentInjectionTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Equivalent injection values for a given point in time." ;
+        rdfs:label              "EquivalentInjectionTimePoint"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EquivalentInjectionTimePoint.EquivalentInjectionSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The EquivalentInjection schedule that has this time point." ;
+        rdfs:domain           nc:EquivalentInjectionTimePoint ;
+        rdfs:label            "EquivalentInjectionSchedule"@en ;
+        rdfs:range            nc:EquivalentInjectionSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:EquivalentInjectionSchedule.EquivalentInjectionTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:EquivalentInjectionTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:EquivalentInjectionTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EquivalentInjectionTimePoint.p
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Equivalent active power injection. Load sign convention is used, i.e. positive sign means flow out from a node.\nStarting value for steady state solutions." ;
+        rdfs:domain        nc:EquivalentInjectionTimePoint ;
+        rdfs:label         "p"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EquivalentInjectionTimePoint.q
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Equivalent reactive power injection. Load sign convention is used, i.e. positive sign means flow out from a node.\nStarting value for steady state solutions." ;
+        rdfs:domain        nc:EquivalentInjectionTimePoint ;
+        rdfs:label         "q"@en ;
+        cims:dataType      cim:ReactivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EquivalentInjectionTimePoint.regulationStatus
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Specifies the regulation status of the EquivalentInjection.  True is regulating.  False is not regulating." ;
+        rdfs:domain        nc:EquivalentInjectionTimePoint ;
+        rdfs:label         "regulationStatus"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EquivalentInjectionTimePoint.regulationTarget
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The target voltage for voltage regulation. The attribute shall be a positive value." ;
+        rdfs:domain        nc:EquivalentInjectionTimePoint ;
+        rdfs:label         "regulationTarget"@en ;
+        cims:dataType      cim:Voltage ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ExternalNetworkInjection.ExternalNetowrkInjectionSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "External Network Injection schedule associated with an External Network Injection." ;
+        rdfs:domain           cim:ExternalNetworkInjection ;
+        rdfs:label            "ExternalNetowrkInjectionSchedule"@en ;
+        rdfs:range            nc:ExternalNetworkInjectionSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ExternalNetworkInjectionSchedule.ExternalNetworkInjection ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ExternalNetworkInjection.ExternalNetworkinjectionRegularSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "ExternalNetworkinjectionRegularSchedule which belongs to a external network injection." ;
+        rdfs:domain           cim:ExternalNetworkInjection ;
+        rdfs:label            "ExternalNetworkinjectionRegularSchedule"@en ;
+        rdfs:range            nc:ExternalNetworkInjectionRegularSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ExternalNetworkInjectionRegularSchedule.ExternalNetworkinjection ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ExternalNetworkInjectionRegularSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Regular schedule for external network injection." ;
+        rdfs:label              "ExternalNetworkInjectionRegularSchedule"@en ;
+        rdfs:subClassOf         nc:BaseRegularIntervalSchedule ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ExternalNetworkInjectionRegularSchedule.ExternalNetworkinjection
+        rdf:type              rdf:Property ;
+        rdfs:comment          "External network injection which has ExternalNetworkinjectionRegularSchedule" ;
+        rdfs:domain           nc:ExternalNetworkInjectionRegularSchedule ;
+        rdfs:label            "ExternalNetworkinjection"@en ;
+        rdfs:range            cim:ExternalNetworkInjection ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ExternalNetworkInjection.ExternalNetworkinjectionRegularSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ExternalNetworkInjectionRegularSchedule.p
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Active power injection. Load sign convention is used, i.e. positive sign means flow out from a node.\nStarting value for steady state solutions." ;
+        rdfs:domain        nc:ExternalNetworkInjectionRegularSchedule ;
+        rdfs:label         "p"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ExternalNetworkInjectionRegularSchedule.q
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Reactive power injection. Load sign convention is used, i.e. positive sign means flow out from a node.\nStarting value for steady state solutions." ;
+        rdfs:domain        nc:ExternalNetworkInjectionRegularSchedule ;
+        rdfs:label         "q"@en ;
+        cims:dataType      cim:ReactivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ExternalNetworkInjectionRegularSchedule.referencePriority
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Priority of unit for use as powerflow voltage phase angle reference bus selection. 0 = don t care (default) 1 = highest priority. 2 is less than 1 and so on." ;
+        rdfs:domain        nc:ExternalNetworkInjectionRegularSchedule ;
+        rdfs:label         "referencePriority"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ExternalNetworkInjectionSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Schedule for external network injection." ;
+        rdfs:label              "ExternalNetworkInjectionSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ExternalNetworkInjectionSchedule.ExternalNetworkInjection
+        rdf:type              rdf:Property ;
+        rdfs:comment          "External Network Injection which has External Network Injection schedules." ;
+        rdfs:domain           nc:ExternalNetworkInjectionSchedule ;
+        rdfs:label            "ExternalNetworkInjection"@en ;
+        rdfs:range            cim:ExternalNetworkInjection ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ExternalNetworkInjection.ExternalNetowrkInjectionSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ExternalNetworkInjectionSchedule.ExternalNetworkinjectionTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this external network injection schedule." ;
+        rdfs:domain           nc:ExternalNetworkInjectionSchedule ;
+        rdfs:label            "ExternalNetworkinjectionTimePoint"@en ;
+        rdfs:range            nc:ExternalNetworkInjectionTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ExternalNetworkInjectionTimePoint.ExternalNetworkInjectionSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:ExternalNetworkInjectionTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "External network injection values for a given point in time." ;
+        rdfs:label              "ExternalNetworkInjectionTimePoint"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ExternalNetworkInjectionTimePoint.ExternalNetworkInjectionSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The external network injection schedule that has this time point." ;
+        rdfs:domain           nc:ExternalNetworkInjectionTimePoint ;
+        rdfs:label            "ExternalNetworkInjectionSchedule"@en ;
+        rdfs:range            nc:ExternalNetworkInjectionSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ExternalNetworkInjectionSchedule.ExternalNetworkinjectionTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:ExternalNetworkInjectionTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:ExternalNetworkInjectionTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ExternalNetworkInjectionTimePoint.p
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Active power injection. Load sign convention is used, i.e. positive sign means flow out from a node.\nStarting value for steady state solutions." ;
+        rdfs:domain        nc:ExternalNetworkInjectionTimePoint ;
+        rdfs:label         "p"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ExternalNetworkInjectionTimePoint.q
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Reactive power injection. Load sign convention is used, i.e. positive sign means flow out from a node.\nStarting value for steady state solutions." ;
+        rdfs:domain        nc:ExternalNetworkInjectionTimePoint ;
+        rdfs:label         "q"@en ;
+        cims:dataType      cim:ReactivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ExternalNetworkInjectionTimePoint.referencePriority
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Priority of unit for use as powerflow voltage phase angle reference bus selection. 0 = don t care (default) 1 = highest priority. 2 is less than 1 and so on." ;
+        rdfs:domain        nc:ExternalNetworkInjectionTimePoint ;
+        rdfs:label         "referencePriority"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GeneratingUnit.GeneratingUnitSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Generating unit schedule associated with a generating unit." ;
+        rdfs:domain           cim:GeneratingUnit ;
+        rdfs:label            "GeneratingUnitSchedule"@en ;
+        rdfs:range            nc:GeneratingUnitSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GeneratingUnitSchedule.GeneratingUnit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:GeneratingUnitSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Schedule for generating unit." ;
+        rdfs:label              "GeneratingUnitSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:GeneratingUnitSchedule.GeneratingUnit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Generating unit which has generating unit schedules." ;
+        rdfs:domain           nc:GeneratingUnitSchedule ;
+        rdfs:label            "GeneratingUnit"@en ;
+        rdfs:range            cim:GeneratingUnit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GeneratingUnit.GeneratingUnitSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:GeneratingUnitSchedule.GeneratingUnitTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this generating unit schedule." ;
+        rdfs:domain           nc:GeneratingUnitSchedule ;
+        rdfs:label            "GeneratingUnitTimePoint"@en ;
+        rdfs:range            nc:GeneratingUnitTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:GeneratingUnitTimePoint.GeneratingUnitSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:GeneratingUnitTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Generating unit values for a given point in time." ;
+        rdfs:label              "GeneratingUnitTimePoint"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:GeneratingUnitTimePoint.GeneratingUnitSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The generating unit schedule that has this time point." ;
+        rdfs:domain           nc:GeneratingUnitTimePoint ;
+        rdfs:label            "GeneratingUnitSchedule"@en ;
+        rdfs:range            nc:GeneratingUnitSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:GeneratingUnitSchedule.GeneratingUnitTimePoint ;
+        cims:multiplicity     cims:M:1 .
+
+nc:GeneratingUnitTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:GeneratingUnitTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GeneratingUnitTimePoint.normalPF
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Generating unit economic participation factor.  The sum of the participation factors across generating units does not have to sum to one.  It is used for representing distributed slack participation factor. The attribute shall be a positive value or zero." ;
+        rdfs:domain        nc:GeneratingUnitTimePoint ;
+        rdfs:label         "normalPF"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:HourPattern  rdf:type        rdfs:Class ;
+        rdfs:comment            "A period of the day with a given pattern." ;
+        rdfs:label              "HourPattern"@en ;
+        rdfs:subClassOf         cim:IdentifiedObject ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:HourPattern.BaseRegularIntervalSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Base regulat interval schedule which belongs to an hour pattern." ;
+        rdfs:domain           nc:HourPattern ;
+        rdfs:label            "BaseRegularIntervalSchedule"@en ;
+        rdfs:range            nc:BaseRegularIntervalSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:BaseRegularIntervalSchedule.HourPattern ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:HourPattern.HourPeriod
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Hour period which belongs to an hour pattern." ;
+        rdfs:domain           nc:HourPattern ;
+        rdfs:label            "HourPeriod"@en ;
+        rdfs:range            nc:HourPeriod ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:HourPeriod.HourPattern ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" .
+
+nc:HourPattern.energyDemandKind
+        rdf:type           rdf:Property ;
+        rdfs:domain        nc:HourPattern ;
+        rdfs:label         "energyDemandKind"@en ;
+        rdfs:range         nc:EnergyDemandKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:HourPattern.peakKind
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of peak for a given hour pattern." ;
+        rdfs:domain        nc:HourPattern ;
+        rdfs:label         "peakKind"@en ;
+        rdfs:range         nc:PeakKind ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:HourPeriod  rdf:type         rdfs:Class ;
+        rdfs:label              "HourPeriod"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:HourPeriod.HourPattern
+        rdf:type              rdf:Property ;
+        rdfs:comment          "HourPattern which has some hour periods." ;
+        rdfs:domain           nc:HourPeriod ;
+        rdfs:label            "HourPattern"@en ;
+        rdfs:range            nc:HourPattern ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:HourPattern.HourPeriod ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:HourPeriod.endTime
+        rdf:type           rdf:Property ;
+        rdfs:domain        nc:HourPeriod ;
+        rdfs:label         "endTime"@en ;
+        cims:dataType      cim:Time ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:HourPeriod.mRID  rdf:type  rdf:Property ;
+        rdfs:comment       "Master resource identifier issued by a model authority. The mRID is unique within an exchange context. Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended.\nFor CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID is mapped to rdf:ID or rdf:about attributes that identify CIM object elements." ;
+        rdfs:domain        nc:HourPeriod ;
+        rdfs:label         "mRID"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:HourPeriod.startTime
+        rdf:type           rdf:Property ;
+        rdfs:domain        nc:HourPeriod ;
+        rdfs:label         "startTime"@en ;
+        cims:dataType      cim:Time ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:InServiceRegularSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Regular schedule for elements having in service." ;
+        rdfs:label              "InServiceRegularSchedule"@en ;
+        rdfs:subClassOf         nc:BaseRegularIntervalSchedule ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:InServiceRegularSchedule.Equipment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Equipment which has InServiceRegularSchedule." ;
+        rdfs:domain           nc:InServiceRegularSchedule ;
+        rdfs:label            "Equipment"@en ;
+        rdfs:range            cim:Equipment ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Equipment.InServiceRegularSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:InServiceRegularSchedule.inService
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Specifies the availability of the equipment. True means the equipment is available for topology processing, which determines if the equipment is energized or not. False means that the equipment is treated by network applications as if it is not in the model." ;
+        rdfs:domain        nc:InServiceRegularSchedule ;
+        rdfs:label         "inService"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:InServiceSchedule  rdf:type  rdfs:Class ;
+        rdfs:comment            "Schedule for elements having in service." ;
+        rdfs:label              "InServiceSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:InServiceSchedule.Equipment
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Equipment which has equipment schedules." ;
+        rdfs:domain           nc:InServiceSchedule ;
+        rdfs:label            "Equipment"@en ;
+        rdfs:range            cim:Equipment ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Equipment.InServiceSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:InServiceSchedule.InServiceTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this in service schedule." ;
+        rdfs:domain           nc:InServiceSchedule ;
+        rdfs:label            "InServiceTimePoint"@en ;
+        rdfs:range            nc:InServiceTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:InServiceTimePoint.InServiceSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:InServiceTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "In service values for a given point in time." ;
+        rdfs:label              "InServiceTimePoint"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:InServiceTimePoint.InServiceSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The in service schedule that has this time point." ;
+        rdfs:domain           nc:InServiceTimePoint ;
+        rdfs:label            "InServiceSchedule"@en ;
+        rdfs:range            nc:InServiceSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:InServiceSchedule.InServiceTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:InServiceTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:InServiceTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:InServiceTimePoint.inService
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Specifies the availability of the equipment. True means the equipment is available for topology processing, which determines if the equipment is energized or not. False means that the equipment is treated by network applications as if it is not in the model." ;
+        rdfs:domain        nc:InServiceTimePoint ;
+        rdfs:label         "inService"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PeakKind  rdf:type           rdfs:Class ;
+        rdfs:label              "PeakKind"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:PeakKind.offPeak  rdf:type  nc:PeakKind ;
+        rdfs:comment     "Off-peak refer to periods of lower demand for a particular service or commodity." ;
+        rdfs:label       "offPeak"@en ;
+        cims:stereotype  "enum" .
+
+nc:PeakKind.onPeak  rdf:type  nc:PeakKind ;
+        rdfs:comment     "Off-peak refer to periods of higher demand for a particular service or commodity." ;
+        rdfs:label       "onPeak"@en ;
+        cims:stereotype  "enum" .
+
+nc:RegulatingControl.RegulatingControlRegularSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "RegulatingControlRegularSchedule which belongs to a regulating control." ;
+        rdfs:domain           cim:RegulatingControl ;
+        rdfs:label            "RegulatingControlRegularSchedule"@en ;
+        rdfs:range            nc:RegulatingControlRegularSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RegulatingControlRegularSchedule.RegulatingControl ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RegulatingControl.RegulatingControlSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Regulating control schedule associated with a regulating control." ;
+        rdfs:domain           cim:RegulatingControl ;
+        rdfs:label            "RegulatingControlSchedule"@en ;
+        rdfs:range            nc:RegulatingControlSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RegulatingControlSchedule.RegulatingControl ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:RegulatingControlRegularSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Regular schedule for regulating control." ;
+        rdfs:label              "RegulatingControlRegularSchedule"@en ;
+        rdfs:subClassOf         nc:BaseRegularIntervalSchedule ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RegulatingControlRegularSchedule.RegulatingControl
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Regulating control which has RegulatingControlRegularSchedule." ;
+        rdfs:domain           nc:RegulatingControlRegularSchedule ;
+        rdfs:label            "RegulatingControl"@en ;
+        rdfs:range            cim:RegulatingControl ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RegulatingControl.RegulatingControlRegularSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:RegulatingControlRegularSchedule.maxAllowedTargetValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum allowed target value (RegulatingControl.targetValue)." ;
+        rdfs:domain        nc:RegulatingControlRegularSchedule ;
+        rdfs:label         "maxAllowedTargetValue"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RegulatingControlRegularSchedule.minAllowedTargetValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Minimum allowed target value (RegulatingControl.targetValue)." ;
+        rdfs:domain        nc:RegulatingControlRegularSchedule ;
+        rdfs:label         "minAllowedTargetValue"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RegulatingControlRegularSchedule.targetValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The target value specified for case input.   This value can be used for the target value without the use of schedules. The value has the units appropriate to the mode attribute." ;
+        rdfs:domain        nc:RegulatingControlRegularSchedule ;
+        rdfs:label         "targetValue"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RegulatingControlRegularSchedule.targetValueUnitMultiplier
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Specify the multiplier for used for the targetValue." ;
+        rdfs:domain        nc:RegulatingControlRegularSchedule ;
+        rdfs:label         "targetValueUnitMultiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RegulatingControlSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Schedule for regulating control." ;
+        rdfs:label              "RegulatingControlSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RegulatingControlSchedule.RegulatingControl
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Regulating control which has regulating control schedules." ;
+        rdfs:domain           nc:RegulatingControlSchedule ;
+        rdfs:label            "RegulatingControl"@en ;
+        rdfs:range            cim:RegulatingControl ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RegulatingControl.RegulatingControlSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:RegulatingControlSchedule.RegulatingControlTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this regulating control schedule." ;
+        rdfs:domain           nc:RegulatingControlSchedule ;
+        rdfs:label            "RegulatingControlTimePoint"@en ;
+        rdfs:range            nc:RegulatingControlTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RegulatingControlTimePoint.RegulatingControlSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:RegulatingControlTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Regulating control values for a given point in time." ;
+        rdfs:label              "RegulatingControlTimePoint"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RegulatingControlTimePoint.RegulatingControlSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The regulating control schedule that has this time point." ;
+        rdfs:domain           nc:RegulatingControlTimePoint ;
+        rdfs:label            "RegulatingControlSchedule"@en ;
+        rdfs:range            nc:RegulatingControlSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:RegulatingControlSchedule.RegulatingControlTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:RegulatingControlTimePoint.TapChangerControlSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The tap changer control schedule that has this time point." ;
+        rdfs:domain           nc:RegulatingControlTimePoint ;
+        rdfs:label            "TapChangerControlSchedule"@en ;
+        rdfs:range            nc:TapChangerControlSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:TapChangerControlSchedule.RegulatingControlTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:RegulatingControlTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:RegulatingControlTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RegulatingControlTimePoint.maxAllowedTargetValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum allowed target value (RegulatingControl.targetValue)." ;
+        rdfs:domain        nc:RegulatingControlTimePoint ;
+        rdfs:label         "maxAllowedTargetValue"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RegulatingControlTimePoint.minAllowedTargetValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Minimum allowed target value (RegulatingControl.targetValue)." ;
+        rdfs:domain        nc:RegulatingControlTimePoint ;
+        rdfs:label         "minAllowedTargetValue"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RegulatingControlTimePoint.targetValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The target value specified for case input.   This value can be used for the target value without the use of schedules. The value has the units appropriate to the mode attribute." ;
+        rdfs:domain        nc:RegulatingControlTimePoint ;
+        rdfs:label         "targetValue"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RegulatingControlTimePoint.targetValueUnitMultiplier
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Specify the multiplier for used for the targetValue." ;
+        rdfs:domain        nc:RegulatingControlTimePoint ;
+        rdfs:label         "targetValueUnitMultiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Season.BaseRegularIntervalSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Base regular interval schedule which has seasons." ;
+        rdfs:domain           cim:Season ;
+        rdfs:label            "BaseRegularIntervalSchedule"@en ;
+        rdfs:range            nc:BaseRegularIntervalSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:BaseRegularIntervalSchedule.Season ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ShuntCompensator.ShuntCompensatorSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Shunt compensator schedule associated with a shunt compensator." ;
+        rdfs:domain           cim:ShuntCompensator ;
+        rdfs:label            "ShuntCompensatorSchedule"@en ;
+        rdfs:range            nc:ShuntCompensatorSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ShuntCompensatorSchedule.ShuntCompensator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:ShuntCompensatorSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Schedule for shunt compensator." ;
+        rdfs:label              "ShuntCompensatorSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ShuntCompensatorSchedule.ShuntCompensator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Shunt compensator which has shunt compensator schedules." ;
+        rdfs:domain           nc:ShuntCompensatorSchedule ;
+        rdfs:label            "ShuntCompensator"@en ;
+        rdfs:range            cim:ShuntCompensator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ShuntCompensator.ShuntCompensatorSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:ShuntCompensatorSchedule.ShuntCompensatorTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this shunt compensator schedule." ;
+        rdfs:domain           nc:ShuntCompensatorSchedule ;
+        rdfs:label            "ShuntCompensatorTimePoint"@en ;
+        rdfs:range            nc:ShuntCompensatorTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:ShuntCompensatorTimePoint.ShuntCompensatorSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:ShuntCompensatorTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Shunt compensator values for a given point in time." ;
+        rdfs:label              "ShuntCompensatorTimePoint"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ShuntCompensatorTimePoint.ShuntCompensatorSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The shunt compensator schedule that has this time point." ;
+        rdfs:domain           nc:ShuntCompensatorTimePoint ;
+        rdfs:label            "ShuntCompensatorSchedule"@en ;
+        rdfs:range            nc:ShuntCompensatorSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:ShuntCompensatorSchedule.ShuntCompensatorTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:ShuntCompensatorTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:ShuntCompensatorTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ShuntCompensatorTimePoint.sections
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Shunt compensator sections in use. Starting value for steady state solution. The attribute shall be a positive value or zero. Non integer values are allowed to support continuous variables. The reasons for continuous value are to support study cases where no discrete shunt compensators has yet been designed, a solutions where a narrow voltage band force the sections to oscillate or accommodate for a continuous solution as input. \nFor LinearShuntConpensator the value shall be between zero and ShuntCompensator.maximumSections. At value zero the shunt compensator conductance and admittance is zero. Linear interpolation of conductance and admittance between the previous and next integer section is applied in case of non-integer values.\nFor NonlinearShuntCompensator-s shall only be set to one of the NonlinearShuntCompenstorPoint.sectionNumber. There is no interpolation between NonlinearShuntCompenstorPoint-s." ;
+        rdfs:domain        nc:ShuntCompensatorTimePoint ;
+        rdfs:label         "sections"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:StaticVarCompensator.StaticVarCompensatorSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Static var compensator schedule associated with a static var compensator." ;
+        rdfs:domain           cim:StaticVarCompensator ;
+        rdfs:label            "StaticVarCompensatorSchedule"@en ;
+        rdfs:range            nc:StaticVarCompensatorSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:StaticVarCompensatorSchedule.StaticVarCompensator ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:StaticVarCompensatorSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Schedule for static var compensator." ;
+        rdfs:label              "StaticVarCompensatorSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:StaticVarCompensatorSchedule.StaticVarCompensator
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Static var compensator which has static var compensator schedules." ;
+        rdfs:domain           nc:StaticVarCompensatorSchedule ;
+        rdfs:label            "StaticVarCompensator"@en ;
+        rdfs:range            cim:StaticVarCompensator ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:StaticVarCompensator.StaticVarCompensatorSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:StaticVarCompensatorSchedule.StaticVarCompensatorTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this static var compensator schedule." ;
+        rdfs:domain           nc:StaticVarCompensatorSchedule ;
+        rdfs:label            "StaticVarCompensatorTimePoint"@en ;
+        rdfs:range            nc:StaticVarCompensatorTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:StaticVarCompensatorTimePoint.StaticVarCompensatorSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:StaticVarCompensatorTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Static var compensator values for a given point in time." ;
+        rdfs:label              "StaticVarCompensatorTimePoint"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:StaticVarCompensatorTimePoint.StaticVarCompensatorSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The StaticVarCompensator schedule that has this time point." ;
+        rdfs:domain           nc:StaticVarCompensatorTimePoint ;
+        rdfs:label            "StaticVarCompensatorSchedule"@en ;
+        rdfs:range            nc:StaticVarCompensatorSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:StaticVarCompensatorSchedule.StaticVarCompensatorTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:StaticVarCompensatorTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:StaticVarCompensatorTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:StaticVarCompensatorTimePoint.q
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Reactive power injection. Load sign convention is used, i.e. positive sign means flow out from a node.\nStarting value for a steady state solution." ;
+        rdfs:domain        nc:StaticVarCompensatorTimePoint ;
+        rdfs:label         "q"@en ;
+        cims:dataType      cim:ReactivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Switch.SwitchRegularSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "SwitchRegularSchedule which belongs to a switch." ;
+        rdfs:domain           cim:Switch ;
+        rdfs:label            "SwitchRegularSchedule"@en ;
+        rdfs:range            nc:SwitchRegularSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:SwitchRegularSchedule.Switch ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:Switch.SwitchSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Switch schedule associated with a switch." ;
+        rdfs:domain           cim:Switch ;
+        rdfs:label            "SwitchSchedule"@en ;
+        rdfs:range            nc:SwitchSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:SwitchSchedule.Switch ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SwitchRegularSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Regular schedule for switch." ;
+        rdfs:label              "SwitchRegularSchedule"@en ;
+        rdfs:subClassOf         nc:BaseRegularIntervalSchedule ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SwitchRegularSchedule.Switch
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Switch which has SwitchRegularSchedule." ;
+        rdfs:domain           nc:SwitchRegularSchedule ;
+        rdfs:label            "Switch"@en ;
+        rdfs:range            cim:Switch ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Switch.SwitchRegularSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:SwitchRegularSchedule.locked
+        rdf:type           rdf:Property ;
+        rdfs:comment       "If true, the switch is locked. The resulting switch state is a combination of locked and Switch.open attributes as follows:\n<ul>\n\t<li>locked=true and Switch.open=true. The resulting state is open and locked;</li>\n\t<li>locked=false and Switch.open=true. The resulting state is open;</li>\n\t<li>locked=false and Switch.open=false. The resulting state is closed.</li>\n</ul>" ;
+        rdfs:domain        nc:SwitchRegularSchedule ;
+        rdfs:label         "locked"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SwitchRegularSchedule.open
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The attribute tells if the switch is considered open when used as input to topology processing." ;
+        rdfs:domain        nc:SwitchRegularSchedule ;
+        rdfs:label         "open"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SwitchSchedule  rdf:type     rdfs:Class ;
+        rdfs:comment            "Schedule for switch." ;
+        rdfs:label              "SwitchSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SwitchSchedule.Switch
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Switch which has switch schedules." ;
+        rdfs:domain           nc:SwitchSchedule ;
+        rdfs:label            "Switch"@en ;
+        rdfs:range            cim:Switch ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:Switch.SwitchSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:SwitchSchedule.SwitchTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this switch schedule." ;
+        rdfs:domain           nc:SwitchSchedule ;
+        rdfs:label            "SwitchTimePoint"@en ;
+        rdfs:range            nc:SwitchTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:SwitchTimePoint.SwitchSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:SwitchTimePoint  rdf:type    rdfs:Class ;
+        rdfs:comment            "Switch values for a given point in time." ;
+        rdfs:label              "SwitchTimePoint"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SwitchTimePoint.SwitchSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The switch schedule that has this time point." ;
+        rdfs:domain           nc:SwitchTimePoint ;
+        rdfs:label            "SwitchSchedule"@en ;
+        rdfs:range            nc:SwitchSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SwitchSchedule.SwitchTimePoint ;
+        cims:multiplicity     cims:M:1 .
+
+nc:SwitchTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:SwitchTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SwitchTimePoint.locked
+        rdf:type           rdf:Property ;
+        rdfs:comment       "If true, the switch is locked. The resulting switch state is a combination of locked and Switch.open attributes as follows:\n<ul>\n\t<li>locked=true and Switch.open=true. The resulting state is open and locked;</li>\n\t<li>locked=false and Switch.open=true. The resulting state is open;</li>\n\t<li>locked=false and Switch.open=false. The resulting state is closed.</li>\n</ul>" ;
+        rdfs:domain        nc:SwitchTimePoint ;
+        rdfs:label         "locked"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SwitchTimePoint.open
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The attribute tells if the switch is considered open when used as input to topology processing." ;
+        rdfs:domain        nc:SwitchTimePoint ;
+        rdfs:label         "open"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SynchronousMachine.SynchronousMachineRegularSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "SynchronousMachineRegularSchedule which belongs to a synchronous machine." ;
+        rdfs:domain           cim:SynchronousMachine ;
+        rdfs:label            "SynchronousMachineRegularSchedule"@en ;
+        rdfs:range            nc:SynchronousMachineRegularSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:SynchronousMachineRegularSchedule.SynchronousMachine ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SynchronousMachine.SynchronousMachineSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Synchronous machine schedule associated with a synchronous machine." ;
+        rdfs:domain           cim:SynchronousMachine ;
+        rdfs:label            "SynchronousMachineSchedule"@en ;
+        rdfs:range            nc:SynchronousMachineSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:SynchronousMachineSchedule.SynchronousMachine ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:SynchronousMachineRegularSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Regular schedule for synchronous machine." ;
+        rdfs:label              "SynchronousMachineRegularSchedule"@en ;
+        rdfs:subClassOf         nc:BaseRegularIntervalSchedule ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SynchronousMachineRegularSchedule.SynchronousMachine
+        rdf:type              rdf:Property ;
+        rdfs:comment          "SynchronousMachine which has SynchronousMachineRegularSchedule." ;
+        rdfs:domain           nc:SynchronousMachineRegularSchedule ;
+        rdfs:label            "SynchronousMachine"@en ;
+        rdfs:range            cim:SynchronousMachine ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SynchronousMachine.SynchronousMachineRegularSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:SynchronousMachineRegularSchedule.operatingMode
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Current mode of operation." ;
+        rdfs:domain        nc:SynchronousMachineRegularSchedule ;
+        rdfs:label         "operatingMode"@en ;
+        rdfs:range         cim:SynchronousMachineOperatingMode ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SynchronousMachineRegularSchedule.referencePriority
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Priority of unit for use as powerflow voltage phase angle reference bus selection. 0 = don t care (default) 1 = highest priority. 2 is less than 1 and so on." ;
+        rdfs:domain        nc:SynchronousMachineRegularSchedule ;
+        rdfs:label         "referencePriority"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SynchronousMachineSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Schedule for synchronous machine." ;
+        rdfs:label              "SynchronousMachineSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SynchronousMachineSchedule.SynchronousMachine
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Synchronous machine which has synchronous machine schedules." ;
+        rdfs:domain           nc:SynchronousMachineSchedule ;
+        rdfs:label            "SynchronousMachine"@en ;
+        rdfs:range            cim:SynchronousMachine ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SynchronousMachine.SynchronousMachineSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:SynchronousMachineSchedule.SynchronousMachineTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this synchronous machine schedule." ;
+        rdfs:domain           nc:SynchronousMachineSchedule ;
+        rdfs:label            "SynchronousMachineTimePoint"@en ;
+        rdfs:range            nc:SynchronousMachineTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:SynchronousMachineTimePoint.SynchronousMachineSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:SynchronousMachineTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Synchronous machine values for a given point in time." ;
+        rdfs:label              "SynchronousMachineTimePoint"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SynchronousMachineTimePoint.SynchronousMachineSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The synchronous machine schedule that has this time point." ;
+        rdfs:domain           nc:SynchronousMachineTimePoint ;
+        rdfs:label            "SynchronousMachineSchedule"@en ;
+        rdfs:range            nc:SynchronousMachineSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:SynchronousMachineSchedule.SynchronousMachineTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:SynchronousMachineTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:SynchronousMachineTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SynchronousMachineTimePoint.operatingMode
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Current mode of operation." ;
+        rdfs:domain        nc:SynchronousMachineTimePoint ;
+        rdfs:label         "operatingMode"@en ;
+        rdfs:range         cim:SynchronousMachineOperatingMode ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SynchronousMachineTimePoint.referencePriority
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Priority of unit for use as powerflow voltage phase angle reference bus selection. 0 = don t care (default) 1 = highest priority. 2 is less than 1 and so on." ;
+        rdfs:domain        nc:SynchronousMachineTimePoint ;
+        rdfs:label         "referencePriority"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:TapChanger.TapRegularSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "TapRegularSchedule which belongs to a tap change." ;
+        rdfs:domain           cim:TapChanger ;
+        rdfs:label            "TapRegularSchedule"@en ;
+        rdfs:range            nc:TapRegularSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:TapRegularSchedule.TapChanger ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:TapChanger.TapSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Tap schedule associated with a tap changer." ;
+        rdfs:domain           cim:TapChanger ;
+        rdfs:label            "TapSchedule"@en ;
+        rdfs:range            nc:TapSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:TapSchedule.TapChanger ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:TapChangerControl.TapChangerControlRegularSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "TapChangerControlRegularSchedule which belongs to a tap changer control." ;
+        rdfs:domain           cim:TapChangerControl ;
+        rdfs:label            "TapChangerControlRegularSchedule"@en ;
+        rdfs:range            nc:TapChangerControlRegularSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:TapChangerControlRegularSchedule.TapChangerControl ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:TapChangerControl.TapChangerControlSchedule
+        rdf:type              rdf:Property ;
+        rdfs:domain           cim:TapChangerControl ;
+        rdfs:label            "TapChangerControlSchedule"@en ;
+        rdfs:range            nc:TapChangerControlSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:TapChangerControlSchedule.TapChangerControl ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:TapChangerControlRegularSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Regular schedule for tap changer control." ;
+        rdfs:label              "TapChangerControlRegularSchedule"@en ;
+        rdfs:subClassOf         nc:RegulatingControlRegularSchedule ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:TapChangerControlRegularSchedule.TapChangerControl
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Tap changer control which has TapChangerControlRegularSchedule." ;
+        rdfs:domain           nc:TapChangerControlRegularSchedule ;
+        rdfs:label            "TapChangerControl"@en ;
+        rdfs:range            cim:TapChangerControl ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:TapChangerControl.TapChangerControlRegularSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:TapChangerControlSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Schedule for tap changer control." ;
+        rdfs:label              "TapChangerControlSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:TapChangerControlSchedule.RegulatingControlTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this stap changer control schedule." ;
+        rdfs:domain           nc:TapChangerControlSchedule ;
+        rdfs:label            "RegulatingControlTimePoint"@en ;
+        rdfs:range            nc:RegulatingControlTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:RegulatingControlTimePoint.TapChangerControlSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:TapChangerControlSchedule.TapChangerControl
+        rdf:type              rdf:Property ;
+        rdfs:domain           nc:TapChangerControlSchedule ;
+        rdfs:label            "TapChangerControl"@en ;
+        rdfs:range            cim:TapChangerControl ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:TapChangerControl.TapChangerControlSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:TapRegularSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Regular schedule for tap." ;
+        rdfs:label              "TapRegularSchedule"@en ;
+        rdfs:subClassOf         nc:BaseRegularIntervalSchedule ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:TapRegularSchedule.TapChanger
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Tap changer which has TapRegularSchedule." ;
+        rdfs:domain           nc:TapRegularSchedule ;
+        rdfs:label            "TapChanger"@en ;
+        rdfs:range            cim:TapChanger ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:TapChanger.TapRegularSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:TapRegularSchedule.controlEnabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Specifies the regulation status of the equipment.  True is regulating, false is not regulating." ;
+        rdfs:domain        nc:TapRegularSchedule ;
+        rdfs:label         "controlEnabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:TapRegularSchedule.step
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Tap changer position.\nStarting step for a steady state solution. Non integer values are allowed to support continuous tap variables. The reasons for continuous value are to support study cases where no discrete tap changer has yet been designed, a solution where a narrow voltage band forces the tap step to oscillate or to accommodate for a continuous solution as input.\nThe attribute shall be equal to or greater than lowStep and equal to or less than highStep." ;
+        rdfs:domain        nc:TapRegularSchedule ;
+        rdfs:label         "step"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:TapSchedule  rdf:type        rdfs:Class ;
+        rdfs:comment            "Schedule for tap." ;
+        rdfs:label              "TapSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:TapSchedule.TapChanger
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Tap changer which has tap schedules." ;
+        rdfs:domain           nc:TapSchedule ;
+        rdfs:label            "TapChanger"@en ;
+        rdfs:range            cim:TapChanger ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:TapChanger.TapSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:TapSchedule.TapScheduleTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this tap schedule." ;
+        rdfs:domain           nc:TapSchedule ;
+        rdfs:label            "TapScheduleTimePoint"@en ;
+        rdfs:range            nc:TapScheduleTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:TapScheduleTimePoint.TapSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:TapScheduleTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Tap schedule values for a given point in time." ;
+        rdfs:label              "TapScheduleTimePoint"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:TapScheduleTimePoint.TapSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The tap schedule that has this time point." ;
+        rdfs:domain           nc:TapScheduleTimePoint ;
+        rdfs:label            "TapSchedule"@en ;
+        rdfs:range            nc:TapSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:TapSchedule.TapScheduleTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:TapScheduleTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:TapScheduleTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:TapScheduleTimePoint.controlEnabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Specifies the regulation status of the equipment.  True is regulating, false is not regulating." ;
+        rdfs:domain        nc:TapScheduleTimePoint ;
+        rdfs:label         "controlEnabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:TapScheduleTimePoint.step
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Tap changer position.\nStarting step for a steady state solution. Non integer values are allowed to support continuous tap variables. The reasons for continuous value are to support study cases where no discrete tap changer has yet been designed, a solution where a narrow voltage band forces the tap step to oscillate or to accommodate for a continuous solution as input.\nThe attribute shall be equal to or greater than lowStep and equal to or less than highStep." ;
+        rdfs:domain        nc:TapScheduleTimePoint ;
+        rdfs:label         "step"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:TimeSeriesInterpolationKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kinds of interpolation of values between two time point. " ;
+        rdfs:label              "TimeSeriesInterpolationKind"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:TimeSeriesInterpolationKind.linear
+        rdf:type         nc:TimeSeriesInterpolationKind ;
+        rdfs:comment     "Linear interpolation is applied for values between two time points." ;
+        rdfs:label       "linear"@en ;
+        cims:stereotype  "enum" .
+
+nc:TimeSeriesInterpolationKind.next
+        rdf:type         nc:TimeSeriesInterpolationKind ;
+        rdfs:comment     "The value between two time points is set to next value." ;
+        rdfs:label       "next"@en ;
+        cims:stereotype  "enum" .
+
+nc:TimeSeriesInterpolationKind.none
+        rdf:type         nc:TimeSeriesInterpolationKind ;
+        rdfs:comment     "No interpolation is applied." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+nc:TimeSeriesInterpolationKind.previous
+        rdf:type         nc:TimeSeriesInterpolationKind ;
+        rdfs:comment     "The value between two time points is set to previous value." ;
+        rdfs:label       "previous"@en ;
+        cims:stereotype  "enum" .
+
+nc:TimeSeriesInterpolationKind.zero
+        rdf:type         nc:TimeSeriesInterpolationKind ;
+        rdfs:comment     "The value between two time points is set to zero." ;
+        rdfs:label       "zero"@en ;
+        cims:stereotype  "enum" .
+
+nc:VoltageLimit.VoltageLimitSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Voltage limit schedule associated with a voltage limit." ;
+        rdfs:domain           cim:VoltageLimit ;
+        rdfs:label            "VoltageLimitSchedule"@en ;
+        rdfs:range            nc:VoltageLimitSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:VoltageLimitSchedule.VoltageLimit ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:VoltageLimitSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Schedule for voltage limit." ;
+        rdfs:label              "VoltageLimitSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:VoltageLimitSchedule.VoltageLimit
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Voltage limit which has voltage limit schedules." ;
+        rdfs:domain           nc:VoltageLimitSchedule ;
+        rdfs:label            "VoltageLimit"@en ;
+        rdfs:range            cim:VoltageLimit ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:VoltageLimit.VoltageLimitSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:VoltageLimitSchedule.VoltageLimitTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this voltage limit schedule." ;
+        rdfs:domain           nc:VoltageLimitSchedule ;
+        rdfs:label            "VoltageLimitTimePoint"@en ;
+        rdfs:range            nc:VoltageLimitTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:VoltageLimitTimePoint.VoltageLimitSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:VoltageLimitTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Voltage limit values for a given point in time." ;
+        rdfs:label              "VoltageLimitTimePoint"@en ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:VoltageLimitTimePoint.VoltageLimitSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The voltage limit schedule that has this time point." ;
+        rdfs:domain           nc:VoltageLimitTimePoint ;
+        rdfs:label            "VoltageLimitSchedule"@en ;
+        rdfs:range            nc:VoltageLimitSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:VoltageLimitSchedule.VoltageLimitTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:VoltageLimitTimePoint.atTime
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The time the data is valid for." ;
+        rdfs:domain        nc:VoltageLimitTimePoint ;
+        rdfs:label         "atTime"@en ;
+        cims:dataType      cim:DateTime ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VoltageLimitTimePoint.value
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Limit on voltage. High or low limit nature of the limit depends upon the properties of the operational limit type. The attribute shall be a positive value or zero." ;
+        rdfs:domain        nc:VoltageLimitTimePoint ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Voltage ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VsConverter.VsConverterRegularSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "VsConverterRegularSchedule which belongs to a VSConverter." ;
+        rdfs:domain           cim:VsConverter ;
+        rdfs:label            "VsConverterRegularSchedule"@en ;
+        rdfs:range            nc:VsConverterRegularSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:VsConverterRegularSchedule.VsConverter ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:VsConverter.VsConverterSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Vs converter schedule associated with a Vs converter." ;
+        rdfs:domain           cim:VsConverter ;
+        rdfs:label            "VsConverterSchedule"@en ;
+        rdfs:range            nc:VsConverterSchedule ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:VsConverterSchedule.VsConverter ;
+        cims:multiplicity     cims:M:0..n ;
+        cims:stereotype       "NC" .
+
+nc:VsConverterRegularSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Regular schedule for VS converter." ;
+        rdfs:label              "VsConverterRegularSchedule"@en ;
+        rdfs:subClassOf         nc:ACDCConverterRegularSchedule ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:VsConverterRegularSchedule.VsConverter
+        rdf:type              rdf:Property ;
+        rdfs:comment          "VsConverter which has VsConverterRegularSchedule." ;
+        rdfs:domain           nc:VsConverterRegularSchedule ;
+        rdfs:label            "VsConverter"@en ;
+        rdfs:range            cim:VsConverter ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:VsConverter.VsConverterRegularSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:VsConverterRegularSchedule.droop
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Droop constant. The pu value is obtained as D [kV/MW] x Sb / Ubdc. The attribute shall be a positive value." ;
+        rdfs:domain        nc:VsConverterRegularSchedule ;
+        rdfs:label         "droop"@en ;
+        cims:dataType      cim:PU ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VsConverterRegularSchedule.droopCompensation
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Compensation constant. Used to compensate for voltage drop when controlling voltage at a distant bus. The attribute shall be a positive value." ;
+        rdfs:domain        nc:VsConverterRegularSchedule ;
+        rdfs:label         "droopCompensation"@en ;
+        cims:dataType      cim:Resistance ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VsConverterRegularSchedule.pPccControl
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of control of real power and/or DC voltage." ;
+        rdfs:domain        nc:VsConverterRegularSchedule ;
+        rdfs:label         "pPccControl"@en ;
+        rdfs:range         cim:VsPpccControlKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VsConverterRegularSchedule.qPccControl
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of reactive power control." ;
+        rdfs:domain        nc:VsConverterRegularSchedule ;
+        rdfs:label         "qPccControl"@en ;
+        rdfs:range         cim:VsQpccControlKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VsConverterRegularSchedule.qShare
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Reactive power sharing factor among parallel converters on Uac control. The attribute shall be a positive value or zero." ;
+        rdfs:domain        nc:VsConverterRegularSchedule ;
+        rdfs:label         "qShare"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VsConverterRegularSchedule.targetPWMfactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Magnitude of pulse-modulation factor. The attribute shall be a positive value." ;
+        rdfs:domain        nc:VsConverterRegularSchedule ;
+        rdfs:label         "targetPWMfactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VsConverterRegularSchedule.targetPhasePcc
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Phase target at AC side, at point of common coupling. The attribute shall be a positive value." ;
+        rdfs:domain        nc:VsConverterRegularSchedule ;
+        rdfs:label         "targetPhasePcc"@en ;
+        cims:dataType      cim:AngleDegrees ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VsConverterRegularSchedule.targetPowerFactorPcc
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Power factor target at the AC side, at point of common coupling. The attribute shall be a positive value." ;
+        rdfs:domain        nc:VsConverterRegularSchedule ;
+        rdfs:label         "targetPowerFactorPcc"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VsConverterRegularSchedule.targetQpcc
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Reactive power injection target in AC grid, at point of common coupling.  Load sign convention is used, i.e. positive sign means flow out from a node." ;
+        rdfs:domain        nc:VsConverterRegularSchedule ;
+        rdfs:label         "targetQpcc"@en ;
+        cims:dataType      cim:ReactivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VsConverterRegularSchedule.targetUpcc
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Voltage target in AC grid, at point of common coupling. The attribute shall be a positive value." ;
+        rdfs:domain        nc:VsConverterRegularSchedule ;
+        rdfs:label         "targetUpcc"@en ;
+        cims:dataType      cim:Voltage ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VsConverterSchedule
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Schedule for VS converter." ;
+        rdfs:label              "VsConverterSchedule"@en ;
+        rdfs:subClassOf         nc:BaseIrregularTimeSeries ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:VsConverterSchedule.VsConverter
+        rdf:type              rdf:Property ;
+        rdfs:comment          "Vs converter which has Vs converter schedules." ;
+        rdfs:domain           nc:VsConverterSchedule ;
+        rdfs:label            "VsConverter"@en ;
+        rdfs:range            cim:VsConverter ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:VsConverter.VsConverterSchedule ;
+        cims:multiplicity     cims:M:0..1 ;
+        cims:stereotype       "NC" .
+
+nc:VsConverterSchedule.VsConverterTimePoint
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The time point that relates to this VS converter schedule." ;
+        rdfs:domain           nc:VsConverterSchedule ;
+        rdfs:label            "VsConverterTimePoint"@en ;
+        rdfs:range            nc:VsConverterTimePoint ;
+        cims:AssociationUsed  "No" ;
+        cims:inverseRoleName  nc:VsConverterTimePoint.VsConverterSchedule ;
+        cims:multiplicity     cims:M:1..n ;
+        cims:stereotype       "NC" ;
+        cims:stereotype       <http://iec.ch/TC57/NonStandard/UML#ofAggregate> .
+
+nc:VsConverterTimePoint
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "VS converter values for a given point in time." ;
+        rdfs:label              "VsConverterTimePoint"@en ;
+        rdfs:subClassOf         nc:ACDCTimePoint ;
+        cims:belongsToCategory  shs:Package_SteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:VsConverterTimePoint.VsConverterSchedule
+        rdf:type              rdf:Property ;
+        rdfs:comment          "The VS converter schedule that has this time point." ;
+        rdfs:domain           nc:VsConverterTimePoint ;
+        rdfs:label            "VsConverterSchedule"@en ;
+        rdfs:range            nc:VsConverterSchedule ;
+        cims:AssociationUsed  "Yes" ;
+        cims:inverseRoleName  nc:VsConverterSchedule.VsConverterTimePoint ;
+        cims:multiplicity     cims:M:1 ;
+        cims:stereotype       "NC" .
+
+nc:VsConverterTimePoint.droop
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Droop constant. The pu value is obtained as D [kV/MW] x Sb / Ubdc. The attribute shall be a positive value." ;
+        rdfs:domain        nc:VsConverterTimePoint ;
+        rdfs:label         "droop"@en ;
+        cims:dataType      cim:PU ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VsConverterTimePoint.droopCompensation
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Compensation constant. Used to compensate for voltage drop when controlling voltage at a distant bus. The attribute shall be a positive value." ;
+        rdfs:domain        nc:VsConverterTimePoint ;
+        rdfs:label         "droopCompensation"@en ;
+        cims:dataType      cim:Resistance ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VsConverterTimePoint.pPccControl
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of control of real power and/or DC voltage." ;
+        rdfs:domain        nc:VsConverterTimePoint ;
+        rdfs:label         "pPccControl"@en ;
+        rdfs:range         cim:VsPpccControlKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VsConverterTimePoint.qPccControl
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Kind of reactive power control." ;
+        rdfs:domain        nc:VsConverterTimePoint ;
+        rdfs:label         "qPccControl"@en ;
+        rdfs:range         cim:VsQpccControlKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VsConverterTimePoint.qShare
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Reactive power sharing factor among parallel converters on Uac control. The attribute shall be a positive value or zero." ;
+        rdfs:domain        nc:VsConverterTimePoint ;
+        rdfs:label         "qShare"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VsConverterTimePoint.targetPWMfactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Magnitude of pulse-modulation factor. The attribute shall be a positive value." ;
+        rdfs:domain        nc:VsConverterTimePoint ;
+        rdfs:label         "targetPWMfactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VsConverterTimePoint.targetPhasePcc
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Phase target at AC side, at point of common coupling. The attribute shall be a positive value." ;
+        rdfs:domain        nc:VsConverterTimePoint ;
+        rdfs:label         "targetPhasePcc"@en ;
+        cims:dataType      cim:AngleDegrees ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VsConverterTimePoint.targetPowerFactorPcc
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Power factor target at the AC side, at point of common coupling. The attribute shall be a positive value." ;
+        rdfs:domain        nc:VsConverterTimePoint ;
+        rdfs:label         "targetPowerFactorPcc"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VsConverterTimePoint.targetQpcc
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Reactive power injection target in AC grid, at point of common coupling.  Load sign convention is used, i.e. positive sign means flow out from a node." ;
+        rdfs:domain        nc:VsConverterTimePoint ;
+        rdfs:label         "targetQpcc"@en ;
+        cims:dataType      cim:ReactivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VsConverterTimePoint.targetUpcc
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Voltage target in AC grid, at point of common coupling. The attribute shall be a positive value." ;
+        rdfs:domain        nc:VsConverterTimePoint ;
+        rdfs:label         "targetUpcc"@en ;
+        cims:dataType      cim:Voltage ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+profcim:IRI  rdf:type           rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as rdf:resource in RDFXML.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "IRI"@en ;
+        cims:belongsToCategory  shs:Package_DocSteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringFixedLanguage
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited.\nThe primitive is serialized as literal without language support." ;
+        rdfs:label              "StringFixedLanguage"@en ;
+        cims:belongsToCategory  shs:Package_DocSteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringIRI  rdf:type     rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as literal without language support.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "StringIRI"@en ;
+        cims:belongsToCategory  shs:Package_DocSteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:URL  rdf:type           rdfs:Class ;
+        rdfs:comment            "A Uniform Resource Locator (URL), colloquially termed a web address, is a reference to a web resource that specifies its location on a computer network and a mechanism for retrieving it. A URL is a specific type of Uniform Resource Identifier (URI), although many people use the two terms interchangeably.URLs occur most commonly to reference web pages (http), but are also used for file transfer (ftp), email (mailto), database access (JDBC), and many other applications." ;
+        rdfs:label              "URL"@en ;
+        cims:belongsToCategory  shs:Package_DocSteadyStateHypothesisScheduleProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+shs:Ontology  rdf:type        owl:Ontology ;
+        dcterms:conformsTo    "file://iec61970cim17v40_iec61968cim13v13a_iec62325cim03v17a.eap" , "urn:iso:std:iec:61970-501:draft:ed-2" , "file://CIM100_CGMES31v01_501-20v02_NC23v62_MM10v01.eap" , "urn:iso:std:iec:61970-401:draft:ed-1" , "urn:iso:std:iec:61970-600-2:ed-1" , "urn:iso:std:iec:61970-301:ed-7:amd1" ;
+        dcterms:creator       "ENTSO-E CIM WG NC project"@en ;
+        dcterms:description   "This vocabulary is describing the steady state hypothesis schedule."@en ;
+        dcterms:identifier    "urn:uuid:0d815deb-9968-4c6f-85d7-503d49e0b81f" ;
+        dcterms:language      "en-GB" ;
+        dcterms:license       "https://www.apache.org/licenses/LICENSE-2.0"@en ;
+        dcterms:modified      "2024-04-08"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        dcterms:publisher     "ENTSO-E"@en ;
+        dcterms:rightsHolder  "ENTSO-E"@en ;
+        dcterms:title         "Steady State Hypothesis Schedule Vocabulary"@en ;
+        owl:versionIRI        <https://ap.cim4.eu/SteadyStateHypothesisSchedule/1.0> ;
+        owl:versionInfo       "1.0.0"@en ;
+        dcat:keyword          "SHS" ;
+        dcat:theme            "vocabulary"@en .
+
+shs:Package_DocSteadyStateHypothesisScheduleProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains datatypes used only in the RDFS header." ;
+        rdfs:label    "DocSteadyStateHypothesisScheduleProfile"@en .
+
+shs:Package_SteadyStateHypothesisScheduleProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains steady state hypothesis schedule profile." ;
+        rdfs:label    "SteadyStateHypothesisScheduleProfile"@en .
+

--- a/r2.3/ap-voc/ttl/SteadyStateInstruction-AP-Voc-RDFS2020.ttl
+++ b/r2.3/ap-voc/ttl/SteadyStateInstruction-AP-Voc-RDFS2020.ttl
@@ -1,0 +1,3317 @@
+@prefix cim:     <https://cim.ucaiug.io/ns#> .
+@prefix cims:    <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/#> .
+@prefix nc:      <https://cim4.eu/ns/nc#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix profcim: <https://cim.ucaiug.io/ns/prof-cim#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ssi:     <https://ap.cim4.eu/SteadyStateInstruction#> .
+
+cim:ActivePower  rdf:type       rdfs:Class ;
+        rdfs:comment            "Product of RMS value of the voltage and the RMS value of the in-phase component of the current." ;
+        rdfs:label              "ActivePower"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:ActivePower.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePower.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "W" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ActivePower.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ActivePower ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:AngleDegrees  rdf:type      rdfs:Class ;
+        rdfs:comment            "Measurement of angle in degrees." ;
+        rdfs:label              "AngleDegrees"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:AngleDegrees.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:AngleDegrees ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:AngleDegrees.unit
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:AngleDegrees ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "deg" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:AngleDegrees.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:AngleDegrees ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Boolean  rdf:type           rdfs:Class ;
+        rdfs:comment            "A type with the value space \"true\" and \"false\"." ;
+        rdfs:label              "Boolean"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Contingency  rdf:type       rdfs:Class ;
+        rdfs:comment            "An event threatening system reliability, consisting of one or more contingency elements." ;
+        rdfs:label              "Contingency"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" .
+
+cim:Contingency.mustStudy
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Set true if must study this contingency." ;
+        rdfs:domain        cim:Contingency ;
+        rdfs:label         "mustStudy"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Currency  rdf:type          rdfs:Class ;
+        rdfs:comment            "Monetary currencies.  ISO 4217 standard including 3-character currency code." ;
+        rdfs:label              "Currency"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:Currency.AED  rdf:type  cim:Currency ;
+        rdfs:comment     "United Arab Emirates dirham." ;
+        rdfs:label       "AED"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AFN  rdf:type  cim:Currency ;
+        rdfs:comment     "Afghan afghani." ;
+        rdfs:label       "AFN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ALL  rdf:type  cim:Currency ;
+        rdfs:comment     "Albanian lek." ;
+        rdfs:label       "ALL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AMD  rdf:type  cim:Currency ;
+        rdfs:comment     "Armenian dram." ;
+        rdfs:label       "AMD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ANG  rdf:type  cim:Currency ;
+        rdfs:comment     "Netherlands Antillean guilder." ;
+        rdfs:label       "ANG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AOA  rdf:type  cim:Currency ;
+        rdfs:comment     "Angolan kwanza." ;
+        rdfs:label       "AOA"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ARS  rdf:type  cim:Currency ;
+        rdfs:comment     "Argentine peso." ;
+        rdfs:label       "ARS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AUD  rdf:type  cim:Currency ;
+        rdfs:comment     "Australian dollar." ;
+        rdfs:label       "AUD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AWG  rdf:type  cim:Currency ;
+        rdfs:comment     "Aruban florin." ;
+        rdfs:label       "AWG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.AZN  rdf:type  cim:Currency ;
+        rdfs:comment     "Azerbaijani manat." ;
+        rdfs:label       "AZN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BAM  rdf:type  cim:Currency ;
+        rdfs:comment     "Bosnia and Herzegovina convertible mark." ;
+        rdfs:label       "BAM"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BBD  rdf:type  cim:Currency ;
+        rdfs:comment     "Barbados dollar." ;
+        rdfs:label       "BBD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BDT  rdf:type  cim:Currency ;
+        rdfs:comment     "Bangladeshi taka." ;
+        rdfs:label       "BDT"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BGN  rdf:type  cim:Currency ;
+        rdfs:comment     "Bulgarian lev." ;
+        rdfs:label       "BGN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BHD  rdf:type  cim:Currency ;
+        rdfs:comment     "Bahraini dinar." ;
+        rdfs:label       "BHD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BIF  rdf:type  cim:Currency ;
+        rdfs:comment     "Burundian franc." ;
+        rdfs:label       "BIF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BMD  rdf:type  cim:Currency ;
+        rdfs:comment     "Bermudian dollar (customarily known as Bermuda dollar)." ;
+        rdfs:label       "BMD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BND  rdf:type  cim:Currency ;
+        rdfs:comment     "Brunei dollar." ;
+        rdfs:label       "BND"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BOB  rdf:type  cim:Currency ;
+        rdfs:comment     "Boliviano." ;
+        rdfs:label       "BOB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BOV  rdf:type  cim:Currency ;
+        rdfs:comment     "Bolivian Mvdol (funds code)." ;
+        rdfs:label       "BOV"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BRL  rdf:type  cim:Currency ;
+        rdfs:comment     "Brazilian real." ;
+        rdfs:label       "BRL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BSD  rdf:type  cim:Currency ;
+        rdfs:comment     "Bahamian dollar." ;
+        rdfs:label       "BSD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BTN  rdf:type  cim:Currency ;
+        rdfs:comment     "Bhutanese ngultrum." ;
+        rdfs:label       "BTN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BWP  rdf:type  cim:Currency ;
+        rdfs:comment     "Botswana pula." ;
+        rdfs:label       "BWP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BYR  rdf:type  cim:Currency ;
+        rdfs:comment     "Belarusian ruble." ;
+        rdfs:label       "BYR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.BZD  rdf:type  cim:Currency ;
+        rdfs:comment     "Belize dollar." ;
+        rdfs:label       "BZD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CAD  rdf:type  cim:Currency ;
+        rdfs:comment     "Canadian dollar." ;
+        rdfs:label       "CAD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CDF  rdf:type  cim:Currency ;
+        rdfs:comment     "Congolese franc." ;
+        rdfs:label       "CDF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CHF  rdf:type  cim:Currency ;
+        rdfs:comment     "Swiss franc." ;
+        rdfs:label       "CHF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CLF  rdf:type  cim:Currency ;
+        rdfs:comment     "Unidad de Fomento (funds code), Chile." ;
+        rdfs:label       "CLF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CLP  rdf:type  cim:Currency ;
+        rdfs:comment     "Chilean peso." ;
+        rdfs:label       "CLP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CNY  rdf:type  cim:Currency ;
+        rdfs:comment     "Chinese yuan." ;
+        rdfs:label       "CNY"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.COP  rdf:type  cim:Currency ;
+        rdfs:comment     "Colombian peso." ;
+        rdfs:label       "COP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.COU  rdf:type  cim:Currency ;
+        rdfs:comment     "Unidad de Valor Real." ;
+        rdfs:label       "COU"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CRC  rdf:type  cim:Currency ;
+        rdfs:comment     "Costa Rican colon." ;
+        rdfs:label       "CRC"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CUC  rdf:type  cim:Currency ;
+        rdfs:comment     "Cuban convertible peso." ;
+        rdfs:label       "CUC"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CUP  rdf:type  cim:Currency ;
+        rdfs:comment     "Cuban peso." ;
+        rdfs:label       "CUP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CVE  rdf:type  cim:Currency ;
+        rdfs:comment     "Cape Verde escudo." ;
+        rdfs:label       "CVE"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.CZK  rdf:type  cim:Currency ;
+        rdfs:comment     "Czech koruna." ;
+        rdfs:label       "CZK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.DJF  rdf:type  cim:Currency ;
+        rdfs:comment     "Djiboutian franc." ;
+        rdfs:label       "DJF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.DKK  rdf:type  cim:Currency ;
+        rdfs:comment     "Danish krone." ;
+        rdfs:label       "DKK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.DOP  rdf:type  cim:Currency ;
+        rdfs:comment     "Dominican peso." ;
+        rdfs:label       "DOP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.DZD  rdf:type  cim:Currency ;
+        rdfs:comment     "Algerian dinar." ;
+        rdfs:label       "DZD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.EEK  rdf:type  cim:Currency ;
+        rdfs:comment     "Estonian kroon." ;
+        rdfs:label       "EEK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.EGP  rdf:type  cim:Currency ;
+        rdfs:comment     "Egyptian pound." ;
+        rdfs:label       "EGP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ERN  rdf:type  cim:Currency ;
+        rdfs:comment     "Eritrean nakfa." ;
+        rdfs:label       "ERN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ETB  rdf:type  cim:Currency ;
+        rdfs:comment     "Ethiopian birr." ;
+        rdfs:label       "ETB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.EUR  rdf:type  cim:Currency ;
+        rdfs:comment     "Euro." ;
+        rdfs:label       "EUR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.FJD  rdf:type  cim:Currency ;
+        rdfs:comment     "Fiji dollar." ;
+        rdfs:label       "FJD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.FKP  rdf:type  cim:Currency ;
+        rdfs:comment     "Falkland Islands pound." ;
+        rdfs:label       "FKP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GBP  rdf:type  cim:Currency ;
+        rdfs:comment     "Pound sterling." ;
+        rdfs:label       "GBP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GEL  rdf:type  cim:Currency ;
+        rdfs:comment     "Georgian lari." ;
+        rdfs:label       "GEL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GHS  rdf:type  cim:Currency ;
+        rdfs:comment     "Ghanaian cedi." ;
+        rdfs:label       "GHS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GIP  rdf:type  cim:Currency ;
+        rdfs:comment     "Gibraltar pound." ;
+        rdfs:label       "GIP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GMD  rdf:type  cim:Currency ;
+        rdfs:comment     "Gambian dalasi." ;
+        rdfs:label       "GMD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GNF  rdf:type  cim:Currency ;
+        rdfs:comment     "Guinean franc." ;
+        rdfs:label       "GNF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GTQ  rdf:type  cim:Currency ;
+        rdfs:comment     "Guatemalan quetzal." ;
+        rdfs:label       "GTQ"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.GYD  rdf:type  cim:Currency ;
+        rdfs:comment     "Guyanese dollar." ;
+        rdfs:label       "GYD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HKD  rdf:type  cim:Currency ;
+        rdfs:comment     "Hong Kong dollar." ;
+        rdfs:label       "HKD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HNL  rdf:type  cim:Currency ;
+        rdfs:comment     "Honduran lempira." ;
+        rdfs:label       "HNL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HRK  rdf:type  cim:Currency ;
+        rdfs:comment     "Croatian kuna." ;
+        rdfs:label       "HRK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HTG  rdf:type  cim:Currency ;
+        rdfs:comment     "Haitian gourde." ;
+        rdfs:label       "HTG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.HUF  rdf:type  cim:Currency ;
+        rdfs:comment     "Hungarian forint." ;
+        rdfs:label       "HUF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.IDR  rdf:type  cim:Currency ;
+        rdfs:comment     "Indonesian rupiah." ;
+        rdfs:label       "IDR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ILS  rdf:type  cim:Currency ;
+        rdfs:comment     "Israeli new sheqel." ;
+        rdfs:label       "ILS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.INR  rdf:type  cim:Currency ;
+        rdfs:comment     "Indian rupee." ;
+        rdfs:label       "INR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.IQD  rdf:type  cim:Currency ;
+        rdfs:comment     "Iraqi dinar." ;
+        rdfs:label       "IQD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.IRR  rdf:type  cim:Currency ;
+        rdfs:comment     "Iranian rial." ;
+        rdfs:label       "IRR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ISK  rdf:type  cim:Currency ;
+        rdfs:comment     "Icelandic króna." ;
+        rdfs:label       "ISK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.JMD  rdf:type  cim:Currency ;
+        rdfs:comment     "Jamaican dollar." ;
+        rdfs:label       "JMD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.JOD  rdf:type  cim:Currency ;
+        rdfs:comment     "Jordanian dinar." ;
+        rdfs:label       "JOD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.JPY  rdf:type  cim:Currency ;
+        rdfs:comment     "Japanese yen." ;
+        rdfs:label       "JPY"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KES  rdf:type  cim:Currency ;
+        rdfs:comment     "Kenyan shilling." ;
+        rdfs:label       "KES"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KGS  rdf:type  cim:Currency ;
+        rdfs:comment     "Kyrgyzstani som." ;
+        rdfs:label       "KGS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KHR  rdf:type  cim:Currency ;
+        rdfs:comment     "Cambodian riel." ;
+        rdfs:label       "KHR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KMF  rdf:type  cim:Currency ;
+        rdfs:comment     "Comoro franc." ;
+        rdfs:label       "KMF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KPW  rdf:type  cim:Currency ;
+        rdfs:comment     "North Korean won." ;
+        rdfs:label       "KPW"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KRW  rdf:type  cim:Currency ;
+        rdfs:comment     "South Korean won." ;
+        rdfs:label       "KRW"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KWD  rdf:type  cim:Currency ;
+        rdfs:comment     "Kuwaiti dinar." ;
+        rdfs:label       "KWD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KYD  rdf:type  cim:Currency ;
+        rdfs:comment     "Cayman Islands dollar." ;
+        rdfs:label       "KYD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.KZT  rdf:type  cim:Currency ;
+        rdfs:comment     "Kazakhstani tenge." ;
+        rdfs:label       "KZT"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LAK  rdf:type  cim:Currency ;
+        rdfs:comment     "Lao kip." ;
+        rdfs:label       "LAK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LBP  rdf:type  cim:Currency ;
+        rdfs:comment     "Lebanese pound." ;
+        rdfs:label       "LBP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LKR  rdf:type  cim:Currency ;
+        rdfs:comment     "Sri Lanka rupee." ;
+        rdfs:label       "LKR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LRD  rdf:type  cim:Currency ;
+        rdfs:comment     "Liberian dollar." ;
+        rdfs:label       "LRD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LSL  rdf:type  cim:Currency ;
+        rdfs:comment     "Lesotho loti." ;
+        rdfs:label       "LSL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LTL  rdf:type  cim:Currency ;
+        rdfs:comment     "Lithuanian litas." ;
+        rdfs:label       "LTL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LVL  rdf:type  cim:Currency ;
+        rdfs:comment     "Latvian lats." ;
+        rdfs:label       "LVL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.LYD  rdf:type  cim:Currency ;
+        rdfs:comment     "Libyan dinar." ;
+        rdfs:label       "LYD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MAD  rdf:type  cim:Currency ;
+        rdfs:comment     "Moroccan dirham." ;
+        rdfs:label       "MAD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MDL  rdf:type  cim:Currency ;
+        rdfs:comment     "Moldovan leu." ;
+        rdfs:label       "MDL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MGA  rdf:type  cim:Currency ;
+        rdfs:comment     "Malagasy ariary." ;
+        rdfs:label       "MGA"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MKD  rdf:type  cim:Currency ;
+        rdfs:comment     "Macedonian denar." ;
+        rdfs:label       "MKD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MMK  rdf:type  cim:Currency ;
+        rdfs:comment     "Myanma kyat." ;
+        rdfs:label       "MMK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MNT  rdf:type  cim:Currency ;
+        rdfs:comment     "Mongolian tugrik." ;
+        rdfs:label       "MNT"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MOP  rdf:type  cim:Currency ;
+        rdfs:comment     "Macanese pataca." ;
+        rdfs:label       "MOP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MRO  rdf:type  cim:Currency ;
+        rdfs:comment     "Mauritanian ouguiya." ;
+        rdfs:label       "MRO"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MUR  rdf:type  cim:Currency ;
+        rdfs:comment     "Mauritian rupee." ;
+        rdfs:label       "MUR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MVR  rdf:type  cim:Currency ;
+        rdfs:comment     "Maldivian rufiyaa." ;
+        rdfs:label       "MVR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MWK  rdf:type  cim:Currency ;
+        rdfs:comment     "Malawian kwacha." ;
+        rdfs:label       "MWK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MXN  rdf:type  cim:Currency ;
+        rdfs:comment     "Mexican peso." ;
+        rdfs:label       "MXN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MYR  rdf:type  cim:Currency ;
+        rdfs:comment     "Malaysian ringgit." ;
+        rdfs:label       "MYR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.MZN  rdf:type  cim:Currency ;
+        rdfs:comment     "Mozambican metical." ;
+        rdfs:label       "MZN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NAD  rdf:type  cim:Currency ;
+        rdfs:comment     "Namibian dollar." ;
+        rdfs:label       "NAD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NGN  rdf:type  cim:Currency ;
+        rdfs:comment     "Nigerian naira." ;
+        rdfs:label       "NGN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NIO  rdf:type  cim:Currency ;
+        rdfs:comment     "Cordoba oro." ;
+        rdfs:label       "NIO"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NOK  rdf:type  cim:Currency ;
+        rdfs:comment     "Norwegian krone." ;
+        rdfs:label       "NOK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NPR  rdf:type  cim:Currency ;
+        rdfs:comment     "Nepalese rupee." ;
+        rdfs:label       "NPR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.NZD  rdf:type  cim:Currency ;
+        rdfs:comment     "New Zealand dollar." ;
+        rdfs:label       "NZD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.OMR  rdf:type  cim:Currency ;
+        rdfs:comment     "Omani rial." ;
+        rdfs:label       "OMR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PAB  rdf:type  cim:Currency ;
+        rdfs:comment     "Panamanian balboa." ;
+        rdfs:label       "PAB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PEN  rdf:type  cim:Currency ;
+        rdfs:comment     "Peruvian nuevo sol." ;
+        rdfs:label       "PEN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PGK  rdf:type  cim:Currency ;
+        rdfs:comment     "Papua New Guinean kina." ;
+        rdfs:label       "PGK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PHP  rdf:type  cim:Currency ;
+        rdfs:comment     "Philippine peso." ;
+        rdfs:label       "PHP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PKR  rdf:type  cim:Currency ;
+        rdfs:comment     "Pakistani rupee." ;
+        rdfs:label       "PKR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PLN  rdf:type  cim:Currency ;
+        rdfs:comment     "Polish zloty." ;
+        rdfs:label       "PLN"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.PYG  rdf:type  cim:Currency ;
+        rdfs:comment     "Paraguayan guaraní." ;
+        rdfs:label       "PYG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.QAR  rdf:type  cim:Currency ;
+        rdfs:comment     "Qatari rial." ;
+        rdfs:label       "QAR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.RON  rdf:type  cim:Currency ;
+        rdfs:comment     "Romanian new leu." ;
+        rdfs:label       "RON"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.RSD  rdf:type  cim:Currency ;
+        rdfs:comment     "Serbian dinar." ;
+        rdfs:label       "RSD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.RUB  rdf:type  cim:Currency ;
+        rdfs:comment     "Russian rouble." ;
+        rdfs:label       "RUB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.RWF  rdf:type  cim:Currency ;
+        rdfs:comment     "Rwandan franc." ;
+        rdfs:label       "RWF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SAR  rdf:type  cim:Currency ;
+        rdfs:comment     "Saudi riyal." ;
+        rdfs:label       "SAR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SBD  rdf:type  cim:Currency ;
+        rdfs:comment     "Solomon Islands dollar." ;
+        rdfs:label       "SBD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SCR  rdf:type  cim:Currency ;
+        rdfs:comment     "Seychelles rupee." ;
+        rdfs:label       "SCR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SDG  rdf:type  cim:Currency ;
+        rdfs:comment     "Sudanese pound." ;
+        rdfs:label       "SDG"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SEK  rdf:type  cim:Currency ;
+        rdfs:comment     "Swedish krona/kronor." ;
+        rdfs:label       "SEK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SGD  rdf:type  cim:Currency ;
+        rdfs:comment     "Singapore dollar." ;
+        rdfs:label       "SGD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SHP  rdf:type  cim:Currency ;
+        rdfs:comment     "Saint Helena pound." ;
+        rdfs:label       "SHP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SLL  rdf:type  cim:Currency ;
+        rdfs:comment     "Sierra Leonean leone." ;
+        rdfs:label       "SLL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SOS  rdf:type  cim:Currency ;
+        rdfs:comment     "Somali shilling." ;
+        rdfs:label       "SOS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SRD  rdf:type  cim:Currency ;
+        rdfs:comment     "Surinamese dollar." ;
+        rdfs:label       "SRD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.STD  rdf:type  cim:Currency ;
+        rdfs:comment     "São Tomé and Príncipe dobra." ;
+        rdfs:label       "STD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SYP  rdf:type  cim:Currency ;
+        rdfs:comment     "Syrian pound." ;
+        rdfs:label       "SYP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.SZL  rdf:type  cim:Currency ;
+        rdfs:comment     "Lilangeni." ;
+        rdfs:label       "SZL"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.THB  rdf:type  cim:Currency ;
+        rdfs:comment     "Thai baht." ;
+        rdfs:label       "THB"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TJS  rdf:type  cim:Currency ;
+        rdfs:comment     "Tajikistani somoni." ;
+        rdfs:label       "TJS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TMT  rdf:type  cim:Currency ;
+        rdfs:comment     "Turkmenistani manat." ;
+        rdfs:label       "TMT"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TND  rdf:type  cim:Currency ;
+        rdfs:comment     "Tunisian dinar." ;
+        rdfs:label       "TND"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TOP  rdf:type  cim:Currency ;
+        rdfs:comment     "Tongan pa'anga." ;
+        rdfs:label       "TOP"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TRY  rdf:type  cim:Currency ;
+        rdfs:comment     "Turkish lira." ;
+        rdfs:label       "TRY"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TTD  rdf:type  cim:Currency ;
+        rdfs:comment     "Trinidad and Tobago dollar." ;
+        rdfs:label       "TTD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TWD  rdf:type  cim:Currency ;
+        rdfs:comment     "New Taiwan dollar." ;
+        rdfs:label       "TWD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.TZS  rdf:type  cim:Currency ;
+        rdfs:comment     "Tanzanian shilling." ;
+        rdfs:label       "TZS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.UAH  rdf:type  cim:Currency ;
+        rdfs:comment     "Ukrainian hryvnia." ;
+        rdfs:label       "UAH"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.UGX  rdf:type  cim:Currency ;
+        rdfs:comment     "Ugandan shilling." ;
+        rdfs:label       "UGX"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.USD  rdf:type  cim:Currency ;
+        rdfs:comment     "United States dollar." ;
+        rdfs:label       "USD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.UYU  rdf:type  cim:Currency ;
+        rdfs:comment     "Uruguayan peso." ;
+        rdfs:label       "UYU"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.UZS  rdf:type  cim:Currency ;
+        rdfs:comment     "Uzbekistan som." ;
+        rdfs:label       "UZS"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.VEF  rdf:type  cim:Currency ;
+        rdfs:comment     "Venezuelan bolívar fuerte." ;
+        rdfs:label       "VEF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.VND  rdf:type  cim:Currency ;
+        rdfs:comment     "Vietnamese Dong." ;
+        rdfs:label       "VND"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.VUV  rdf:type  cim:Currency ;
+        rdfs:comment     "Vanuatu vatu." ;
+        rdfs:label       "VUV"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.WST  rdf:type  cim:Currency ;
+        rdfs:comment     "Samoan tala." ;
+        rdfs:label       "WST"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.XAF  rdf:type  cim:Currency ;
+        rdfs:comment     "CFA franc BEAC." ;
+        rdfs:label       "XAF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.XCD  rdf:type  cim:Currency ;
+        rdfs:comment     "East Caribbean dollar." ;
+        rdfs:label       "XCD"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.XOF  rdf:type  cim:Currency ;
+        rdfs:comment     "CFA Franc BCEAO." ;
+        rdfs:label       "XOF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.XPF  rdf:type  cim:Currency ;
+        rdfs:comment     "CFP franc." ;
+        rdfs:label       "XPF"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.YER  rdf:type  cim:Currency ;
+        rdfs:comment     "Yemeni rial." ;
+        rdfs:label       "YER"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ZAR  rdf:type  cim:Currency ;
+        rdfs:comment     "South African rand." ;
+        rdfs:label       "ZAR"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ZMK  rdf:type  cim:Currency ;
+        rdfs:comment     "Zambian kwacha." ;
+        rdfs:label       "ZMK"@en ;
+        cims:stereotype  "enum" .
+
+cim:Currency.ZWL  rdf:type  cim:Currency ;
+        rdfs:comment     "Zimbabwe dollar." ;
+        rdfs:label       "ZWL"@en ;
+        cims:stereotype  "enum" .
+
+cim:CurrentFlow  rdf:type       rdfs:Class ;
+        rdfs:comment            "Electrical current with sign convention: positive flow is out of the conducting equipment into the connectivity node. Can be both AC and DC." ;
+        rdfs:label              "CurrentFlow"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:CurrentFlow.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:CurrentFlow ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:CurrentFlow.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:CurrentFlow ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "A" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:CurrentFlow.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:CurrentFlow ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Date  rdf:type              rdfs:Class ;
+        rdfs:comment            "Date as \"yyyy-mm-dd\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddZ\". A local timezone relative UTC is specified as \"yyyy-mm-dd(+/-)hh:mm\"." ;
+        rdfs:label              "Date"@en ;
+        cims:belongsToCategory  ssi:Package_DocSteadyStateInstructionProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:DateTime  rdf:type          rdfs:Class ;
+        rdfs:comment            "Date and time as \"yyyy-mm-ddThh:mm:ss.sss\", which conforms with ISO 8601. UTC time zone is specified as \"yyyy-mm-ddThh:mm:ss.sssZ\". A local timezone relative UTC is specified as \"yyyy-mm-ddThh:mm:ss.sss-hh:mm\". The second component (shown here as \"ss.sss\") could have any number of digits in its fractional part to allow any kind of precision beyond seconds." ;
+        rdfs:label              "DateTime"@en ;
+        cims:belongsToCategory  ssi:Package_DocSteadyStateInstructionProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Decimal  rdf:type           rdfs:Class ;
+        rdfs:comment            "Decimal is the base-10 notational system for representing real numbers." ;
+        rdfs:label              "Decimal"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Duration  rdf:type          rdfs:Class ;
+        rdfs:comment            "Duration as \"PnYnMnDTnHnMnS\" which conforms to ISO 8601, where nY expresses a number of years, nM a number of months, nD a number of days. The letter T separates the date expression from the time expression and, after it, nH identifies a number of hours, nM a number of minutes and nS a number of seconds. The number of seconds could be expressed as a decimal number, but all other numbers are integers." ;
+        rdfs:label              "Duration"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:EnergyConsumer  rdf:type    rdfs:Class ;
+        rdfs:comment            "Generic user of energy - a  point of consumption on the power system model.\nEnergyConsumer.pfixed, .qfixed, .pfixedPct and .qfixedPct have meaning only if there is no LoadResponseCharacteristic associated with EnergyConsumer or if LoadResponseCharacteristic.exponentModel is set to False." ;
+        rdfs:label              "EnergyConsumer"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:Equipment  rdf:type         rdfs:Class ;
+        rdfs:comment            "The parts of a power system that are physical devices, electronic or mechanical." ;
+        rdfs:label              "Equipment"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" .
+
+cim:Equipment.inService
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Specifies the availability of the equipment. True means the equipment is available for topology processing, which determines if the equipment is energized or not. False means that the equipment is treated by network applications as if it is not in the model." ;
+        rdfs:domain        cim:Equipment ;
+        rdfs:label         "inService"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Equipment.networkAnalysisEnabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The equipment is enabled to participate in network analysis.  If unspecified, the value is assumed to be true." ;
+        rdfs:domain        cim:Equipment ;
+        rdfs:label         "networkAnalysisEnabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Float  rdf:type             rdfs:Class ;
+        rdfs:comment            "A floating point number. The range is unspecified and not limited." ;
+        rdfs:label              "Float"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Frequency  rdf:type         rdfs:Class ;
+        rdfs:comment            "Cycles per second." ;
+        rdfs:label              "Frequency"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Frequency.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:Frequency ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Frequency.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Frequency ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "Hz" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Frequency.value  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Frequency ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:GeneratingUnit  rdf:type    rdfs:Class ;
+        rdfs:comment            "A single or set of synchronous machines for converting mechanical power into alternating-current power. For example, individual machines within a set may be defined for scheduling purposes while a single control signal is derived for the set. In this case there would be a GeneratingUnit for each member of the set and an additional GeneratingUnit corresponding to the set." ;
+        rdfs:label              "GeneratingUnit"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:GeneratingUnit.startupCost
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The initial startup cost incurred for each start of the GeneratingUnit." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "startupCost"@en ;
+        cims:dataType      cim:Money ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:HydroPump  rdf:type         rdfs:Class ;
+        rdfs:comment            "A synchronous motor-driven pump, typically associated with a pumped storage plant." ;
+        rdfs:label              "HydroPump"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:Impedance  rdf:type         rdfs:Class ;
+        rdfs:comment            "Ratio of voltage to current." ;
+        rdfs:label              "Impedance"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Impedance.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:Impedance ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Impedance.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Impedance ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "ohm" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Impedance.value  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Impedance ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Integer  rdf:type           rdfs:Class ;
+        rdfs:comment            "An integer number. The range is unspecified and not limited." ;
+        rdfs:label              "Integer"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:Money  rdf:type             rdfs:Class ;
+        rdfs:comment            "Amount of money." ;
+        rdfs:label              "Money"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Money.multiplier  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Money ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Money.unit  rdf:type   rdf:Property ;
+        rdfs:domain        cim:Money ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:Currency ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Money.value  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Money ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Decimal ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent  rdf:type           rdfs:Class ;
+        rdfs:comment            "Percentage on a defined base.   For example, specify as 100 to indicate at the defined base." ;
+        rdfs:label              "PerCent"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:PerCent.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PerCent.value  rdf:type  rdf:Property ;
+        rdfs:comment       "Normally 0 to 100 on a defined base." ;
+        rdfs:domain        cim:PerCent ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:PowerElectronicsUnit
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A generating unit or battery or aggregation that connects to the AC network using power electronics rather than rotating machines." ;
+        rdfs:label              "PowerElectronicsUnit"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:ReactivePower  rdf:type     rdfs:Class ;
+        rdfs:comment            "Product of RMS value of the voltage and the RMS value of the quadrature component of the current." ;
+        rdfs:label              "ReactivePower"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:ReactivePower.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ReactivePower ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ReactivePower.unit
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ReactivePower ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "VAr" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:ReactivePower.value
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:ReactivePower ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:RealEnergy  rdf:type        rdfs:Class ;
+        rdfs:comment            "Real electrical energy." ;
+        rdfs:label              "RealEnergy"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:RealEnergy.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:RealEnergy ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "M" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:RealEnergy.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:RealEnergy ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "Wh" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:RealEnergy.value  rdf:type  rdf:Property ;
+        rdfs:domain        cim:RealEnergy ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:RegulatingCondEq  rdf:type  rdfs:Class ;
+        rdfs:comment            "A type of conducting equipment that can regulate a quantity (i.e. voltage or flow) at a specific point in the network. " ;
+        rdfs:label              "RegulatingCondEq"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile .
+
+cim:RegulatingCondEq.controlEnabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Specifies the regulation status of the equipment.  True is regulating, false is not regulating." ;
+        rdfs:domain        cim:RegulatingCondEq ;
+        rdfs:label         "controlEnabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Reservoir  rdf:type         rdfs:Class ;
+        rdfs:comment            "A water storage facility within a hydro system, including: ponds, lakes, lagoons, and rivers. The storage is usually behind some type of dam." ;
+        rdfs:label              "Reservoir"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+cim:Seconds  rdf:type           rdfs:Class ;
+        rdfs:comment            "Time, in seconds." ;
+        rdfs:label              "Seconds"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Seconds.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:Seconds ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "none" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Seconds.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Seconds ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "s" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Seconds.value  rdf:type  rdf:Property ;
+        rdfs:comment       "Time, in seconds" ;
+        rdfs:domain        cim:Seconds ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:String  rdf:type            rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited." ;
+        rdfs:label              "String"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Primitive" .
+
+cim:UnitMultiplier  rdf:type    rdfs:Class ;
+        rdfs:comment            "The unit multipliers defined for the CIM.  When applied to unit symbols, the unit symbol is treated as a derived unit. Regardless of the contents of the unit symbol text, the unit symbol shall be treated as if it were a single-character unit symbol. Unit symbols should not contain multipliers, and it should be left to the multiplier to define the multiple for an entire data type. \n\nFor example, if a unit symbol is \"m2Pers\" and the multiplier is \"k\", then the value is k(m**2/s), and the multiplier applies to the entire final value, not to any individual part of the value. This can be conceptualized by substituting a derived unit symbol for the unit type. If one imagines that the symbol \"Þ\" represents the derived unit \"m2Pers\", then applying the multiplier \"k\" can be conceptualized simply as \"kÞ\".\n\nFor example, the SI unit for mass is \"kg\" and not \"g\".  If the unit symbol is defined as \"kg\", then the multiplier is applied to \"kg\" as a whole and does not replace the \"k\" in front of the \"g\". In this case, the multiplier of \"m\" would be used with the unit symbol of \"kg\" to represent one gram.  As a text string, this violates the instructions in IEC 80000-1. However, because the unit symbol in CIM is treated as a derived unit instead of as an SI unit, it makes more sense to conceptualize the \"kg\" as if it were replaced by one of the proposed replacements for the SI mass symbol. If one imagines that the \"kg\" were replaced by a symbol \"Þ\", then it is easier to conceptualize the multiplier \"m\" as creating the proper unit \"mÞ\", and not the forbidden unit \"mkg\"." ;
+        rdfs:label              "UnitMultiplier"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitMultiplier.M  rdf:type  cim:UnitMultiplier ;
+        rdfs:comment     "Mega 10**6." ;
+        rdfs:label       "M"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitMultiplier.k  rdf:type  cim:UnitMultiplier ;
+        rdfs:comment     "Kilo 10**3." ;
+        rdfs:label       "k"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitMultiplier.none
+        rdf:type         cim:UnitMultiplier ;
+        rdfs:comment     "No multiplier or equivalently multiply by 1." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol  rdf:type        rdfs:Class ;
+        rdfs:comment            "The derived units defined for usage in the CIM. In some cases, the derived unit is equal to an SI unit. Whenever possible, the standard derived symbol is used instead of the formula for the derived unit. For example, the unit symbol Farad is defined as \"F\" instead of \"CPerV\". In cases where a standard symbol does not exist for a derived unit, the formula for the unit is used as the unit symbol. For example, density does not have a standard symbol and so it is represented as \"kgPerm3\". With the exception of the \"kg\", which is an SI unit, the unit symbols do not contain multipliers and therefore represent the base derived unit to which a multiplier can be applied as a whole. \nEvery unit symbol is treated as an unparseable text as if it were a single-letter symbol. The meaning of each unit symbol is defined by the accompanying descriptive text and not by the text contents of the unit symbol.\nTo allow the widest possible range of serializations without requiring special character handling, several substitutions are made which deviate from the format described in IEC 80000-1. The division symbol \"/\" is replaced by the letters \"Per\". Exponents are written in plain text after the unit as \"m3\" instead of being formatted as \"m\" with a superscript of 3  or introducing a symbol as in \"m^3\". The degree symbol \"°\" is replaced with the letters \"deg\". Any clarification of the meaning for a substitution is included in the description for the unit symbol.\nNon-SI units are included in list of unit symbols to allow sources of data to be correctly labelled with their non-SI units (for example, a GPS sensor that is reporting numbers that represent feet instead of meters). This allows software to use the unit symbol information correctly convert and scale the raw data of those sources into SI-based units. \nThe integer values are used for harmonization with IEC 61850." ;
+        rdfs:label              "UnitSymbol"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+cim:UnitSymbol.A  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Current in amperes." ;
+        rdfs:label       "A"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.V  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Electric potential in volts (W/A)." ;
+        rdfs:label       "V"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.VAr  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Reactive power in volt amperes reactive. The “reactive” or “imaginary” component of electrical power (VIsin(phi)). (See also real power and apparent power).\nNote: Different meter designs use different methods to arrive at their results. Some meters may compute reactive power as an arithmetic value, while others compute the value vectorially. The data consumer should determine the method in use and the suitability of the measurement for the intended purpose." ;
+        rdfs:label       "VAr"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.W  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Real power in watts (J/s). Electrical power may have real and reactive components. The real portion of electrical power (I&#178;R or VIcos(phi)), is expressed in Watts. See also apparent power and reactive power." ;
+        rdfs:label       "W"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.Wh  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Real energy in watt hours." ;
+        rdfs:label       "Wh"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.deg  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Plane angle in degrees." ;
+        rdfs:label       "deg"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.none  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Dimension less quantity, e.g. count, per unit, etc." ;
+        rdfs:label       "none"@en ;
+        cims:stereotype  "enum" .
+
+cim:UnitSymbol.ohm  rdf:type  cim:UnitSymbol ;
+        rdfs:comment     "Electric resistance in ohms (V/A)." ;
+        rdfs:label       "ohm"@en ;
+        cims:stereotype  "enum" .
+
+cim:Voltage  rdf:type           rdfs:Class ;
+        rdfs:comment            "Electrical voltage, can be both AC and DC." ;
+        rdfs:label              "Voltage"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "CIMDatatype" .
+
+cim:Voltage.multiplier
+        rdf:type           rdf:Property ;
+        rdfs:domain        cim:Voltage ;
+        rdfs:label         "multiplier"@en ;
+        rdfs:range         cim:UnitMultiplier ;
+        cims:isFixed       "k" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Voltage.unit  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Voltage ;
+        rdfs:label         "unit"@en ;
+        rdfs:range         cim:UnitSymbol ;
+        cims:isFixed       "V" ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+cim:Voltage.value  rdf:type  rdf:Property ;
+        rdfs:domain        cim:Voltage ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ACEmulationControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "The AC emulation control function is used when AC emulation model is activated for a DC system. It consists in computing the active power set point of the DC system as a function of the voltage angle difference between both points of common coupling with the AC network in order to mimic the behavior of an AC transmission line. This control mode enables the automatic adjustment of the active power reference following variations of the AC system operational point. \nThe setpoint of the DC system is calculated by Psetpoint=Pref+Kdc*(angle1-angle2), where\n- Pref is the existing active power setpoint; \n- Kdc is the control system gain and  \n- angle1 and angle2 are the phase angle measurement (measured at points of common coupling with the AC network) respectively at the side 1 and 2 of the DC system." ;
+        rdfs:label              "ACEmulationControlFunction"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ACEmulationControlFunction.gain
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Control system gain in AC transmission emulation control measured in MW/deg. It plays the role of an admittance of the equivalent AC transmission line that the control is emulating the higher is the gain the higher is the active power transfer at steady state." ;
+        rdfs:domain        nc:ACEmulationControlFunction ;
+        rdfs:label         "gain"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ACEmulationControlFunction.referenceP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Existing active power setpoint used to calculate the active power setpoint of the AC emulation control." ;
+        rdfs:domain        nc:ACEmulationControlFunction ;
+        rdfs:label         "referenceP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ACEmulationControlFunction.timeConstant
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Control system time constant in AC transmission emulation control. It affects the time needed to \nreach a new steady state equilibrium point after a network perturbation extremely important to guarantee N-1 relief related to an interconnection. The higher is time constant the slower is the DC system dynamic." ;
+        rdfs:domain        nc:ACEmulationControlFunction ;
+        rdfs:label         "timeConstant"@en ;
+        cims:dataType      cim:Seconds ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ActivePowerControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Active power control function is a function block that calculates operating point of the controlled equipment to achieve the target active power." ;
+        rdfs:label              "ActivePowerControlFunction"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ActivePowerControlFunction.targetValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Target value for the active power that the control function is calculating to achieve by adjusting the operational setting to the controlled equipment." ;
+        rdfs:domain        nc:ActivePowerControlFunction ;
+        rdfs:label         "targetValue"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AreaDispatchableUnit
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Allocates a given producing or consuming unit, including direct current corridor and collection of units, to a given control area (through the scheduling area) for supporting the control of the given area through dispatch instruction. " ;
+        rdfs:label              "AreaDispatchableUnit"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AreaDispatchableUnit.enabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Identifies if the unit is enabled to accept a dispatch instruction. If true, the unit is enabled to accept a dispatch instruction. If false, the unit has the capability, but it is not enabled to receive a dispatch instruction." ;
+        rdfs:domain        nc:AreaDispatchableUnit ;
+        rdfs:label         "enabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AreaDispatchableUnit.p
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Active power injection. Load sign convention is used, i.e. positive sign means flow out from a node." ;
+        rdfs:domain        nc:AreaDispatchableUnit ;
+        rdfs:label         "p"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement  rdf:type    rdfs:Class ;
+        rdfs:comment            "Assessed element is a network element for which the electrical state is evaluated in the regional or cross-regional process and which value is expected to fulfil regional rules function of the operational security limits.\nThe measurements and limits are as defined in the steady state hypothesis." ;
+        rdfs:label              "AssessedElement"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AssessedElement.appointedMargin
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The percentage (appointed to a region) of the remaining margin obtained in the grid model to reach its current limit under normal operating conditions. The maximum percentage shall by default be 10% of the remaining margin.\nIt is only used when an assessed element is considered conservative for a region.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "appointedMargin"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.coordinatedValidationAdjustment
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Positive value calculated and provided by the Coordinated Capacity Calculator (CCC) for the reduction of Remaining Available Margin (RAM) in order to ensure grid security." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "coordinatedValidationAdjustment"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.coordinatedValidationAdjustmentJustification
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Free text description provided by the coordinated capacity calculator (CCC) for justifying the reduction of Remaining Available Margin (RAM) by means of Coordinated Validation Adjustment (CVA). This justification is not intended for any application processing purpose, it should only be used for reporting." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "coordinatedValidationAdjustmentJustification"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.criticalElementContingencyJustification
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Free text describing the justification  of critical element contingency categorization (e.g. the use of the kind). This justification is not intended for any application processing purpose, it should only be used for reporting." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "criticalElementContingencyJustification"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.enabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "If true, the assessed element is enabled, otherwise it is disabled." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "enabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.individualValidationAdjustment
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Positive value calculated and provided by System Operators from their individual validation process for the reduction of Remaining Available Margin (RAM) in order to ensure grid security." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "individualValidationAdjustment"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.individualValidationAdjustmentJustification
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Free text description provided by System Operators for justifying the reduction of Remaining Available Margin (RAM) by means of Individual Validation Adjustment (IVA). This justification is not intended for any application processing purpose, it should only be used for reporting." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "individualValidationAdjustmentJustification"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.individualValidationAdjustmentShare
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Positive value expressed calculated by the Coordinated Capacity Calculator (CCC) based on the provided Individual Validation Adjustment (IVA) by System Operators in order to show the actual reduction of Remaining Available Margin (RAM). Individual Validation Adjustment Share is a positive non-zero value. It is equal or less than the Individual Validation Adjustment value. " ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "individualValidationAdjustmentShare"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.maxFlow
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum flow on a conducting equipment or a collection of conducting equipment forming a power transfer corridor. For assessed element that becomes critical due to contingency, this value represents the maximum flow with remedial action taken into consideration." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "maxFlow"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.maxMarginAdjustment
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum adjustment, relative to maximum flow allowed for exceeding the maximum flow of this assessed element.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "maxMarginAdjustment"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.positiveVirtualMargin
+        rdf:type           rdf:Property ;
+        rdfs:comment       "A positive margin that defines the overload allowed in a solution for the assessed element for the current situation. The margin represents influences that can be solved by the System Operators using available remedial action which is not cross-border relevant remedial action.\nAll relevant operational limits (e.g. PATL, TATL, etc) are modified by this margin value. The attribute represents the increase.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "positiveVirtualMargin"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.scannedThresholdMargin
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Threshold percentage that a scanned element can be overloaded, on a given element, on top of any overload prior to optimisation (default= 5%). e.g. Initial loading of the element is 110%, with a 5% scanned threshold margin, the new maximum is 115% of the limit (e.g. PATL, TATL, etc).\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "scannedThresholdMargin"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElement.targetRemainingAvailableMarginJustification
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Free text describing the justification for the target Remaining Available Margin (RAM). This justification is not intended for any application processing purpose, it should only be used for reporting." ;
+        rdfs:domain        nc:AssessedElement ;
+        rdfs:label         "targetRemainingAvailableMarginJustification"@en ;
+        cims:dataType      cim:String ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementWithContingency
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Combination of an assessed element and a contingency." ;
+        rdfs:label              "AssessedElementWithContingency"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AssessedElementWithContingency.enabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "If true, the assessed element with contingency is enabled, otherwise it is disabled." ;
+        rdfs:domain        nc:AssessedElementWithContingency ;
+        rdfs:label         "enabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AssessedElementWithRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Combination of an assessed element and a remedial action" ;
+        rdfs:label              "AssessedElementWithRemedialAction"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:AssessedElementWithRemedialAction.enabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "If true, the assessed element with remedial action is enabled, otherwise it is disabled." ;
+        rdfs:domain        nc:AssessedElementWithRemedialAction ;
+        rdfs:label         "enabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AutomationFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Automation function is a collection of functional block or other automation function that can be executed as a work cycle program as part of an automated system." ;
+        rdfs:label              "AutomationFunction"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" .
+
+nc:AutomationFunction.enabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "True, if the automation function is enabled (active). Otherwise false." ;
+        rdfs:domain        nc:AutomationFunction ;
+        rdfs:label         "enabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:AvailabilityRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Availability remedial action is a remedial action that cancels or reschedules an availability schedule." ;
+        rdfs:label              "AvailabilityRemedialAction"@en ;
+        rdfs:subClassOf         nc:RemedialAction ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:BiddingZone  rdf:type        rdfs:Class ;
+        rdfs:comment            "A bidding zone is a market-based method for handling power transmission congestion. It consists of scheduling areas that include the relevant production (supply) and consumption (demand) to form an electrical area with the same market price without capacity allocation." ;
+        rdfs:label              "BiddingZone"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:BiddingZone.netPosition
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Net position is the netted sum of electricity exports and imports for each market time unit for a bidding zone." ;
+        rdfs:domain        nc:BiddingZone ;
+        rdfs:label         "netPosition"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BiddingZoneBorder  rdf:type  rdfs:Class ;
+        rdfs:comment            "Defines the aggregated connection capacity between two Bidding Zones." ;
+        rdfs:label              "BiddingZoneBorder"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:BiddingZoneBorder.alreadyAllocatedCapacity
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Already Allocated Capacity (AAC) means the total amount of allocated transmission rights i.e. transmission capacity reserved by virtue of historical long-term contracts and the previously held transmission capacity reservation auctions." ;
+        rdfs:domain        nc:BiddingZoneBorder ;
+        rdfs:label         "alreadyAllocatedCapacity"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BiddingZoneBorder.alreadyAllocatedFlow
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The maximum allowed flow on the collection of interconnection between two bidding zones." ;
+        rdfs:domain        nc:BiddingZoneBorder ;
+        rdfs:label         "alreadyAllocatedFlow"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BiddingZoneBorder.availableTransferCapacity
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Available Transfer Capacity (ATC) means the transmission capacity that remains available, after allocation procedure, to be used under the physical conditions of the transmission system. ATC value is defined as: ATC = NTC - AAC." ;
+        rdfs:domain        nc:BiddingZoneBorder ;
+        rdfs:label         "availableTransferCapacity"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BiddingZoneBorder.netTransferCapacity
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Net Transfer Capacity (NTC) is defined as NTC = TTC – TRM and corresponds to the maximum exchange between two areas compatible with operational security limits applicable in both areas and taking into account the technical uncertainties on future network conditions." ;
+        rdfs:domain        nc:BiddingZoneBorder ;
+        rdfs:label         "netTransferCapacity"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BiddingZoneBorder.totalTransferCapacity
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Total Transfer Capacity (TTC) is the maximum exchange program between two areas compatible with operational security standards applicable at each system if future network conditions, generation and load patterns were perfectly known in advance." ;
+        rdfs:domain        nc:BiddingZoneBorder ;
+        rdfs:label         "totalTransferCapacity"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:BiddingZoneBorder.transmissionReliabilityMargin
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Transmission Reliability Margin (TRM) is the minimum reserve that system operators must have available at their connections so that they can help other countries to which their system is directly or indirectly connected, if necessary." ;
+        rdfs:domain        nc:BiddingZoneBorder ;
+        rdfs:label         "transmissionReliabilityMargin"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CircuitShare  rdf:type       rdfs:Class ;
+        rdfs:comment            "Defines the share of the circuit which is part of an associated power transfer corridor." ;
+        rdfs:label              "CircuitShare"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:CircuitShare.contributionFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Contribution factor for the circuit which is part of a power transfer corridor.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        nc:CircuitShare ;
+        rdfs:label         "contributionFactor"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CompensatorControlModeKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of compensator controller mode." ;
+        rdfs:label              "CompensatorControlModeKind"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:CompensatorControlModeKind.reactivePower
+        rdf:type         nc:CompensatorControlModeKind ;
+        rdfs:comment     "Reactive power control." ;
+        rdfs:label       "reactivePower"@en ;
+        cims:stereotype  "enum" .
+
+nc:CompensatorControlModeKind.voltage
+        rdf:type         nc:CompensatorControlModeKind ;
+        rdfs:comment     "Voltage control." ;
+        rdfs:label       "voltage"@en ;
+        cims:stereotype  "enum" .
+
+nc:CompensatorController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Compensator controller is controlling the equipment to optimize the use of the compensators. " ;
+        rdfs:label              "CompensatorController"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:CompensatorController.mode
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Mode of the compensator controller." ;
+        rdfs:domain        nc:CompensatorController ;
+        rdfs:label         "mode"@en ;
+        rdfs:range         nc:CompensatorControlModeKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Contingency.probability
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The forecasted probability of the occurrence of the contingency based on the given operational condition, status of the equipment and the forecasted environment condition.\nThe allowed value range is [0,100]." ;
+        rdfs:domain        cim:Contingency ;
+        rdfs:label         "probability"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ContingencyWithRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Combination of a contingency and a remedial action. ContingencyWithRemedialAction shall not be instantiated for preventive RemedialAction (RemedialAction.kind equals RemedialActionKind.preventive)." ;
+        rdfs:label              "ContingencyWithRemedialAction"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ContingencyWithRemedialAction.enabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "If true, the contingency with remedial action is enabled, otherwise it is disabled." ;
+        rdfs:domain        nc:ContingencyWithRemedialAction ;
+        rdfs:label         "enabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CountertradeRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Countertrade is a remedial action to relieve physical congestions where the location of activated resources within the bidding zone is not known." ;
+        rdfs:label              "CountertradeRemedialAction"@en ;
+        rdfs:subClassOf         nc:PowerRemedialAction ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:CurrentControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Current control function is a function block that calculates the operating point of the controlled equipment  to achieve the target current." ;
+        rdfs:label              "CurrentControlFunction"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:CurrentControlFunction.targetValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Target value for the current that the control function is calculating to achieve by adjusting the operational setting to the controlled equipment." ;
+        rdfs:domain        nc:CurrentControlFunction ;
+        rdfs:label         "targetValue"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CurrentDroopControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Current droop control function is a function block that calculates the operating point of the controlled equipment to achieve the target current." ;
+        rdfs:label              "CurrentDroopControlFunction"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:CurrentDroopControlFunction.targetValueCapacitive
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Setpoint when control is active in capacitive region." ;
+        rdfs:domain        nc:CurrentDroopControlFunction ;
+        rdfs:label         "targetValueCapacitive"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CurrentDroopControlFunction.targetValueInductive
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Setpoint when control is active in inductive region." ;
+        rdfs:domain        nc:CurrentDroopControlFunction ;
+        rdfs:label         "targetValueInductive"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CurrentDroopOverride
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Current droop override uses the following logic:\n- When the current exceeds a threshold the device executes the following transitions: 1) When injecting an inductive voltage or in monitoring mode the device tends to inject a voltage proportional to the difference between the line current and the aforementioned threshold. 2) When injecting a capacitive voltage the device transitions to monitoring mode. \n- If the aforementioned proportional voltage is lower than the initial one, the voltage injection remains unchanged. \nCurrent droop override is not applied when the device operates in currentDroop mode." ;
+        rdfs:label              "CurrentDroopOverride"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:CurrentDroopOverride.enabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "True, if the current droop override is enabled (active). Otherwise false." ;
+        rdfs:domain        nc:CurrentDroopOverride ;
+        rdfs:label         "enabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CurrentDroopOverride.targetValueCapacitiveI
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Setpoint when control is active in capacitive region." ;
+        rdfs:domain        nc:CurrentDroopOverride ;
+        rdfs:label         "targetValueCapacitiveI"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:CurrentDroopOverride.targetValueInductiveI
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Setpoint when control is active in inductive region." ;
+        rdfs:domain        nc:CurrentDroopOverride ;
+        rdfs:label         "targetValueInductiveI"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCControlModeKind  rdf:type  rdfs:Class ;
+        rdfs:comment            "Kind of DC control mode." ;
+        rdfs:label              "DCControlModeKind"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:DCControlModeKind.acEmulation
+        rdf:type         nc:DCControlModeKind ;
+        rdfs:comment     "An AC emulation control aims to reproduce the behaviour of an AC line by means of a function of the difference between angles in both converter stations in DC links embedded within a single synchronous AC grid. For changes in the phase angle on either station, the response of this control is to ‘emulate the behaviour of an AC line’ in both steady and transient states. \nThe AC emulation control needs measurement signals for the angles at both ends of the DC system (at the AC points of common coupling of the DC system). In practice, the angle difference is measured by built-in devices in the converters and the synchronization of angle measurements on both stations is done by means of GPS.\nACEmulationControlFunction is used by this control. The control can only be applied by a controller that have access to the two AC points of common coupling of the DC system. Therefore it cannot be applied for a ACDCConverterController." ;
+        rdfs:label       "acEmulation"@en ;
+        cims:stereotype  "enum" .
+
+nc:DCControlModeKind.acVoltage
+        rdf:type         nc:DCControlModeKind ;
+        rdfs:comment     "AC voltage control mode (IEC 60633) is a control of the AC voltage of the AC network connected to a DC substation." ;
+        rdfs:label       "acVoltage"@en ;
+        cims:stereotype  "enum" .
+
+nc:DCControlModeKind.activePower
+        rdf:type         nc:DCControlModeKind ;
+        rdfs:comment     "Control is active power control at AC side, at point of common coupling. According to IEC 60633 the active power control mode is control of the active power flow exchanged between a DC substation and the connected AC network." ;
+        rdfs:label       "activePower"@en ;
+        cims:stereotype  "enum" .
+
+nc:DCControlModeKind.damping
+        rdf:type         nc:DCControlModeKind ;
+        rdfs:comment     "Damping control mode (IEC 60633) is supplementary control mode providing the damping of power oscillations in one or more connected AC networks." ;
+        rdfs:label       "damping"@en ;
+        cims:stereotype  "enum" .
+
+nc:DCControlModeKind.dcCurrent
+        rdf:type         nc:DCControlModeKind ;
+        rdfs:comment     "Control is DC current in a DC system (IEC 60633)." ;
+        rdfs:label       "dcCurrent"@en ;
+        cims:stereotype  "enum" .
+
+nc:DCControlModeKind.dcVoltage
+        rdf:type         nc:DCControlModeKind ;
+        rdfs:comment     "Control is DC voltage in a DC substation (IEC 60633)." ;
+        rdfs:label       "dcVoltage"@en ;
+        cims:stereotype  "enum" .
+
+nc:DCControlModeKind.frequency
+        rdf:type         nc:DCControlModeKind ;
+        rdfs:comment     "Frequency control mode (IEC 60633) is a control of the frequency of the connected AC network by varying the active power exchanged between a DC substation and the connected AC network." ;
+        rdfs:label       "frequency"@en ;
+        cims:stereotype  "enum" .
+
+nc:DCControlModeKind.islanded
+        rdf:type         nc:DCControlModeKind ;
+        rdfs:comment     "Islanded network operation mode (IEC 60633) is a control mode in which the DC substation is connected to an islanded AC network." ;
+        rdfs:label       "islanded"@en ;
+        cims:stereotype  "enum" .
+
+nc:DCControlModeKind.pPccAndUdcDroop
+        rdf:type         nc:DCControlModeKind ;
+        rdfs:comment     "Control is active power at point of common coupling and local DC voltage, with the droop." ;
+        rdfs:label       "pPccAndUdcDroop"@en ;
+        cims:stereotype  "enum" .
+
+nc:DCControlModeKind.pPccAndUdcDroopPilot
+        rdf:type         nc:DCControlModeKind ;
+        rdfs:comment     "Control is active power at point of common coupling and the pilot DC voltage, with the droop. The mode is used for Multi Terminal High Voltage DC (MTDC) systems where multiple DC Substations are connected to the DC transmission lines. The pilot voltage is then used to coordinate the control the DC voltage across the DC substations." ;
+        rdfs:label       "pPccAndUdcDroopPilot"@en ;
+        cims:stereotype  "enum" .
+
+nc:DCControlModeKind.pPccAndUdcDroopWithCompensation
+        rdf:type         nc:DCControlModeKind ;
+        rdfs:comment     "Control is active power at point of common coupling and compensated DC voltage, with the droop. Compensation factor is the resistance, as an approximation of the DC voltage of a common (real or virtual) node in the DC network." ;
+        rdfs:label       "pPccAndUdcDroopWithCompensation"@en ;
+        cims:stereotype  "enum" .
+
+nc:DCControlModeKind.phasePcc
+        rdf:type         nc:DCControlModeKind ;
+        rdfs:comment     "Control is phase at point of common coupling." ;
+        rdfs:label       "phasePcc"@en ;
+        cims:stereotype  "enum" .
+
+nc:DCControlModeKind.powerFactorPcc
+        rdf:type         nc:DCControlModeKind ;
+        rdfs:comment     "Control is power factor at point of common coupling." ;
+        rdfs:label       "powerFactorPcc"@en ;
+        cims:stereotype  "enum" .
+
+nc:DCControlModeKind.pulseWidthModulation
+        rdf:type         nc:DCControlModeKind ;
+        rdfs:comment     "No explicit control. Pulse-modulation factor is directly set in magnitude and phase." ;
+        rdfs:label       "pulseWidthModulation"@en ;
+        cims:stereotype  "enum" .
+
+nc:DCControlModeKind.reactivePower
+        rdf:type         nc:DCControlModeKind ;
+        rdfs:comment     "Control is reactive power control at AC side, at point of common coupling. According to IEC 60633 reactive power control mode is a control of the reactive power exchanged between a converter unit, or DC substation and the connected AC network." ;
+        rdfs:label       "reactivePower"@en ;
+        cims:stereotype  "enum" .
+
+nc:DCControlModeKind.sstiDamping
+        rdf:type         nc:DCControlModeKind ;
+        rdfs:comment     "Sub-synchronous torsional interaction (SSTI) damping control mode (IEC 60633) is a supplementary control mode providing the damping of critical frequencies of an (electrical) nearby generator." ;
+        rdfs:label       "sstiDamping"@en ;
+        cims:stereotype  "enum" .
+
+nc:DCCurrentControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "DC current control function is a function block that calculates the operating point of the controlled equipment  to achieve the target current." ;
+        rdfs:label              "DCCurrentControlFunction"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCCurrentControlFunction.targetValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Target value for the current that the control function is calculating to achieve by adjusting the operational setting to the controlled equipment." ;
+        rdfs:domain        nc:DCCurrentControlFunction ;
+        rdfs:label         "targetValue"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCPole  rdf:type             rdfs:Class ;
+        rdfs:comment            "The direct current (DC) system pole (IEC 60633) is part of a DC system consisting of all the equipment in the DC substations and the interconnecting transmission lines, if any, which during normal operation exhibit a common direct voltage polarity with respect to earth." ;
+        rdfs:label              "DCPole"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCPole.maxEconomicP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum high economic active power limit, that should not exceed the maximum operating active power limit." ;
+        rdfs:domain        nc:DCPole ;
+        rdfs:label         "maxEconomicP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCPole.minEconomicP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Low economic active power limit that shall be greater than or equal to the minimum operating active power limit." ;
+        rdfs:domain        nc:DCPole ;
+        rdfs:label         "minEconomicP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCPole.p  rdf:type      rdf:Property ;
+        rdfs:comment       "Active power injection. Load sign convention is used, i.e. positive sign means flow out from a node." ;
+        rdfs:domain        nc:DCPole ;
+        rdfs:label         "p"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCPole.participationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Participation factor describing the entity part of the active power provided by a collection of entities (e.g. an active power forecast to a collection of entities is divided to each of the member entity according to the participation factor). Must be a positive value.\nIn the case of a sharing strategy, the distribution is following entities value (V) equals aggregated value (T) divided by sum of participation factors (PF), i.e. V=T/sum(PF). \nIn the case of priority strategy, the item with the lowest number gets allocated energy first." ;
+        rdfs:domain        nc:DCPole ;
+        rdfs:label         "participationFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCSwitch  rdf:type           rdfs:Class ;
+        rdfs:comment            "A switch within the DC system." ;
+        rdfs:label              "DCSwitch"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCSwitch.locked  rdf:type  rdf:Property ;
+        rdfs:comment       "If true, the switch is locked. The resulting switch state is a combination of locked and DCSwitch.open attributes as follows:\n<ul>\n\t<li>locked=true and DCSwitch.open=true. The resulting state is open and locked;</li>\n\t<li>locked=false and DCSwitch.open=true. The resulting state is open;</li>\n\t<li>locked=false and DCSwitch.open=false. The resulting state is closed.</li>\n</ul>" ;
+        rdfs:domain        nc:DCSwitch ;
+        rdfs:label         "locked"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCSwitch.open  rdf:type  rdf:Property ;
+        rdfs:comment       "The attribute tells if the switch is considered open when used as input to topology processing." ;
+        rdfs:domain        nc:DCSwitch ;
+        rdfs:label         "open"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCTieCorridor  rdf:type      rdfs:Class ;
+        rdfs:comment            "A collection of one or more direct current poles that connect two different control areas." ;
+        rdfs:label              "DCTieCorridor"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCTieCorridor.p  rdf:type  rdf:Property ;
+        rdfs:comment       "Active power at the point of common coupling. Load sign convention is used, i.e. positive sign means flow out from a node.\nStarting value for a steady state solution in the case a simplified power flow model is used." ;
+        rdfs:domain        nc:DCTieCorridor ;
+        rdfs:label         "p"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCTieCorridor.q  rdf:type  rdf:Property ;
+        rdfs:comment       "Reactive power at the point of common coupling. Load sign convention is used, i.e. positive sign means flow out from a node.\nStarting value for a steady state solution in the case a simplified power flow model is used." ;
+        rdfs:domain        nc:DCTieCorridor ;
+        rdfs:label         "q"@en ;
+        cims:dataType      cim:ReactivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DCVoltageControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "DC voltage control function is a function block that calculate the operating point of the controlled equipment to achieve the target voltage." ;
+        rdfs:label              "DCVoltageControlFunction"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DCVoltageControlFunction.targetValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Target value for the voltage that the control function is calculating to achieve by adjusting the operational setting to the controlled equipment." ;
+        rdfs:domain        nc:DCVoltageControlFunction ;
+        rdfs:label         "targetValue"@en ;
+        cims:dataType      cim:Voltage ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:DirectCurrentEquipmentController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Direct current equipment controller used to control different parts of the hierarchical structure of the DC control system defined by IEC 60633." ;
+        rdfs:label              "DirectCurrentEquipmentController"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:DirectCurrentEquipmentController.mode
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Mode of the dc controller." ;
+        rdfs:domain        nc:DirectCurrentEquipmentController ;
+        rdfs:label         "mode"@en ;
+        rdfs:range         nc:DCControlModeKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EnergyBlockOrder  rdf:type   rdfs:Class ;
+        rdfs:comment            "The energy block order is a block (an amount) of energy that forms the sequence of orders that are going to be distributed to an energy block component." ;
+        rdfs:label              "EnergyBlockOrder"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EnergyBlockOrder.p
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The maximum active power that can be applied as part of this block order." ;
+        rdfs:domain        nc:EnergyBlockOrder ;
+        rdfs:label         "p"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EnergyBlockOrder.participationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Participation factor." ;
+        rdfs:domain        nc:EnergyBlockOrder ;
+        rdfs:label         "participationFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EnergyBlockOrder.sequence
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Sequence needs to be ordered by the scheduling area. It has to be unique by the scheduling area." ;
+        rdfs:domain        nc:EnergyBlockOrder ;
+        rdfs:label         "sequence"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EnergyConsumer.participationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Participation factor describing the entity part of the active power provided by a collection of entities (e.g. an active power forecast to a collection of entities is divided to each of the member entity according to the participation factor). Must be a positive value.\nIn the case of a sharing strategy, the distribution is following entities value (V) equals aggregated value (T) divided by sum of participation factors (PF), i.e. V=T/sum(PF). \nIn the case of priority strategy, the item with the lowest number gets allocated energy first." ;
+        rdfs:domain        cim:EnergyConsumer ;
+        rdfs:label         "participationFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EnergyGroup  rdf:type        rdfs:Class ;
+        rdfs:comment            "An energy group is an aggregation of energy components which have the same energy characteristic, e.g. fuel type and technology. It can be used to allocate energy. " ;
+        rdfs:label              "EnergyGroup"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:EnergyGroup.p  rdf:type  rdf:Property ;
+        rdfs:comment       "Active power for the energy group representing a particular energy type. e.g. WInd Power" ;
+        rdfs:domain        nc:EnergyGroup ;
+        rdfs:label         "p"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:EnergyGroup.participationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Participation factor for the power group in relation to scheduling area. Must be a positive value." ;
+        rdfs:domain        nc:EnergyGroup ;
+        rdfs:label         "participationFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:FACTSEquipment  rdf:type     rdfs:Class ;
+        rdfs:comment            "Flexible Alternating Current Transmission System regulating equipment." ;
+        rdfs:label              "FACTSEquipment"@en ;
+        rdfs:subClassOf         cim:RegulatingCondEq ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "NC" .
+
+nc:FACTSEquipment.q  rdf:type  rdf:Property ;
+        rdfs:comment       "Reactive power injection. Load sign convention is used, i.e. positive sign means flow out from a node.\nStarting value for a steady state solution." ;
+        rdfs:domain        nc:FACTSEquipment ;
+        rdfs:label         "q"@en ;
+        cims:dataType      cim:ReactivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:FrequencyControlFuntion
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Frequency control function is a function block that calculate the operating point of the controlled equipment to achieve the target frequency." ;
+        rdfs:label              "FrequencyControlFuntion"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:FrequencyControlFuntion.frequencyBias
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Target value for the active power that the control function is calculating to achieve by adjusting the operational setting to the controlled equipment." ;
+        rdfs:domain        nc:FrequencyControlFuntion ;
+        rdfs:label         "frequencyBias"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:FrequencyControlFuntion.targetValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Target value for the frequency that the control function is calculating to achieve by adjusting the operational setting to the controlled equipment." ;
+        rdfs:domain        nc:FrequencyControlFuntion ;
+        rdfs:label         "targetValue"@en ;
+        cims:dataType      cim:Frequency ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:FuelStorage  rdf:type        rdfs:Class ;
+        rdfs:comment            "Fuel storage. e.g. pile of coal that can be shared between multiple thermal generating units." ;
+        rdfs:label              "FuelStorage"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:FuelStorage.energyStorage
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Amount of energy available in the storage." ;
+        rdfs:domain        nc:FuelStorage ;
+        rdfs:label         "energyStorage"@en ;
+        cims:dataType      cim:RealEnergy ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:FunctionBlock  rdf:type      rdfs:Class ;
+        rdfs:comment            "Function block is a function described as a set of elementary blocks. The blocks describe the function between input variables and output variables." ;
+        rdfs:label              "FunctionBlock"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" .
+
+nc:FunctionBlock.enabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "True, if the function block is enabled (active). Otherwise false." ;
+        rdfs:domain        nc:FunctionBlock ;
+        rdfs:label         "enabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GeneratingUnit.mustRun
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Identifies if the generating unit is a must-run unit. This means that it cannot be instructed to shutdown due to other obligation. e.g. Providing heat. If true, the generating unit is must-run. If false, it is not." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "mustRun"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GeneratingUnit.mustRunP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Minimum active power injection that is needed to meet must-run requirement. This value can be higher or equal to minimum operational limit. Load sign convention is used, i.e. positive sign means flow out from a node." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "mustRunP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GeneratingUnit.mustRunQ
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Minimum reactive power injection that is needed to meet must-run requirement. This value can be higher or equal to minimum operational limit. Load sign convention is used, i.e. positive sign means flow out from a node." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "mustRunQ"@en ;
+        cims:dataType      cim:ReactivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GeneratingUnit.participationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Participation factor describing the entity part of the active power provided by a collection of entities (e.g. an active power forecast to a collection of entities is divided to each of the member entity according to the participation factor). Must be a positive value.\nIn the case of a sharing strategy, the distribution is following entities value (V) equals aggregated value (T) divided by sum of participation factors (PF), i.e. V=T/sum(PF). \nIn the case of priority strategy, the item with the lowest number gets allocated energy first." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "participationFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GeneratingUnit.warmStartupCost
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The warm startup cost incurred for each start of the GeneratingUnit." ;
+        rdfs:domain        cim:GeneratingUnit ;
+        rdfs:label         "warmStartupCost"@en ;
+        cims:dataType      cim:Money ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GridStateAlteration
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Grid state alteration is a change of values describing state (operating point) of one element in the grid model compared to the base case." ;
+        rdfs:label              "GridStateAlteration"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" .
+
+nc:GridStateAlteration.enabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The status of the GridStateAlteration set by an operation or by a signal resulting from a control action." ;
+        rdfs:domain        nc:GridStateAlteration ;
+        rdfs:label         "enabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GridStateAlteration.participationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Participation factor describing the entity part of the active power provided by a collection of entities (e.g. an active power forecast to a collection of entities is divided to each of the member entity according to the participation factor). Must be a positive value.\nIn the case of a sharing strategy, the distribution is following entities value (V) equals aggregated value (T) divided by sum of participation factors (PF), i.e. V=T/sum(PF). \nIn the case of priority strategy, the item with the lowest number gets allocated energy first.\ne.g. If 0 this grid alteration does not participate. The sum of all participation factors for all grid state alterations associated with same remedial action shall be equal to 100%." ;
+        rdfs:domain        nc:GridStateAlteration ;
+        rdfs:label         "participationFactor"@en ;
+        cims:dataType      cim:PerCent ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:GridStateAlterationRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Grid state alteration remedial action describes one or many grid state alterations applied to a grid model state or a particular scenario in order to resolve one or more identified constraints. " ;
+        rdfs:label              "GridStateAlterationRemedialAction"@en ;
+        rdfs:subClassOf         nc:RemedialAction ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:HydroPump.participationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Participation factor describing the entity part of the active power provided by a collection of entities (e.g. an active power forecast to a collection of entities is divided to each of the member entity according to the participation factor). Must be a positive value.\nIn the case of a sharing strategy, the distribution is following entities value (V) equals aggregated value (T) divided by sum of participation factors (PF), i.e. V=T/sum(PF). \nIn the case of priority strategy, the item with the lowest number gets allocated energy first." ;
+        rdfs:domain        cim:HydroPump ;
+        rdfs:label         "participationFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ImpedanceControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Impedance control function is a function block that calculates the operating point of the controlled equipment to achieve the target impedance." ;
+        rdfs:label              "ImpedanceControlFunction"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ImpedanceControlFunction.targetValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Target value for the impedance that the control function is calculating to achieve by adjusting the operational setting to the controlled equipment." ;
+        rdfs:domain        nc:ImpedanceControlFunction ;
+        rdfs:label         "targetValue"@en ;
+        cims:dataType      cim:Impedance ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:InfeedLimit  rdf:type        rdfs:Class ;
+        rdfs:comment            "Infeed limit set constraints fed in to the network by two or more terminals." ;
+        rdfs:label              "InfeedLimit"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:InfeedLimit.valueA
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Value of current limit. The attribute shall be a positive value or zero." ;
+        rdfs:domain        nc:InfeedLimit ;
+        rdfs:label         "valueA"@en ;
+        cims:dataType      cim:CurrentFlow ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:InfeedLimit.valueW
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Value of active power limit. The attribute shall be a positive value or zero." ;
+        rdfs:domain        nc:InfeedLimit ;
+        rdfs:label         "valueW"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:InjectionControlModeKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of injection controller mode." ;
+        rdfs:label              "InjectionControlModeKind"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:InjectionControlModeKind.activePower
+        rdf:type         nc:InjectionControlModeKind ;
+        rdfs:comment     "Active power is specified." ;
+        rdfs:label       "activePower"@en ;
+        cims:stereotype  "enum" .
+
+nc:InjectionControlModeKind.powerFactor
+        rdf:type         nc:InjectionControlModeKind ;
+        rdfs:comment     "Power factor is specified." ;
+        rdfs:label       "powerFactor"@en ;
+        cims:stereotype  "enum" .
+
+nc:InjectionControlModeKind.reactivePower
+        rdf:type         nc:InjectionControlModeKind ;
+        rdfs:comment     "Reactive power control." ;
+        rdfs:label       "reactivePower"@en ;
+        cims:stereotype  "enum" .
+
+nc:InjectionControlModeKind.voltage
+        rdf:type         nc:InjectionControlModeKind ;
+        rdfs:comment     "Voltage control." ;
+        rdfs:label       "voltage"@en ;
+        cims:stereotype  "enum" .
+
+nc:InjectionController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Injection controller is controlling the equipment which represents an injection or an external network." ;
+        rdfs:label              "InjectionController"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:InjectionController.mode
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Mode of the injection controller." ;
+        rdfs:domain        nc:InjectionController ;
+        rdfs:label         "mode"@en ;
+        rdfs:range         nc:InjectionControlModeKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ModularStaticSynchronousSeriesCompensator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Modular static synchronous series compensator (MSSSC) is a type of flexible AC transmission system regulating equipment which consists of solid-state voltage source inverter connected in series with a transmission line. This is similar to static synchronous series compensator (SSSC), but without injection transformer. This enables the MSSSC to be truly modular with the ability to simply install a number of equipment in series to provide a desired maximum level of impedance. MSSSC can be dispersed into multiple location in a circuit working collectively under the same controller scheme." ;
+        rdfs:label              "ModularStaticSynchronousSeriesCompensator"@en ;
+        rdfs:subClassOf         nc:FACTSEquipment ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PTCActivePowerSupport
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Defines the active power capability (support) of the scheme in relation to a PowerTransferCorridor." ;
+        rdfs:label              "PTCActivePowerSupport"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PTCActivePowerSupport.value
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The support that a System Integrity Protection Scheme (SIPS) gives to a Power Transfer Corridor (PTC)." ;
+        rdfs:domain        nc:PTCActivePowerSupport ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PhaseControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Phase control function is a function block that calculate the operating point of the controlled equipment to achieve the target voltage." ;
+        rdfs:label              "PhaseControlFunction"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PhaseControlFunction.targetValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Target value for the phase that the control function is calculating to achieve by adjusting the operational setting to the controlled equipment." ;
+        rdfs:domain        nc:PhaseControlFunction ;
+        rdfs:label         "targetValue"@en ;
+        cims:dataType      cim:AngleDegrees ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerCapacity  rdf:type      rdfs:Class ;
+        rdfs:comment            "Power capacity defines the capacity in regard to generation, consumption and transmission (import and export) for a relevant power system resource, e.g. bidding zone, including maximum and minimum electrical power capacity and any capacity allocation." ;
+        rdfs:label              "PowerCapacity"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerCapacity.maxInterchange
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum total active power (AC and DC)  that the net position for the bidding zone can have to maintain operational security. Positive sign means flow into the bidding zone." ;
+        rdfs:domain        nc:PowerCapacity ;
+        rdfs:label         "maxInterchange"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerCapacity.minImportP
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Minimum imported active power requirement." ;
+        rdfs:domain        nc:PowerCapacity ;
+        rdfs:label         "minImportP"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerCapacity.minInterchange
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Minimum total active power (AC and DC)  that the net position for the bidding zone can have to maintain operational security. Negative sign means flow out of the bidding zone." ;
+        rdfs:domain        nc:PowerCapacity ;
+        rdfs:label         "minInterchange"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerCapacity.netACInterchange
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The netted aggregation of all AC external schedules of an area. Positive sign means flow into the area (Import)." ;
+        rdfs:domain        nc:PowerCapacity ;
+        rdfs:label         "netACInterchange"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerCapacity.netACInterchangeTolerance
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The area AC Net Position tolerance." ;
+        rdfs:domain        nc:PowerCapacity ;
+        rdfs:label         "netACInterchangeTolerance"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerCapacity.netDCInterchange
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The netted aggregation of all DC external schedules of an area. Positive sign means flow into the area." ;
+        rdfs:domain        nc:PowerCapacity ;
+        rdfs:label         "netDCInterchange"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerCapacity.regulatingDownAllocation
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The balancing capacity allocated for regulating down, by decreasing the production, increasing the direct current export, decreasing direct current import or increasing the consumption of energy in the bidding zone. This must be a positive number." ;
+        rdfs:domain        nc:PowerCapacity ;
+        rdfs:label         "regulatingDownAllocation"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerCapacity.regulatingUpAllocation
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The balancing capacity allocated for regulating up, by increasing the production, decreasing the direct current export, increasing direct current import or reducing the consumption of energy in the bidding zone. This must be a positive number." ;
+        rdfs:domain        nc:PowerCapacity ;
+        rdfs:label         "regulatingUpAllocation"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerElectronicsUnit.p
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Active power injection. Load sign convention is used, i.e. positive sign means flow out from a node.\nStarting value for a steady state solution." ;
+        rdfs:domain        cim:PowerElectronicsUnit ;
+        rdfs:label         "p"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerElectronicsUnit.participationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Participation factor describing the entity part of the active power provided by a collection of entities (e.g. an active power forecast to a collection of entities is divided to each of the member entity according to the participation factor). Must be a positive value.\nIn the case of a sharing strategy, the distribution is following entities value (V) equals aggregated value (T) divided by sum of participation factors (PF), i.e. V=T/sum(PF). \nIn the case of priority strategy, the item with the lowest number gets allocated energy first." ;
+        rdfs:domain        cim:PowerElectronicsUnit ;
+        rdfs:label         "participationFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerFactorControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Power factor control function is a function block that calculates the operating point of the controlled equipment to achieve the target power factor." ;
+        rdfs:label              "PowerFactorControlFunction"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerFactorControlFunction.targetValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Target value for the power factor that the control function is calculating to achieve by adjusting the operational setting to the controlled equipment." ;
+        rdfs:domain        nc:PowerFactorControlFunction ;
+        rdfs:label         "targetValue"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Energy remedial action describes actions to rearrange power schedules." ;
+        rdfs:label              "PowerRemedialAction"@en ;
+        rdfs:subClassOf         nc:RemedialAction ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "NC" .
+
+nc:PowerRemedialAction.maxRegulatingDown
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum net amount of active power that the remedial action can regulate down." ;
+        rdfs:domain        nc:PowerRemedialAction ;
+        rdfs:label         "maxRegulatingDown"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerRemedialAction.maxRegulatingUp
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum net amount of active power that the remedial action can regulate up." ;
+        rdfs:domain        nc:PowerRemedialAction ;
+        rdfs:label         "maxRegulatingUp"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerShiftKeyStrategy
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Strategy of the power shift key." ;
+        rdfs:label              "PowerShiftKeyStrategy"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerShiftKeyStrategy.enabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "If true, the assessed element is enabled, otherwise it is disabled." ;
+        rdfs:domain        nc:PowerShiftKeyStrategy ;
+        rdfs:label         "enabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerShiftKeyStrategy.participationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Participation factor describing the entities part of the power shift strategy. Must be a positive value." ;
+        rdfs:domain        nc:PowerShiftKeyStrategy ;
+        rdfs:label         "participationFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:PowerTransferCorridor
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A power transfer corridor is defined as a set of circuits (transmission lines or transformers) separating two portions of the power system, or a subset of circuits exposed to a substantial portion of the transmission exchange between two parts of the system." ;
+        rdfs:label              "PowerTransferCorridor"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:PowerTransferCorridor.enabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "It enables/disables the monitoring/assessment of a power transfer corridor. True means that the monitoring of the power transfer corridor is assessed. False means the power transfer corridor is not assessed. " ;
+        rdfs:domain        nc:PowerTransferCorridor ;
+        rdfs:label         "enabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RangeConstraint  rdf:type    rdfs:Class ;
+        rdfs:comment            "Defines the rage constraint." ;
+        rdfs:label              "RangeConstraint"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" .
+
+nc:RangeConstraint.value
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The value at the time. The meaning of the value is defined by the attribute referenced by the PropertyReference. The value can be integer, float or boolean. In case of boolean 1 equals true and 0 equals false. \nIf the valueKind is incremental or incrementalPercentage, then the value shall be positive (greater than zero).\nIf the valueKind is incrementalPercentage, then the value shall be in the range [0, 100]." ;
+        rdfs:domain        nc:RangeConstraint ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ReactivePowerControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Reactive power control function is a function block that calculate the operating point of the controlled equipment to achieve the target reactive power." ;
+        rdfs:label              "ReactivePowerControlFunction"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ReactivePowerControlFunction.targetValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Target value for the reactive power that the control function is calculating to achieve by adjusting the operational setting to the controlled equipment." ;
+        rdfs:domain        nc:ReactivePowerControlFunction ;
+        rdfs:label         "targetValue"@en ;
+        cims:dataType      cim:ReactivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RedispatchRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Redispatch remedial action is a remedial action that through rearranging power schedules is eliminating breaches of constraints." ;
+        rdfs:label              "RedispatchRemedialAction"@en ;
+        rdfs:subClassOf         nc:PowerRemedialAction ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RemedialAction  rdf:type     rdfs:Class ;
+        rdfs:comment            "Remedial action describes one or more actions that can be performed on a given power system model situation to eliminate one or more identified breaches of constraints. The remedial action can be costly, and have a cost characteristic, or non costly. " ;
+        rdfs:label              "RemedialAction"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "NC" .
+
+nc:RemedialAction.available
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Identifies if the remedial action is available to be proposed. True means available, False means unavailable." ;
+        rdfs:domain        nc:RemedialAction ;
+        rdfs:label         "available"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionDependency
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Remedial action dependency is making two remedial actions depending on each other. Multiple dependency is done by multiple instances of this class. The dependency can arrive by having one of the following examples.\n<ul>\n\t<li>The dependent remedial action is controlled by different system operator (Modeling Authority)  (e.g. SIPS that goes across control area).</li>\n\t<li>The dependent remedial action is representing  two or more remedial action that represent the same grid state alteration but with different modeling resolution (e.g. detail direct current model versus a simplified model).</li>\n\t<li>The remedial action can be combined with other remedial action without the need to create multiple remedial action with the same grid alteration for enabling dependency.</li>\n</ul>" ;
+        rdfs:label              "RemedialActionDependency"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RemedialActionDependency.enabled
+        rdf:type           rdf:Property ;
+        rdfs:comment       "If true, the remedial action dependency is enabled, otherwise it is disabled." ;
+        rdfs:domain        nc:RemedialActionDependency ;
+        rdfs:label         "enabled"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionGroup
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Grouping of remedial actions that can be operated together." ;
+        rdfs:label              "RemedialActionGroup"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RemedialActionGroup.maxRegulatingDown
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum net amount of active power that the group of remedial actions can regulate down." ;
+        rdfs:domain        nc:RemedialActionGroup ;
+        rdfs:label         "maxRegulatingDown"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionGroup.maxRegulatingUp
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Maximum net amount of active power that the group of remedial actions can regulate up." ;
+        rdfs:domain        nc:RemedialActionGroup ;
+        rdfs:label         "maxRegulatingUp"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionScheme
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Remedial Action Scheme (RAS), Special Protection Schemes (SPS), System Protection Schemes (SPS) or System Integrity Protection Schemes (SIPS).\nA Remedial Action Scheme consists of one or more stages that can trigger and execute a protection action." ;
+        rdfs:label              "RemedialActionScheme"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RemedialActionScheme.armed
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Defines the arming status of the remedial action scheme. It is set by operation or by signal." ;
+        rdfs:domain        nc:RemedialActionScheme ;
+        rdfs:label         "armed"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RemedialActionScheme.inService
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Specifies the availability of the Remedial Action Scheme (RAS). If true, the RAS is available for contingency processing. If false, the RAS is treated by contingency processing as if it is not in the model." ;
+        rdfs:domain        nc:RemedialActionScheme ;
+        rdfs:label         "inService"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:Reservoir.energyStorage
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Amount of energy available in the storage." ;
+        rdfs:domain        cim:Reservoir ;
+        rdfs:label         "energyStorage"@en ;
+        cims:dataType      cim:RealEnergy ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:RotatingMachineControlModeKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of rotating machine controller mode." ;
+        rdfs:label              "RotatingMachineControlModeKind"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+nc:RotatingMachineControlModeKind.activePower
+        rdf:type         nc:RotatingMachineControlModeKind ;
+        rdfs:comment     "Active power is specified." ;
+        rdfs:label       "activePower"@en ;
+        cims:stereotype  "enum" .
+
+nc:RotatingMachineControlModeKind.powerFactor
+        rdf:type         nc:RotatingMachineControlModeKind ;
+        rdfs:comment     "Power factor is specified." ;
+        rdfs:label       "powerFactor"@en ;
+        cims:stereotype  "enum" .
+
+nc:RotatingMachineControlModeKind.reactivePower
+        rdf:type         nc:RotatingMachineControlModeKind ;
+        rdfs:comment     "Reactive power control." ;
+        rdfs:label       "reactivePower"@en ;
+        cims:stereotype  "enum" .
+
+nc:RotatingMachineControlModeKind.voltage
+        rdf:type         nc:RotatingMachineControlModeKind ;
+        rdfs:comment     "Voltage control." ;
+        rdfs:label       "voltage"@en ;
+        cims:stereotype  "enum" .
+
+nc:RotatingMachineController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Rotating machine controller is controlling the equipment which may be used as a generator or motor." ;
+        rdfs:label              "RotatingMachineController"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:RotatingMachineController.mode
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Mode of the rotating machine controller." ;
+        rdfs:domain        nc:RotatingMachineController ;
+        rdfs:label         "mode"@en ;
+        rdfs:range         nc:RotatingMachineControlModeKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SSSCControlModeKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Control modes of the Static Synchronous Series Compensator (SSSC)." ;
+        rdfs:label              "SSSCControlModeKind"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:SSSCControlModeKind.currentDroop
+        rdf:type         nc:SSSCControlModeKind ;
+        rdfs:comment     "<font color=\"#636671\">The device injects a voltage proportional to the difference between the line current and the target value of the CurrentDroopControlFunction. There are capacitive and inductive operational regions.</font>" ;
+        rdfs:label       "currentDroop"@en ;
+        cims:stereotype  "enum" .
+
+nc:SSSCControlModeKind.effectiveReactance
+        rdf:type         nc:SSSCControlModeKind ;
+        rdfs:comment     "<font color=\"#636671\">The device injects a voltage proportional to the line current to achieve the specified target value defined by the ImpedanceControlFunction. The voltage will vary according to the line current level.</font>" ;
+        rdfs:label       "effectiveReactance"@en ;
+        cims:stereotype  "enum" .
+
+nc:SSSCControlModeKind.monitoring
+        rdf:type         nc:SSSCControlModeKind ;
+        rdfs:comment     "<font color=\"#636671\">The device bypasses and a voltage injection is close to zero. In monitoring mode current is monitored.</font>" ;
+        rdfs:label       "monitoring"@en ;
+        cims:stereotype  "enum" .
+
+nc:SSSCControlModeKind.voltageInjection
+        rdf:type         nc:SSSCControlModeKind ;
+        rdfs:comment     "<font color=\"#636671\">The device injects a fixed voltage that is either inductive or capacitive according to the specified target value of the VoltageInjectionControlFunction. The effective reactance varies according to the flow of the line current.</font>" ;
+        rdfs:label       "voltageInjection"@en ;
+        cims:stereotype  "enum" .
+
+nc:SSSCController  rdf:type     rdfs:Class ;
+        rdfs:comment            "The controller of a Static synchronous series compensator (SSSC)." ;
+        rdfs:label              "SSSCController"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SSSCController.mode
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Mode of the Static Synchronous Series compensator controller." ;
+        rdfs:domain        nc:SSSCController ;
+        rdfs:label         "mode"@en ;
+        rdfs:range         nc:SSSCControlModeKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ScheduleResource  rdf:type   rdfs:Class ;
+        rdfs:comment            "A schedule resource is a market-based method for handling participation of small units, particularly located on the lower voltage level that is controlled by a Distributed System Operator (DSO). It is a collection of units that can operate in the market by providing bids, offers and a resulting committed operational schedule for the collection." ;
+        rdfs:label              "ScheduleResource"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ScheduleResource.p
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Active power injection. Load sign convention is used, i.e. positive sign means flow out from a node." ;
+        rdfs:domain        nc:ScheduleResource ;
+        rdfs:label         "p"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ScheduleResource.participationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Participation factor describing the entity part of the active power provided by a collection of entities (e.g. an active power forecast to a collection of entities is divided to each of the member entity according to the participation factor). Must be a positive value.\nIn the case of a sharing strategy, the distribution is following entities value (V) equals aggregated value (T) divided by sum of participation factors (PF), i.e. V=T/sum(PF). \nIn the case of priority strategy, the item with the lowest number gets allocated energy first." ;
+        rdfs:domain        nc:ScheduleResource ;
+        rdfs:label         "participationFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SchedulingArea  rdf:type     rdfs:Class ;
+        rdfs:comment            "An area where production and/or consumption of energy can be forecasted, scheduled and measured. The area is operated by only one system operator, typically a Transmission System Operator (TSO). The area can consist of a sub area, which has the same definition as the main area, but it can be operated by another system operator (typically Distributed System Operator (DSO) or a Closed Distributed System Operator (CDSO)). This includes microgrid concept. A substation is the smallest grouping that can be included in the area. The area size should be considered in terms of the possibility of accumulated reading (settlement metering) and the capability of operating as an island." ;
+        rdfs:label              "SchedulingArea"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SchedulingArea.p  rdf:type  rdf:Property ;
+        rdfs:comment       "Netted active power representing production, consumption and import/export for the scheduling area. " ;
+        rdfs:domain        nc:SchedulingArea ;
+        rdfs:label         "p"@en ;
+        cims:dataType      cim:ActivePower ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SchedulingArea.participationFactor
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Participation factor describing the entity part of the active power provided by a collection of entities (e.g. an active power forecast to a collection of entities is divided to each of the member entity according to the participation factor). Must be a positive value.\nIn the case of a sharing strategy, the distribution is following entities value (V) equals aggregated value (T) divided by sum of participation factors (PF), i.e. V=T/sum(PF). \nIn the case of priority strategy, the item with the lowest number gets allocated energy first." ;
+        rdfs:domain        nc:SchedulingArea ;
+        rdfs:label         "participationFactor"@en ;
+        cims:dataType      cim:Float ;
+        cims:multiplicity  cims:M:0..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SchemeRemedialAction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Scheme remedial action is remedial action that involves a scheme that can include conditional logic and stages of grid alteration. The primary remedial action is the arming of these schemes, that will then perform curative remedial action when the condition is met. System Integrity Protection Scheme (SIPS) and Special Protection Scheme (SPS) are example of this. " ;
+        rdfs:label              "SchemeRemedialAction"@en ;
+        rdfs:subClassOf         nc:RemedialAction ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:StageTrigger  rdf:type       rdfs:Class ;
+        rdfs:comment            "Stage that is triggered either by TriggerCondition or by gate condition within a stage." ;
+        rdfs:label              "StageTrigger"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:StageTrigger.armed
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The status of the class set by operation or by signal. Optional field that will override other status fields." ;
+        rdfs:domain        nc:StageTrigger ;
+        rdfs:label         "armed"@en ;
+        cims:dataType      cim:Boolean ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:StaticSynchronousCompensator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Static synchronous compensator (STATCOM), also known as a static synchronous condenser (STATCON), is a type of flexible AC transmission system regulating equipment used on alternating current electricity transmission networks. It is based on a power electronics voltage-source converter and can act as either a source or sink of reactive AC power to an electricity network. If connected to a source of power it can also provide active AC power." ;
+        rdfs:label              "StaticSynchronousCompensator"@en ;
+        rdfs:subClassOf         nc:FACTSEquipment ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:StaticSynchronousSeriesCompensator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Static synchronous series compensator (SSSC) is a type of flexible AC transmission system which consists of a solid-state voltage source inverter coupled with a transformer that is connected in series with a transmission line. This device can inject an almost sinusoidal voltage in series with the line. This injected voltage could be considered as an inductive or capacitive reactance, which is connected in series with the transmission line. This feature can provide controllable voltage compensation. In addition, SSSC is able to reverse the power flow by injecting a sufficiently large series reactive compensating voltage. Moreover it can inject a voltage proportional to the difference between the line current and the pre-configured current threshold.<font color=\"#636671\"> </font>It shall have two Terminal-s associated with it. " ;
+        rdfs:label              "StaticSynchronousSeriesCompensator"@en ;
+        rdfs:subClassOf         nc:FACTSEquipment ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:StaticVarCompensator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A facility for providing variable and controllable shunt reactive power. The SVC typically consists of a stepdown transformer, filter, thyristor-controlled reactor, and thyristor-switched capacitor arms.\n\nThe SVC may operate in fixed MVar output mode or in voltage control mode. When in voltage control mode, the output of the SVC will be proportional to the deviation of voltage at the controlled bus from the voltage setpoint.  The SVC characteristic slope defines the proportion.  If the voltage at the controlled bus is equal to the voltage setpoint, the SVC MVar output is zero." ;
+        rdfs:label              "StaticVarCompensator"@en ;
+        rdfs:subClassOf         nc:FACTSEquipment ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SubstationController
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Substation controller is controlling the equipment to optimize the use of the controlling equipment within a substation. " ;
+        rdfs:label              "SubstationController"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:SubstationController.mode
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Mode of the substation controller." ;
+        rdfs:domain        nc:SubstationController ;
+        rdfs:label         "mode"@en ;
+        rdfs:range         nc:SubstationControllerModeKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:SubstationControllerModeKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of substation controller mode." ;
+        rdfs:label              "SubstationControllerModeKind"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:SubstationControllerModeKind.activePower
+        rdf:type         nc:SubstationControllerModeKind ;
+        rdfs:comment     "Active power control is the primary control of the substation.." ;
+        rdfs:label       "activePower"@en ;
+        cims:stereotype  "enum" .
+
+nc:SubstationControllerModeKind.reactivePower
+        rdf:type         nc:SubstationControllerModeKind ;
+        rdfs:comment     "Reactive power control is the primary control of the substation." ;
+        rdfs:label       "reactivePower"@en ;
+        cims:stereotype  "enum" .
+
+nc:SubstationControllerModeKind.voltage
+        rdf:type         nc:SubstationControllerModeKind ;
+        rdfs:comment     "Voltage control is the primary control of the substation." ;
+        rdfs:label       "voltage"@en ;
+        cims:stereotype  "enum" .
+
+nc:TCSCControlModeKind
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Kind of TCSC control mode." ;
+        rdfs:label              "TCSCControlModeKind"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#enumeration> .
+
+nc:TCSCControlModeKind.activePower
+        rdf:type         nc:TCSCControlModeKind ;
+        rdfs:comment     "Control is active power." ;
+        rdfs:label       "activePower"@en ;
+        cims:stereotype  "enum" .
+
+nc:TCSCControlModeKind.current
+        rdf:type         nc:TCSCControlModeKind ;
+        rdfs:comment     "Control is current." ;
+        rdfs:label       "current"@en ;
+        cims:stereotype  "enum" .
+
+nc:TCSCControlModeKind.impedance
+        rdf:type         nc:TCSCControlModeKind ;
+        rdfs:comment     "Control is impedance." ;
+        rdfs:label       "impedance"@en ;
+        cims:stereotype  "enum" .
+
+nc:TCSCController  rdf:type     rdfs:Class ;
+        rdfs:comment            "TCSC controller is controlling the equipment to optimize the performance of the TCSC. " ;
+        rdfs:label              "TCSCController"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:TCSCController.mode
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Mode of the TCSC controller." ;
+        rdfs:domain        nc:TCSCController ;
+        rdfs:label         "mode"@en ;
+        rdfs:range         nc:TCSCControlModeKind ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ThyristorControlledSeriesCompensator
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Thyristor-controlled series capacitors (TCSC) is a type of flexible AC transmission system regulating equipment that is configured with controlled reactors in parallel with sections of a capacitor bank. This combination allows smooth control of the fundamental frequency capacitive reactance over a wide range. The thyristor valve contains a string of series connected high power thyristors. TCSC can control power flows in order to achieve eliminating of line overloads, reducing loop flows and minimising system losses." ;
+        rdfs:label              "ThyristorControlledSeriesCompensator"@en ;
+        rdfs:subClassOf         nc:FACTSEquipment ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:ThyristorControlledSeriesCompensator.compensationZ
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The actual compensation impedance provided by the compensator. The attribute value shall be positive if compensation is in the capacitive range. The attribute value shall be negative if compensation is in the inductive rating." ;
+        rdfs:domain        nc:ThyristorControlledSeriesCompensator ;
+        rdfs:label         "compensationZ"@en ;
+        cims:dataType      cim:Impedance ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:ThyristorControlledSeriesCompensator.currentSection
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The current section on which the TCSC is operating." ;
+        rdfs:domain        nc:ThyristorControlledSeriesCompensator ;
+        rdfs:label         "currentSection"@en ;
+        cims:dataType      cim:Integer ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VoltageAngleLimit  rdf:type  rdfs:Class ;
+        rdfs:comment            "Voltage angle limit between two terminals. The association end OperationalLimitSet.Terminal defines one end and the host of the limit. The association end VoltageAngleLimit.AngleReferenceTerminal defines the reference terminal." ;
+        rdfs:label              "VoltageAngleLimit"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:VoltageAngleLimit.value
+        rdf:type           rdf:Property ;
+        rdfs:comment       "The difference in angle degrees between referenced by the association end OperationalLimitSet.Terminal and the Terminal referenced by the association end VoltageAngleLimit.AngleReferenceTerminal. The value shall be positive (greater than zero)." ;
+        rdfs:domain        nc:VoltageAngleLimit ;
+        rdfs:label         "value"@en ;
+        cims:dataType      cim:AngleDegrees ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VoltageControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Voltage control function is a function block that calculate the operating point of the controlled equipment to achieve the target voltage." ;
+        rdfs:label              "VoltageControlFunction"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:VoltageControlFunction.targetValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Target value for the voltage that the control function is calculating to achieve by adjusting the operational setting to the controlled equipment." ;
+        rdfs:domain        nc:VoltageControlFunction ;
+        rdfs:label         "targetValue"@en ;
+        cims:dataType      cim:Voltage ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+nc:VoltageInjectionControlFunction
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "Voltage injection control function is a function block that calculates the operating point of the controlled equipment to achieve the target voltage injection. The controlled point is the Terminal with sequenceNumber =1." ;
+        rdfs:label              "VoltageInjectionControlFunction"@en ;
+        cims:belongsToCategory  ssi:Package_SteadyStateInstructionProfile ;
+        cims:stereotype         "Description" , "NC" ;
+        cims:stereotype         <http://iec.ch/TC57/NonStandard/UML#concrete> .
+
+nc:VoltageInjectionControlFunction.targetValue
+        rdf:type           rdf:Property ;
+        rdfs:comment       "Target value for the voltage that the control function is calculating to achieve by adjusting the operational setting to the controlled equipment." ;
+        rdfs:domain        nc:VoltageInjectionControlFunction ;
+        rdfs:label         "targetValue"@en ;
+        cims:dataType      cim:Voltage ;
+        cims:multiplicity  cims:M:1..1 ;
+        cims:stereotype    "NC" ;
+        cims:stereotype    <http://iec.ch/TC57/NonStandard/UML#attribute> .
+
+profcim:IRI  rdf:type           rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as rdf:resource in RDFXML.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "IRI"@en ;
+        cims:belongsToCategory  ssi:Package_DocSteadyStateInstructionProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringFixedLanguage
+        rdf:type                rdfs:Class ;
+        rdfs:comment            "A string consisting of a sequence of characters. The character encoding is UTF-8. The string length is unspecified and unlimited.\nThe primitive is serialized as literal without language support." ;
+        rdfs:label              "StringFixedLanguage"@en ;
+        cims:belongsToCategory  ssi:Package_DocSteadyStateInstructionProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:StringIRI  rdf:type     rdfs:Class ;
+        rdfs:comment            "An IRI (Internationalized Resource Identifier) within an RDF graph is a Unicode string that conforms to the syntax defined in RFC 3987.\nThe primitive is serialized as literal without language support.\nIRIs in the RDF abstract syntax must be absolute, and may contain a fragment identifier.\nIRI equality: Two IRIs are equal if and only if they are equivalent under Simple String Comparison according to section 5.1 of [RFC3987]. Further normalization must not be performed when comparing IRIs for equality.\nIRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicode characters. Every absolute URI and URL is an IRI, but not every IRI is an URI. When IRIs are used in operations that are only defined for URIs, they must first be converted according to the mapping defined in section 3.1 of [RFC3987]. A notable example is retrieval over the HTTP protocol. The mapping involves UTF-8 encoding of non-ASCII characters, %-encoding of octets not allowed in URIs, and Punycode-encoding of domain names." ;
+        rdfs:label              "StringIRI"@en ;
+        cims:belongsToCategory  ssi:Package_DocSteadyStateInstructionProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+profcim:URL  rdf:type           rdfs:Class ;
+        rdfs:comment            "A Uniform Resource Locator (URL), colloquially termed a web address, is a reference to a web resource that specifies its location on a computer network and a mechanism for retrieving it. A URL is a specific type of Uniform Resource Identifier (URI), although many people use the two terms interchangeably.URLs occur most commonly to reference web pages (http), but are also used for file transfer (ftp), email (mailto), database access (JDBC), and many other applications." ;
+        rdfs:label              "URL"@en ;
+        cims:belongsToCategory  ssi:Package_DocSteadyStateInstructionProfile ;
+        cims:stereotype         "profcim" , "Primitive" .
+
+ssi:Ontology  rdf:type        owl:Ontology ;
+        dcterms:conformsTo    "urn:iso:std:iec:61970-501:draft:ed-2" , "urn:iso:std:iec:61970-600-2:ed-1" , "file://iec61970cim17v40_iec61968cim13v13a_iec62325cim03v17a.eap" , "file://CIM100_CGMES31v01_501-20v02_NC23v62_MM10v01.eap" , "urn:iso:std:iec:61970-401:draft:ed-1" , "urn:iso:std:iec:61970-301:ed-7:amd1" ;
+        dcterms:creator       "ENTSO-E CIM WG NC project "@en ;
+        dcterms:description   "This vocabulary is describing the steady state instruction profile."@en ;
+        dcterms:identifier    "urn:uuid:6d01969f-38fd-460d-b260-b839a8123319" ;
+        dcterms:language      "en-GB" ;
+        dcterms:license       "https://www.apache.org/licenses/LICENSE-2.0"@en ;
+        dcterms:modified      "2024-04-08"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        dcterms:publisher     "ENTSO-E"@en ;
+        dcterms:rightsHolder  "ENTSO-E"@en ;
+        dcterms:title         "Steady state instruction Vocabulary"@en ;
+        owl:priorVersion      <http://entsoe.eu/ns/CIM/SteadyStateInstruction-EU/2.2> ;
+        owl:versionIRI        <https://ap.cim4.eu/SteadyStateInstruction/2.3> ;
+        owl:versionInfo       "2.3.0"@en ;
+        dcat:keyword          "SSI" ;
+        dcat:theme            "vocabulary"@en .
+
+ssi:Package_DocSteadyStateInstructionProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains datatypes used only in the RDFS header." ;
+        rdfs:label    "DocSteadyStateInstructionProfile"@en .
+
+ssi:Package_SteadyStateInstructionProfile
+        rdf:type      cims:ClassCategory ;
+        rdfs:comment  "This package contains steady state instruction profile." ;
+        rdfs:label    "SteadyStateInstructionProfile"@en .
+


### PR DESCRIPTION
Partly implements https://github.com/Sveino/Inst4CIM-KG/issues/35
But it has defects:
- doesn't add a Makefile (instead I used scripts I have that sort of do the job)
- the files are not quite properly sorted. Except `EquipmentReliability-AP-Voc-RDFS2020.ttl`, where I moved these to be first (manually):
```
er:Ontology
er:Package_DocEquipmentReliabilityProfile
er:Package_EquipmentReliabilityProfile
```

So consider this a draft for comment.